### PR TITLE
feat: implement stage 1 (hir) infra

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a90734b3d5dcf656e7624cca6bce9c3a90ee11f900e80141a7427ccfb3d317"
 
 [[package]]
+name = "cranelift-entity"
+version = "0.81.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d84f8e8a408071d67f479a00c6d3da965b1f9b4b240b7e7e27edb1a34401b3cd"
+
+[[package]]
 name = "ctor"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +408,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "intrusive-collections"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4f90afb01281fdeffb0f8e082d230cbe4f888f837cc90759696b858db1a700"
+dependencies = [
+ "memoffset",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +507,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "miden-diagnostics"
 version = "0.1.0"
 dependencies = [
@@ -510,9 +534,14 @@ name = "miden-ir"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bitflags",
+ "cranelift-entity",
+ "intrusive-collections",
  "miden-diagnostics",
  "pretty_assertions",
+ "smallvec",
  "thiserror",
+ "typed-arena",
 ]
 
 [[package]]
@@ -921,6 +950,12 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ parking_lot = "0.12"
 parking_lot_core = "0.9"
 pretty_assertions = "1.0"
 rustc-hash = "1.1"
-smallvec = { version = "1.9", features = ["union", "const_generics", "const_new", "specialization"] }
+smallvec = { version = "1.9", features = ["union", "const_generics", "const_new"] }
 smallstr = { version = "0.3", features = ["union"] }
 thiserror = "1.0"
 

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -12,8 +12,13 @@ edition.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+bitflags.workspace = true
+cranelift-entity = "0.81"
+intrusive-collections = "0.9"
 miden-diagnostics = { path = "../diagnostics" }
+smallvec.workspace = true
 thiserror.workspace = true
+typed-arena = "2.0"
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/ir/src/hir/block.rs
+++ b/ir/src/hir/block.rs
@@ -1,0 +1,88 @@
+use cranelift_entity::entity_impl;
+use intrusive_collections::linked_list::{Cursor, LinkedList};
+use intrusive_collections::{LinkedListLink, UnsafeRef};
+
+use super::*;
+
+/// A handle to a single function block
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Block(u32);
+entity_impl!(Block, "block");
+impl Default for Block {
+    #[inline]
+    fn default() -> Self {
+        use cranelift_entity::packed_option::ReservedValue;
+
+        Self::reserved_value()
+    }
+}
+
+/// Data associated with a `Block`.
+///
+/// Blocks have arguments, and consist of a sequence of instructions.
+pub struct BlockData {
+    pub link: LinkedListLink,
+    pub params: ValueList,
+    pub insts: LinkedList<InstAdapter>,
+}
+impl Drop for BlockData {
+    fn drop(&mut self) {
+        self.insts.fast_clear();
+    }
+}
+impl Clone for BlockData {
+    fn clone(&self) -> Self {
+        Self {
+            link: LinkedListLink::default(),
+            params: self.params.clone(),
+            insts: LinkedList::new(InstAdapter::new()),
+        }
+    }
+}
+impl BlockData {
+    pub(crate) fn new() -> Self {
+        Self {
+            link: LinkedListLink::default(),
+            params: ValueList::new(),
+            insts: LinkedList::new(InstAdapter::new()),
+        }
+    }
+
+    pub fn insts<'f>(&'f self) -> impl Iterator<Item = Inst> + 'f {
+        Insts {
+            cursor: self.insts.front(),
+        }
+    }
+
+    pub unsafe fn append(&mut self, inst: UnsafeRef<InstNode>) {
+        self.insts.push_back(inst);
+    }
+
+    pub fn first(&self) -> Option<Inst> {
+        self.insts.front().get().map(|data| data.key)
+    }
+
+    pub fn last(&self) -> Option<Inst> {
+        self.insts.back().get().map(|data| data.key)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.insts.is_empty()
+    }
+}
+
+struct Insts<'f> {
+    cursor: Cursor<'f, InstAdapter>,
+}
+impl<'f> Iterator for Insts<'f> {
+    type Item = Inst;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.cursor.is_null() {
+            return None;
+        }
+        let next = self.cursor.get().map(|data| data.key);
+        self.cursor.move_next();
+        next
+    }
+}

--- a/ir/src/hir/builder.rs
+++ b/ir/src/hir/builder.rs
@@ -1,0 +1,20 @@
+use miden_diagnostics::SourceSpan;
+
+use crate::types::Type;
+
+use super::*;
+
+pub trait InstBuilderBase<'f> {
+    fn data_flow_graph(&self) -> &DataFlowGraph;
+    fn data_flow_graph_mut(&mut self) -> &mut DataFlowGraph;
+    fn build(
+        self,
+        data: Instruction,
+        ctrl_ty: Type,
+        span: SourceSpan,
+    ) -> (Inst, &'f mut DataFlowGraph);
+}
+
+pub trait InstBuilder<'f>: InstBuilderBase<'f> {}
+
+impl<'f, T: InstBuilderBase<'f>> InstBuilder<'f> for T {}

--- a/ir/src/hir/dataflow.rs
+++ b/ir/src/hir/dataflow.rs
@@ -1,0 +1,253 @@
+use std::cell::{Ref, RefCell};
+use std::collections::BTreeMap;
+use std::ops::{Index, IndexMut};
+use std::rc::Rc;
+
+use cranelift_entity::{EntityRef, PrimaryMap, SecondaryMap};
+use intrusive_collections::UnsafeRef;
+use smallvec::SmallVec;
+
+use miden_diagnostics::{SourceSpan, Span};
+
+use crate::types::Type;
+
+use super::*;
+
+pub struct DataFlowGraph {
+    pub signatures: Rc<RefCell<PrimaryMap<FuncRef, Signature>>>,
+    pub callees: Rc<RefCell<BTreeMap<String, FuncRef>>>,
+    pub blocks: OrderedArenaMap<Block, BlockData>,
+    pub insts: ArenaMap<Inst, InstNode>,
+    pub results: SecondaryMap<Inst, ValueList>,
+    pub values: PrimaryMap<Value, ValueData>,
+    pub value_lists: ValueListPool,
+}
+impl DataFlowGraph {
+    pub fn new(
+        signatures: Rc<RefCell<PrimaryMap<FuncRef, Signature>>>,
+        callees: Rc<RefCell<BTreeMap<String, FuncRef>>>,
+    ) -> Self {
+        Self {
+            signatures,
+            callees,
+            blocks: OrderedArenaMap::new(),
+            insts: ArenaMap::new(),
+            results: SecondaryMap::new(),
+            values: PrimaryMap::new(),
+            value_lists: ValueListPool::new(),
+        }
+    }
+
+    /// Returns the signature of the given function reference
+    pub fn callee_signature(&self, callee: FuncRef) -> Ref<'_, Signature> {
+        Ref::map(self.signatures.borrow(), |sigs| sigs.get(callee).unwrap())
+    }
+
+    /// Looks up the function reference for the given name
+    pub fn get_callee(&self, name: &str) -> Option<FuncRef> {
+        self.callees.borrow().get(name).copied()
+    }
+
+    /// Registers a function name as a callable function with the given signature
+    pub fn register_callee(&self, name: String, signature: Signature) -> FuncRef {
+        let mut callees = self.callees.borrow_mut();
+        // Don't register duplicates
+        if let Some(func) = callees.get(&name).copied() {
+            return func;
+        }
+        let mut signatures = self.signatures.borrow_mut();
+        let func = signatures.push(signature);
+        callees.insert(name, func);
+        func
+    }
+
+    pub fn make_value(&mut self, data: ValueData) -> Value {
+        self.values.push(data)
+    }
+
+    pub fn value_type(&self, v: Value) -> Type {
+        self.values[v].ty()
+    }
+
+    pub fn set_value_type(&mut self, v: Value, ty: Type) {
+        self.values[v].set_type(ty)
+    }
+
+    pub fn get_value(&self, v: Value) -> ValueData {
+        self.values[v].clone()
+    }
+
+    pub fn push_inst(&mut self, block: Block, data: Instruction, span: SourceSpan) -> Inst {
+        let inst = self.insts.alloc_key();
+        let node = InstNode::new(inst, block, Span::new(span, data));
+        self.insts.append(inst, node);
+        self.results.resize(inst.index() + 1);
+        let item = unsafe { UnsafeRef::from_raw(&self.insts[inst]) };
+        unsafe {
+            self.block_data_mut(block).append(item);
+        }
+        inst
+    }
+
+    pub fn inst_args(&self, inst: Inst) -> &[Value] {
+        self.insts[inst].arguments(&self.value_lists)
+    }
+
+    pub fn make_inst_results(&mut self, inst: Inst, ctrl_ty: Type) -> usize {
+        self.results[inst].clear(&mut self.value_lists);
+
+        let opcode = self.insts[inst].opcode();
+        if let Some(fdata) = self.call_signature(inst) {
+            let mut num_results = 0;
+            for ty in fdata.results() {
+                self.append_result(inst, ty.clone());
+                num_results += 1;
+            }
+            num_results
+        } else {
+            let mut args = SmallVec::<[Type; 2]>::default();
+            for arg in self.inst_args(inst) {
+                args.push(self.value_type(*arg));
+            }
+            let mut results = opcode.results(ctrl_ty, args.as_slice());
+            let num_results = results.len();
+            for ty in results.drain(..) {
+                self.append_result(inst, ty);
+            }
+            num_results
+        }
+    }
+
+    pub fn append_result(&mut self, inst: Inst, ty: Type) -> Value {
+        let res = self.values.next_key();
+        let num = self.results[inst].push(res, &mut self.value_lists);
+        debug_assert!(num <= u16::MAX as usize, "too many result values");
+        self.make_value(ValueData::Inst {
+            ty,
+            inst,
+            num: num as u16,
+        })
+    }
+
+    pub fn first_result(&self, inst: Inst) -> Value {
+        self.results[inst]
+            .first(&self.value_lists)
+            .expect("instruction has no results")
+    }
+
+    pub fn has_results(&self, inst: Inst) -> bool {
+        !self.results[inst].is_empty()
+    }
+
+    pub fn inst_results(&self, inst: Inst) -> &[Value] {
+        self.results[inst].as_slice(&self.value_lists)
+    }
+
+    pub fn call_signature(&self, inst: Inst) -> Option<Signature> {
+        match self.insts[inst].analyze_call(&self.value_lists) {
+            CallInfo::NotACall => None,
+            CallInfo::Direct(f, _) => Some(self.callee_signature(f).clone()),
+        }
+    }
+
+    pub fn analyze_call(&self, inst: Inst) -> CallInfo<'_> {
+        self.insts[inst].analyze_call(&self.value_lists)
+    }
+
+    pub fn analyze_branch(&self, inst: Inst) -> BranchInfo {
+        self.insts[inst].analyze_branch(&self.value_lists)
+    }
+
+    pub fn blocks<'f>(&'f self) -> impl Iterator<Item = (Block, &'f BlockData)> {
+        Blocks {
+            cursor: self.blocks.cursor(),
+        }
+    }
+
+    pub fn block_insts<'f>(&'f self, block: Block) -> impl Iterator<Item = Inst> + 'f {
+        self.blocks[block].insts()
+    }
+
+    pub fn block_data(&self, block: Block) -> &BlockData {
+        &self.blocks[block]
+    }
+
+    pub fn block_data_mut(&mut self, block: Block) -> &mut BlockData {
+        &mut self.blocks[block]
+    }
+
+    pub fn last_inst(&self, block: Block) -> Option<Inst> {
+        self.blocks[block].last()
+    }
+
+    pub fn is_block_inserted(&self, block: Block) -> bool {
+        self.blocks.contains(block)
+    }
+
+    pub fn is_block_empty(&self, block: Block) -> bool {
+        self.blocks[block].is_empty()
+    }
+
+    pub fn make_block(&mut self) -> Block {
+        self.blocks.push(BlockData::new())
+    }
+
+    pub fn remove_block(&mut self, block: Block) {
+        self.blocks.remove(block);
+    }
+
+    pub fn num_block_params(&self, block: Block) -> usize {
+        self.blocks[block].params.len(&self.value_lists)
+    }
+
+    pub fn block_params(&self, block: Block) -> &[Value] {
+        self.blocks[block].params.as_slice(&self.value_lists)
+    }
+
+    pub fn block_param_types(&self, block: Block) -> Vec<Type> {
+        self.block_params(block)
+            .iter()
+            .map(|&v| self.value_type(v))
+            .collect()
+    }
+
+    pub fn append_block_param(&mut self, block: Block, ty: Type, span: SourceSpan) -> Value {
+        let param = self.values.next_key();
+        let num = self.blocks[block].params.push(param, &mut self.value_lists);
+        debug_assert!(num <= u16::MAX as usize, "too many parameters on block");
+        self.make_value(ValueData::Param {
+            ty,
+            num: num as u16,
+            block,
+            span,
+        })
+    }
+}
+impl Index<Inst> for DataFlowGraph {
+    type Output = Span<Instruction>;
+
+    fn index(&self, inst: Inst) -> &Self::Output {
+        &self.insts[inst]
+    }
+}
+impl IndexMut<Inst> for DataFlowGraph {
+    fn index_mut(&mut self, inst: Inst) -> &mut Self::Output {
+        &mut self.insts[inst]
+    }
+}
+
+struct Blocks<'f> {
+    cursor: intrusive_collections::linked_list::Cursor<'f, LayoutAdapter<Block, BlockData>>,
+}
+impl<'f> Iterator for Blocks<'f> {
+    type Item = (Block, &'f BlockData);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.cursor.is_null() {
+            return None;
+        }
+        let next = self.cursor.get().map(|data| (data.key(), data.value()));
+        self.cursor.move_next();
+        next
+    }
+}

--- a/ir/src/hir/function.rs
+++ b/ir/src/hir/function.rs
@@ -1,0 +1,113 @@
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::fmt;
+use std::rc::Rc;
+
+use cranelift_entity::{entity_impl, PrimaryMap};
+
+use miden_diagnostics::{SourceSpan, Spanned};
+
+use crate::types::{FunctionType, Type};
+
+use super::*;
+
+/// A handle that refers to a function definition/declaration
+#[derive(Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct FuncRef(u32);
+entity_impl!(FuncRef, "fn");
+
+bitflags::bitflags! {
+    pub struct Visibility: u8 {
+        /// The function is private
+        const PRIVATE = 1;
+        /// The function is public
+        const PUBLIC = 1 << 1;
+        /// The function is defined externally, but referenced locally
+        const EXTERN = 1 << 2;
+    }
+}
+impl Visibility {
+    pub fn is_externally_defined(&self) -> bool {
+        self.contains(Self::EXTERN)
+    }
+
+    pub fn is_public(&self) -> bool {
+        self.contains(Self::PUBLIC)
+    }
+}
+impl Default for Visibility {
+    fn default() -> Self {
+        Self::PRIVATE
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Signature {
+    pub visibility: Visibility,
+    pub name: String,
+    pub ty: FunctionType,
+}
+impl Signature {
+    /// Returns a slice of the parameter types for this function
+    pub fn params(&self) -> &[Type] {
+        self.ty.params()
+    }
+
+    /// Returns the parameter type of the argument at `index`, if present
+    #[inline]
+    pub fn param(&self, index: usize) -> Option<&Type> {
+        self.ty.params().get(index)
+    }
+
+    pub fn results(&self) -> &[Type] {
+        match self.ty.results() {
+            [Type::Unit] => &[],
+            [Type::Never] => &[],
+            results => results,
+        }
+    }
+}
+impl Eq for Signature {}
+impl PartialEq for Signature {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self.params().len() == other.params().len()
+            && self.results().len() == other.results().len()
+    }
+}
+
+/// Represents the dataflow structure of a function definition
+#[derive(Spanned)]
+pub struct Function {
+    pub id: FuncRef,
+    #[span]
+    pub span: SourceSpan,
+    pub signature: Signature,
+    pub dfg: DataFlowGraph,
+}
+impl Function {
+    pub fn new(
+        id: FuncRef,
+        span: SourceSpan,
+        signature: Signature,
+        signatures: Rc<RefCell<PrimaryMap<FuncRef, Signature>>>,
+        callees: Rc<RefCell<BTreeMap<String, FuncRef>>>,
+    ) -> Self {
+        let dfg = DataFlowGraph::new(signatures, callees);
+        Self {
+            id,
+            span,
+            signature,
+            dfg,
+        }
+    }
+}
+impl fmt::Debug for Function {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Function")
+            .field("id", &self.id)
+            .field("span", &self.span)
+            .field("signature", &self.signature)
+            .finish()
+    }
+}

--- a/ir/src/hir/immediates.rs
+++ b/ir/src/hir/immediates.rs
@@ -1,0 +1,201 @@
+use core::fmt;
+use core::hash::{Hash, Hasher};
+
+use crate::types::Type;
+
+#[derive(Debug, Copy, Clone)]
+pub enum Immediate {
+    I1(bool),
+    I8(i8),
+    I16(i16),
+    I32(i32),
+    I64(i64),
+    I128(i128),
+    Isize(isize),
+    F64(f64),
+    Felt(u64),
+}
+impl Immediate {
+    pub fn ty(&self) -> Type {
+        match self {
+            Self::I1(_) => Type::I1,
+            Self::I8(_) => Type::I8,
+            Self::I16(_) => Type::I16,
+            Self::I32(_) => Type::I32,
+            Self::I64(_) => Type::I64,
+            Self::I128(_) => Type::I128,
+            Self::Isize(_) => Type::Isize,
+            Self::F64(_) => Type::F64,
+            Self::Felt(_) => Type::Felt,
+        }
+    }
+
+    pub fn as_i64(&self) -> Option<i64> {
+        match self {
+            Self::I1(b) => Some(*b as i64),
+            Self::I8(i) => Some(*i as i64),
+            Self::I16(i) => Some(*i as i64),
+            Self::I32(i) => Some(*i as i64),
+            Self::I64(i) => Some(*i),
+            Self::I128(i) => (*i).try_into().ok(),
+            Self::Isize(i) => Some(*i as i64),
+            Self::F64(_) => None,
+            Self::Felt(_) => None,
+        }
+    }
+}
+impl fmt::Display for Immediate {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::I1(i) => write!(f, "{}", i),
+            Self::I8(i) => write!(f, "{}", i),
+            Self::I16(i) => write!(f, "{}", i),
+            Self::I32(i) => write!(f, "{}", i),
+            Self::I64(i) => write!(f, "{}", i),
+            Self::I128(i) => write!(f, "{}", i),
+            Self::Isize(i) => write!(f, "{}", i),
+            Self::F64(n) => write!(f, "{}", n),
+            Self::Felt(i) => write!(f, "{}", i),
+        }
+    }
+}
+impl Hash for Immediate {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let d = std::mem::discriminant(self);
+        d.hash(state);
+        match self {
+            Self::I1(i) => i.hash(state),
+            Self::I8(i) => i.hash(state),
+            Self::I16(i) => i.hash(state),
+            Self::I32(i) => i.hash(state),
+            Self::I64(i) => i.hash(state),
+            Self::I128(i) => i.hash(state),
+            Self::Isize(i) => i.hash(state),
+            Self::F64(f) => {
+                let bytes = f.to_be_bytes();
+                bytes.hash(state)
+            }
+            Self::Felt(i) => i.hash(state),
+        }
+    }
+}
+impl Eq for Immediate {}
+impl PartialEq for Immediate {
+    fn eq(&self, other: &Self) -> bool {
+        match (*self, *other) {
+            (Self::I8(x), Self::I8(y)) => x == y,
+            (Self::I16(x), Self::I16(y)) => x == y,
+            (Self::I32(x), Self::I32(y)) => x == y,
+            (Self::I64(x), Self::I64(y)) => x == y,
+            (Self::I128(x), Self::I128(y)) => x == y,
+            (Self::Isize(x), Self::Isize(y)) => x == y,
+            (Self::F64(x), Self::F64(y)) => x == y,
+            (Self::Felt(x), Self::Felt(y)) => x == y,
+            _ => false,
+        }
+    }
+}
+impl PartialOrd for Immediate {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        use std::cmp::Ordering;
+
+        match (self, other) {
+            (Self::I128(x), Self::I128(y)) => x.partial_cmp(y),
+            (Self::I128(x), Self::F64(y)) => {
+                assert!(!y.is_finite());
+                let y = unsafe { y.to_int_unchecked::<i128>() };
+                x.partial_cmp(&y)
+            }
+            (Self::I128(x), y) => {
+                let y = y.as_i64().unwrap() as i128;
+                x.partial_cmp(&y)
+            }
+            (Self::F64(x), Self::I128(y)) => {
+                assert!(!x.is_finite());
+                let x = unsafe { x.to_int_unchecked::<i128>() };
+                x.partial_cmp(y)
+            }
+            (Self::F64(x), Self::F64(y)) => x.partial_cmp(y),
+            (Self::F64(x), y) => {
+                let y = y.as_i64().unwrap() as f64;
+                match x.total_cmp(&y) {
+                    Ordering::Equal => Some(Ordering::Equal),
+                    ord => Some(ord),
+                }
+            }
+            (x, Self::F64(y)) => {
+                let x = x.as_i64().unwrap() as f64;
+                match x.total_cmp(&y) {
+                    Ordering::Equal => Some(Ordering::Equal),
+                    ord => Some(ord),
+                }
+            }
+            (x, Self::I128(y)) => {
+                let x = x.as_i64().unwrap() as i128;
+                x.partial_cmp(y)
+            }
+            (x, y) => {
+                let x = x.as_i64().unwrap();
+                let y = y.as_i64().unwrap();
+                match x.cmp(&y) {
+                    Ordering::Equal => Some(Ordering::Equal),
+                    ord => Some(ord),
+                }
+            }
+        }
+    }
+}
+impl From<bool> for Immediate {
+    #[inline(always)]
+    fn from(value: bool) -> Self {
+        Self::I1(value)
+    }
+}
+impl From<i8> for Immediate {
+    #[inline(always)]
+    fn from(value: i8) -> Self {
+        Self::I8(value)
+    }
+}
+impl From<i16> for Immediate {
+    #[inline(always)]
+    fn from(value: i16) -> Self {
+        Self::I16(value)
+    }
+}
+impl From<i32> for Immediate {
+    #[inline(always)]
+    fn from(value: i32) -> Self {
+        Self::I32(value)
+    }
+}
+impl From<i64> for Immediate {
+    #[inline(always)]
+    fn from(value: i64) -> Self {
+        Self::I64(value)
+    }
+}
+impl From<i128> for Immediate {
+    #[inline(always)]
+    fn from(value: i128) -> Self {
+        Self::I128(value)
+    }
+}
+impl From<isize> for Immediate {
+    #[inline(always)]
+    fn from(value: isize) -> Self {
+        Self::Isize(value)
+    }
+}
+impl From<f64> for Immediate {
+    #[inline(always)]
+    fn from(value: f64) -> Self {
+        Self::F64(value)
+    }
+}
+impl From<char> for Immediate {
+    #[inline(always)]
+    fn from(value: char) -> Self {
+        Self::I32(value as u32 as i32)
+    }
+}

--- a/ir/src/hir/instruction.rs
+++ b/ir/src/hir/instruction.rs
@@ -1,0 +1,586 @@
+use core::fmt;
+use core::ops::{Deref, DerefMut};
+
+use cranelift_entity::entity_impl;
+use intrusive_collections::{intrusive_adapter, LinkedListLink, UnsafeRef};
+use smallvec::SmallVec;
+
+use miden_diagnostics::{Span, Spanned};
+
+use crate::types::Type;
+
+use super::*;
+
+/// A handle to a single instruction
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Inst(u32);
+entity_impl!(Inst, "inst");
+
+/// Represents the data associated with an `Inst`.
+///
+/// Specifically, this represents a leaf node in the control flow graph of
+/// a function, i.e. it links a specific instruction in to the sequence of
+/// instructions belonging to a specific block.
+#[derive(Clone, Spanned)]
+pub struct InstNode {
+    pub link: LinkedListLink,
+    pub key: Inst,
+    pub block: Block,
+    #[span]
+    pub data: Span<Instruction>,
+}
+impl InstNode {
+    pub fn new(key: Inst, block: Block, data: Span<Instruction>) -> Self {
+        Self {
+            link: LinkedListLink::default(),
+            key,
+            block,
+            data,
+        }
+    }
+}
+impl Deref for InstNode {
+    type Target = Span<Instruction>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
+}
+impl DerefMut for InstNode {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.data
+    }
+}
+
+intrusive_adapter!(pub InstAdapter = UnsafeRef<InstNode>: InstNode { link: LinkedListLink });
+
+/// Represents the type of instruction associated with a particular opcode
+#[derive(Debug, Clone)]
+pub enum Instruction {
+    BinaryOp(BinaryOp),
+    BinaryOpImm(BinaryOpImm),
+    UnaryOp(UnaryOp),
+    UnaryOpImm(UnaryOpImm),
+    Call(Call),
+    Br(Br),
+    CondBr(CondBr),
+    Switch(Switch),
+    Ret(Ret),
+    PrimOp(PrimOp),
+    PrimOpImm(PrimOpImm),
+    InlineAsm(InlineAsm),
+}
+impl Instruction {
+    pub fn opcode(&self) -> Opcode {
+        match self {
+            Self::BinaryOp(BinaryOp { ref op, .. })
+            | Self::BinaryOpImm(BinaryOpImm { ref op, .. })
+            | Self::UnaryOp(UnaryOp { ref op, .. })
+            | Self::UnaryOpImm(UnaryOpImm { ref op, .. })
+            | Self::Call(Call { ref op, .. })
+            | Self::Br(Br { ref op, .. })
+            | Self::CondBr(CondBr { ref op, .. })
+            | Self::Switch(Switch { ref op, .. })
+            | Self::Ret(Ret { ref op, .. })
+            | Self::PrimOp(PrimOp { ref op, .. })
+            | Self::PrimOpImm(PrimOpImm { ref op, .. })
+            | Self::InlineAsm(InlineAsm { ref op, .. }) => *op,
+        }
+    }
+
+    pub fn arguments<'a>(&'a self, pool: &'a ValueListPool) -> &[Value] {
+        match self {
+            Self::BinaryOp(BinaryOp { ref args, .. }) => args.as_slice(),
+            Self::BinaryOpImm(BinaryOpImm { ref arg, .. }) => core::slice::from_ref(arg),
+            Self::UnaryOp(UnaryOp { ref arg, .. }) => core::slice::from_ref(arg),
+            Self::UnaryOpImm(UnaryOpImm { .. }) => &[],
+            Self::Call(Call { ref args, .. }) => args.as_slice(pool),
+            Self::Br(Br { ref args, .. }) => args.as_slice(pool),
+            Self::CondBr(CondBr { ref cond, .. }) => core::slice::from_ref(cond),
+            Self::Switch(Switch { ref arg, .. }) => core::slice::from_ref(arg),
+            Self::Ret(Ret { ref args, .. }) => args.as_slice(pool),
+            Self::PrimOp(PrimOp { ref args, .. }) => args.as_slice(pool),
+            Self::PrimOpImm(PrimOpImm { ref args, .. }) => args.as_slice(pool),
+            Self::InlineAsm(InlineAsm { ref args, .. }) => args.as_slice(pool),
+        }
+    }
+
+    pub fn arguments_mut<'a>(&'a mut self, pool: &'a mut ValueListPool) -> &mut [Value] {
+        match self {
+            Self::BinaryOp(BinaryOp { ref mut args, .. }) => args.as_mut_slice(),
+            Self::BinaryOpImm(BinaryOpImm { ref mut arg, .. }) => core::slice::from_mut(arg),
+            Self::UnaryOp(UnaryOp { ref mut arg, .. }) => core::slice::from_mut(arg),
+            Self::UnaryOpImm(UnaryOpImm { .. }) => &mut [],
+            Self::Call(Call { ref mut args, .. }) => args.as_mut_slice(pool),
+            Self::Br(Br { ref mut args, .. }) => args.as_mut_slice(pool),
+            Self::CondBr(CondBr { ref mut cond, .. }) => core::slice::from_mut(cond),
+            Self::Switch(Switch { ref mut arg, .. }) => core::slice::from_mut(arg),
+            Self::Ret(Ret { ref mut args, .. }) => args.as_mut_slice(pool),
+            Self::PrimOp(PrimOp { ref mut args, .. }) => args.as_mut_slice(pool),
+            Self::PrimOpImm(PrimOpImm { ref mut args, .. }) => args.as_mut_slice(pool),
+            Self::InlineAsm(InlineAsm { ref mut args, .. }) => args.as_mut_slice(pool),
+        }
+    }
+
+    pub fn analyze_branch<'a>(&'a self, pool: &'a ValueListPool) -> BranchInfo<'a> {
+        match self {
+            Self::Br(ref b) if b.op == Opcode::Br => {
+                BranchInfo::SingleDest(b.destination, b.args.as_slice(pool))
+            }
+            Self::Br(ref b) => BranchInfo::SingleDest(b.destination, &b.args.as_slice(pool)[1..]),
+            Self::CondBr(CondBr {
+                ref then_dest,
+                ref else_dest,
+                ..
+            }) => BranchInfo::MultiDest(vec![
+                JumpTable::new(then_dest.0, then_dest.1.as_slice(pool)),
+                JumpTable::new(else_dest.0, else_dest.1.as_slice(pool)),
+            ]),
+            Self::Switch(Switch {
+                ref arms,
+                ref default,
+                ..
+            }) => {
+                let mut targets = arms
+                    .iter()
+                    .map(|(_, b)| JumpTable::new(*b, &[]))
+                    .collect::<Vec<_>>();
+                targets.push(JumpTable::new(*default, &[]));
+                BranchInfo::MultiDest(targets)
+            }
+            _ => BranchInfo::NotABranch,
+        }
+    }
+
+    pub fn analyze_call<'a>(&'a self, pool: &'a ValueListPool) -> CallInfo<'a> {
+        match self {
+            Self::Call(ref c) => CallInfo::Direct(c.callee, c.args.as_slice(pool)),
+            _ => CallInfo::NotACall,
+        }
+    }
+}
+
+pub enum BranchInfo<'a> {
+    NotABranch,
+    SingleDest(Block, &'a [Value]),
+    MultiDest(Vec<JumpTable<'a>>),
+}
+
+pub struct JumpTable<'a> {
+    pub destination: Block,
+    pub args: &'a [Value],
+}
+impl<'a> JumpTable<'a> {
+    pub fn new(destination: Block, args: &'a [Value]) -> Self {
+        Self { destination, args }
+    }
+}
+
+pub enum CallInfo<'a> {
+    NotACall,
+    Direct(FuncRef, &'a [Value]),
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum Opcode {
+    /// Asserts the given value is 1
+    Assert,
+    /// Asserts the given value is 0
+    Assertz,
+    /// Asserts the two given values are equal
+    AssertEq,
+    /// Same as `Test`, but does not return a value, instead it traps on failure
+    AssertTest,
+    /// Represents an immediate integer value
+    ImmInt,
+    /// Represents an immediate "null" value, where all bytes of the representation are zeroed
+    ImmNull,
+    /// Loads the address of a given value into memory
+    AddrOf,
+    /// Loads a value from a pointer to memory
+    Load,
+    /// Stores a value to a pointer to memory
+    Store,
+    /// Copies `n` values of a given type from a source pointer to a destination pointer
+    MemCpy,
+    /// Casts a pointer value to an integral type
+    PtrToInt,
+    /// Casts an integral type to a pointer value
+    IntToPtr,
+    /// Casts from a field element type to an integral type
+    ///
+    /// It is not valid to perform a cast on any value other than a field element, see
+    /// `Trunc`, `Zext`, and `Sext` for casts between machine integer types.
+    Cast,
+    /// Truncates a larger integral type to a smaller integral type, e.g. i64 -> i32
+    Trunc,
+    /// Zero-extends a smaller unsigned integral type to a larger unsigned integral type, e.g. u32 -> u64
+    Zext,
+    /// Sign-extends a smaller signed integral type to a larger signed integral type, e.g. i32 -> i64
+    Sext,
+    /// Returns true if argument fits in the given integral type, e.g. u32, otherwise false
+    Test,
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+    DivMod,
+    Neg,
+    Inv,
+    Pow2,
+    Exp,
+    Not,
+    And,
+    Or,
+    Xor,
+    Shl,
+    Shr,
+    Rotl,
+    Rotr,
+    Popcnt,
+    Eq,
+    Neq,
+    Gt,
+    Gte,
+    Lt,
+    Lte,
+    IsOdd,
+    Min,
+    Max,
+    Call,
+    Br,
+    CondBr,
+    Switch,
+    Ret,
+    InlineAsm,
+}
+impl Opcode {
+    pub fn is_terminator(&self) -> bool {
+        match self {
+            Self::Br | Self::CondBr | Self::Switch | Self::Ret => true,
+            _ => false,
+        }
+    }
+
+    pub fn num_fixed_args(&self) -> usize {
+        match self {
+            Self::Assert | Self::Assertz | Self::AssertTest => 1,
+            Self::AssertEq => 2,
+            // Immediates/constants have none
+            Self::ImmInt | Self::ImmNull => 0,
+            // Binary ops always have two
+            Self::Store
+            | Self::Add
+            | Self::Sub
+            | Self::Mul
+            | Self::Div
+            | Self::Mod
+            | Self::DivMod
+            | Self::Exp
+            | Self::And
+            | Self::Or
+            | Self::Xor
+            | Self::Shl
+            | Self::Shr
+            | Self::Rotl
+            | Self::Rotr
+            | Self::Eq
+            | Self::Neq
+            | Self::Gt
+            | Self::Gte
+            | Self::Lt
+            | Self::Lte
+            | Self::Min
+            | Self::Max => 2,
+            // Unary ops always have one
+            Self::AddrOf
+            | Self::Load
+            | Self::PtrToInt
+            | Self::IntToPtr
+            | Self::Cast
+            | Self::Trunc
+            | Self::Zext
+            | Self::Sext
+            | Self::Test
+            | Self::Neg
+            | Self::Inv
+            | Self::Pow2
+            | Self::Popcnt
+            | Self::Not
+            | Self::IsOdd => 1,
+            // MemCpy requires source, destination, and arity
+            Self::MemCpy => 3,
+            // Calls are entirely variable
+            Self::Call => 0,
+            // Unconditional branches have no fixed arguments
+            Self::Br => 0,
+            // Ifs have a single argument, the conditional
+            Self::CondBr => 1,
+            // Switches have a single argument, the input value
+            Self::Switch => 1,
+            // Returns require at least one argument
+            Self::Ret => 1,
+            // The following require no arguments
+            Self::InlineAsm => 0,
+        }
+    }
+
+    pub(super) fn results(&self, ctrl_ty: Type, args: &[Type]) -> SmallVec<[Type; 1]> {
+        use smallvec::smallvec;
+
+        match self {
+            // These ops have no results
+            Self::Assert
+            | Self::Assertz
+            | Self::AssertEq
+            | Self::AssertTest
+            | Self::Store
+            | Self::MemCpy
+            | Self::Br
+            | Self::CondBr
+            | Self::Switch
+            | Self::InlineAsm => smallvec![],
+            // These ops have fixed result types
+            Self::Test | Self::IsOdd => smallvec![Type::I1],
+            // For these ops, the controlling type variable determines the type for the op
+            Self::ImmInt
+            | Self::ImmNull
+            | Self::PtrToInt
+            | Self::IntToPtr
+            | Self::Cast
+            | Self::Trunc
+            | Self::Zext
+            | Self::Sext
+            | Self::Ret => {
+                smallvec![ctrl_ty]
+            }
+            // The result type of addrof is derived from the value type
+            Self::AddrOf => {
+                assert_eq!(args.len(), 1);
+                smallvec![Type::Ptr(Box::new(args[0].clone()))]
+            }
+            // The result type of a load is derived from the pointee type
+            Self::Load => {
+                assert_eq!(args.len(), 1);
+                debug_assert!(
+                    args[0].is_pointer(),
+                    "expected pointer type, got {:#?}",
+                    &args[0]
+                );
+                smallvec![args[0].pointee().unwrap()]
+            }
+            // These ops are unary operators whose result type depends on the argument type, which must be integral
+            Self::Neg | Self::Inv | Self::Pow2 | Self::Popcnt | Self::Not => {
+                assert_eq!(args.len(), 1);
+                assert!(args[0].is_integer());
+                smallvec![args[0].clone()]
+            }
+            // These ops are binary operators whose result type depends on the type of the arguments,
+            // and those arguments must be the same type
+            Self::Add
+            | Self::Sub
+            | Self::Mul
+            | Self::Div
+            | Self::Eq
+            | Self::Neq
+            | Self::Gt
+            | Self::Gte
+            | Self::Lt
+            | Self::Lte
+            | Self::Min
+            | Self::Max => {
+                assert_eq!(args.len(), 2);
+                assert_eq!(&args[0], &args[1], "type mismatch: expected operator to have matching operand types, got: {:?} vs {:?}", &args[0], &args[1]);
+                smallvec![args[0].clone()]
+            }
+            // Same as above, but the type must be integral
+            Self::Mod
+            | Self::DivMod
+            | Self::Exp
+            | Self::And
+            | Self::Or
+            | Self::Xor
+            | Self::Shl
+            | Self::Shr
+            | Self::Rotl
+            | Self::Rotr => {
+                assert_eq!(args.len(), 2);
+                assert_eq!(&args[0], &args[1], "type mismatch: expected operator to have matching operand types, got: {:?} vs {:?}", &args[0], &args[1]);
+                assert!(
+                    args[0].is_integer(),
+                    "invalid operand type: expected integral type, got: {:#?}",
+                    &args[0]
+                );
+                smallvec![args[0].clone()]
+            }
+            // Call results are handled separately
+            Self::Call => unreachable!(),
+        }
+    }
+}
+impl fmt::Display for Opcode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Assert => f.write_str("assert"),
+            Self::Assertz => f.write_str("assertz"),
+            Self::AssertEq => f.write_str("assert.eq"),
+            Self::AssertTest => f.write_str("assert.test"),
+            Self::ImmInt => f.write_str("const.int"),
+            Self::ImmNull => f.write_str("const.null"),
+            Self::AddrOf => f.write_str("addrof"),
+            Self::Load => f.write_str("load"),
+            Self::Store => f.write_str("store"),
+            Self::MemCpy => f.write_str("memcpy"),
+            Self::PtrToInt => f.write_str("ptrtoint"),
+            Self::IntToPtr => f.write_str("inttoptr"),
+            Self::Cast => f.write_str("cast"),
+            Self::Trunc => f.write_str("trunc"),
+            Self::Zext => f.write_str("zext"),
+            Self::Sext => f.write_str("sext"),
+            Self::Br => f.write_str("br"),
+            Self::CondBr => f.write_str("condbr"),
+            Self::Switch => f.write_str("switch"),
+            Self::Call => f.write_str("call"),
+            Self::Ret => f.write_str("ret"),
+            Self::Test => f.write_str("test"),
+            Self::Add => f.write_str("add"),
+            Self::Sub => f.write_str("sub"),
+            Self::Mul => f.write_str("mul"),
+            Self::Div => f.write_str("div"),
+            Self::Mod => f.write_str("mod"),
+            Self::DivMod => f.write_str("divmod"),
+            Self::Exp => f.write_str("exp"),
+            Self::Neg => f.write_str("neg"),
+            Self::Inv => f.write_str("inv"),
+            Self::Pow2 => f.write_str("pow2"),
+            Self::Not => f.write_str("not"),
+            Self::And => f.write_str("and"),
+            Self::Or => f.write_str("or"),
+            Self::Xor => f.write_str("xor"),
+            Self::Shl => f.write_str("shl"),
+            Self::Shr => f.write_str("shr"),
+            Self::Rotl => f.write_str("rotl"),
+            Self::Rotr => f.write_str("rotr"),
+            Self::Popcnt => f.write_str("popcnt"),
+            Self::Eq => f.write_str("eq"),
+            Self::Neq => f.write_str("neq"),
+            Self::Gt => f.write_str("gt"),
+            Self::Gte => f.write_str("gte"),
+            Self::Lt => f.write_str("lt"),
+            Self::Lte => f.write_str("lte"),
+            Self::IsOdd => f.write_str("is_odd"),
+            Self::Min => f.write_str("min"),
+            Self::Max => f.write_str("max"),
+            Self::InlineAsm => f.write_str("asm"),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Default, Debug)]
+pub enum Overflow {
+    #[default]
+    Unchecked,
+    Checked,
+    Wrapping,
+    Overflowing,
+}
+
+#[derive(Debug, Clone)]
+pub struct BinaryOp {
+    pub op: Opcode,
+    pub overflow: Overflow,
+    pub args: [Value; 2],
+}
+
+#[derive(Debug, Clone)]
+pub struct BinaryOpImm {
+    pub op: Opcode,
+    pub overflow: Overflow,
+    pub arg: Value,
+    pub imm: Immediate,
+}
+
+#[derive(Debug, Clone)]
+pub struct UnaryOp {
+    pub op: Opcode,
+    pub overflow: Overflow,
+    pub arg: Value,
+}
+
+#[derive(Debug, Clone)]
+pub struct UnaryOpImm {
+    pub op: Opcode,
+    pub overflow: Overflow,
+    pub imm: Immediate,
+}
+
+#[derive(Debug, Clone)]
+pub struct Call {
+    pub op: Opcode,
+    pub callee: FuncRef,
+    pub args: ValueList,
+}
+
+/// Branch
+#[derive(Debug, Clone)]
+pub struct Br {
+    pub op: Opcode,
+    pub destination: Block,
+    pub args: ValueList,
+}
+
+/// Conditional Branch
+#[derive(Debug, Clone)]
+pub struct CondBr {
+    pub op: Opcode,
+    pub cond: Value,
+    pub then_dest: (Block, ValueList),
+    pub else_dest: (Block, ValueList),
+}
+
+/// Multi-way Branch w/Selector
+#[derive(Debug, Clone)]
+pub struct Switch {
+    pub op: Opcode,
+    pub arg: Value,
+    pub arms: Vec<(u32, Block)>,
+    pub default: Block,
+}
+
+/// Return
+#[derive(Debug, Clone)]
+pub struct Ret {
+    pub op: Opcode,
+    pub args: ValueList,
+}
+
+/// A primop/intrinsic that takes a variable number of arguments
+#[derive(Debug, Clone)]
+pub struct PrimOp {
+    pub op: Opcode,
+    pub args: ValueList,
+}
+
+/// A primop that takes an immediate for its first argument, followed by a variable number of
+/// arguments
+#[derive(Debug, Clone)]
+pub struct PrimOpImm {
+    pub op: Opcode,
+    pub imm: Immediate,
+    pub args: ValueList,
+}
+
+#[derive(Debug, Clone)]
+pub struct InlineAsm {
+    pub op: Opcode,
+    pub body: Vec<AsmInstruction>,
+    pub args: ValueList,
+}
+
+#[derive(Debug, Clone)]
+pub struct AsmInstruction {
+    pub name: String,
+}

--- a/ir/src/hir/layout.rs
+++ b/ir/src/hir/layout.rs
@@ -1,0 +1,390 @@
+use core::ops::{Index, IndexMut};
+use core::ptr::NonNull;
+
+use cranelift_entity::EntityRef;
+use intrusive_collections::linked_list::{Cursor, CursorMut, LinkedList};
+use intrusive_collections::{intrusive_adapter, LinkedListLink, UnsafeRef};
+use typed_arena::Arena;
+
+/// This struct holds the data for each node in an ArenaMap/OrderedArenaMap
+#[derive(Clone)]
+pub struct LayoutNode<K: EntityRef, V: Clone> {
+    pub link: LinkedListLink,
+    key: K,
+    value: V,
+}
+impl<K: EntityRef, V: Clone> LayoutNode<K, V> {
+    pub fn new(key: K, value: V) -> Self {
+        Self {
+            link: LinkedListLink::default(),
+            key,
+            value,
+        }
+    }
+
+    #[inline(always)]
+    pub fn key(&self) -> K {
+        self.key
+    }
+
+    #[inline(always)]
+    pub fn value(&self) -> &V {
+        &self.value
+    }
+
+    #[inline(always)]
+    pub fn value_mut(&mut self) -> &mut V {
+        &mut self.value
+    }
+}
+
+intrusive_adapter!(pub LayoutAdapter<K, V> = UnsafeRef<LayoutNode<K, V>>: LayoutNode<K, V> { link: LinkedListLink } where K: EntityRef, V: Clone);
+
+/// ArenaMap provides similar functionality to other kinds of maps:
+///
+/// # Pros
+///
+/// * Once allocated, values stored in the map have a stable location, this can be useful for when you
+/// expect to store elements of the map in an intrusive collection.
+/// * Keys can be more efficiently sized, i.e. rather than pointers/usize keys, you can choose arbitrarily
+/// small bitwidths, as long as there is sufficient keyspace for your use case.
+/// * Attempt to keep data in the map as contiguous in memory as possible. This is again useful for when
+/// the data is also linked into an intrusive collection, like a linked list, where traversing the list
+/// will end up visiting many of the nodes in the map. If each node was its own Box, this would cause
+/// thrashing of the cache - ArenaMap sidesteps this by allocating values in chunks of memory that are
+/// friendlier to the cache.
+///
+/// # Cons
+///
+/// * Memory allocated for data stored in the map is not released until the map is dropped. This is
+/// a tradeoff made to ensure that the data has a stable location in memory, but the flip side of that
+/// is increased memory usage for maps that stick around for a long time. In our case, these maps are
+/// relatively short-lived, so it isn't a problem in practice.
+/// * It doesn't provide as rich of an API as HashMap and friends
+pub struct ArenaMap<K: EntityRef, V: Clone> {
+    keys: Vec<Option<NonNull<V>>>,
+    arena: Arena<V>,
+    _marker: core::marker::PhantomData<K>,
+}
+impl<K: EntityRef, V: Clone> Drop for ArenaMap<K, V> {
+    fn drop(&mut self) {
+        self.keys.clear()
+    }
+}
+impl<K: EntityRef, V: Clone> Clone for ArenaMap<K, V> {
+    fn clone(&self) -> Self {
+        let mut cloned = Self::new();
+        for opt in self.keys.iter() {
+            match opt {
+                None => cloned.keys.push(None),
+                Some(nn) => {
+                    let value = unsafe { nn.as_ref() };
+                    cloned.push(value.clone());
+                }
+            }
+        }
+        cloned
+    }
+}
+impl<K: EntityRef, V: Clone> Default for ArenaMap<K, V> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+impl<K: EntityRef, V: Clone> ArenaMap<K, V> {
+    /// Creates a new, empty ArenaMap
+    pub fn new() -> Self {
+        Self {
+            arena: Arena::default(),
+            keys: vec![],
+            _marker: core::marker::PhantomData,
+        }
+    }
+
+    /// Returns the total number of actively linked items in the map
+    pub fn len(&self) -> usize {
+        self.keys.iter().filter(|item| item.is_some()).count()
+    }
+
+    /// Returns true if this map contains `key`
+    pub fn contains(&self, key: K) -> bool {
+        self.keys
+            .get(key.index())
+            .map(|item| item.is_some())
+            .unwrap_or(false)
+    }
+
+    /// Adds a new entry to the map, returning the key it is associated to
+    pub fn push(&mut self, value: V) -> K {
+        let key = self.alloc_key();
+        self.alloc_node(key, value);
+        key
+    }
+
+    /// Used in conjunction with `alloc_key` to associate data with the allocated key
+    pub fn append(&mut self, key: K, value: V) {
+        self.alloc_node(key, value);
+    }
+
+    /// Returns a reference to the value associated with the given key
+    pub fn get(&self, key: K) -> Option<&V> {
+        self.keys
+            .get(key.index())
+            .and_then(|item| item.map(|nn| unsafe { nn.as_ref() }))
+    }
+
+    /// Returns a mutable reference to the value associated with the given key
+    pub fn get_mut(&mut self, key: K) -> Option<&mut V> {
+        self.keys
+            .get_mut(key.index())
+            .and_then(|item| item.map(|mut nn| unsafe { nn.as_mut() }))
+    }
+
+    /// Takes the value that was stored at the given key
+    pub fn take(&mut self, key: K) -> Option<NonNull<V>> {
+        self.keys[key.index()].take()
+    }
+
+    pub fn iter<'a>(&'a self) -> impl Iterator<Item = Option<NonNull<V>>> + 'a {
+        self.keys.iter().copied()
+    }
+
+    /// Removes the value associated with the given key
+    ///
+    /// NOTE: This function will panic if the key is invalid/unbound
+    pub fn remove(&mut self, key: K) {
+        self.keys[key.index()].take();
+    }
+
+    pub fn alloc_key(&mut self) -> K {
+        let id = self.keys.len();
+        let key = K::new(id);
+        self.keys.push(None);
+        key
+    }
+
+    fn alloc_node(&mut self, key: K, value: V) -> NonNull<V> {
+        let value = self.arena.alloc(value);
+        let nn = unsafe { NonNull::new_unchecked(value) };
+        self.keys[key.index()].replace(nn);
+        nn
+    }
+}
+impl<K: EntityRef, V: Clone> Index<K> for ArenaMap<K, V> {
+    type Output = V;
+
+    #[inline]
+    fn index(&self, index: K) -> &Self::Output {
+        self.get(index).unwrap()
+    }
+}
+impl<K: EntityRef, V: Clone> IndexMut<K> for ArenaMap<K, V> {
+    #[inline]
+    fn index_mut(&mut self, index: K) -> &mut Self::Output {
+        self.get_mut(index).unwrap()
+    }
+}
+
+/// OrderedArenaMap is an extension of ArenaMap that provides for arbitrary ordering of keys/values
+///
+/// This is done using an intrusive linked list alongside an ArenaMap. The list is used to link one
+/// key/value pair to the next, so any ordering you wish to implement is possible. This is particularly
+/// useful for layout of blocks in a function, or instructions within blocks, as you can precisely position
+/// them relative to other blocks/instructions.
+///
+/// Because the linked list is intrusive, it is virtually free in terms of space, but comes with the
+/// standard overhead for traversals. That said, there are a couple of niceties that give it good overall
+/// performance:
+///
+/// * It is a doubly-linked list, so you can traverse equally efficiently front-to-back or back-to-front,
+/// * It has O(1) indexing; given a key, we can directly obtain a reference to a node, and with that,
+/// obtain a cursor over the list starting at that node.
+pub struct OrderedArenaMap<K: EntityRef, V: Clone> {
+    list: LinkedList<LayoutAdapter<K, V>>,
+    map: ArenaMap<K, LayoutNode<K, V>>,
+}
+impl<K: EntityRef, V: Clone> Drop for OrderedArenaMap<K, V> {
+    fn drop(&mut self) {
+        self.list.fast_clear();
+    }
+}
+impl<K: EntityRef, V: Clone> Clone for OrderedArenaMap<K, V> {
+    fn clone(&self) -> Self {
+        let mut cloned = Self::new();
+        for opt in self.map.iter() {
+            match opt {
+                None => {
+                    cloned.map.alloc_key();
+                }
+                Some(nn) => {
+                    let value = unsafe { nn.as_ref() }.value();
+                    cloned.push(value.clone());
+                }
+            }
+        }
+        cloned
+    }
+}
+impl<K: EntityRef, V: Clone> Default for OrderedArenaMap<K, V> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+impl<K: EntityRef, V: Clone> OrderedArenaMap<K, V> {
+    pub fn new() -> Self {
+        Self {
+            map: ArenaMap::new(),
+            list: LinkedList::new(LayoutAdapter::new()),
+        }
+    }
+
+    /// Returns the total number of actively linked items in the map
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    /// Returns true if this map contains the given key and its value has been linked
+    #[inline]
+    pub fn contains(&self, key: K) -> bool {
+        self.map.contains(key)
+    }
+
+    /// Returns a reference to the value associated with the given key, if present and linked
+    pub fn get(&self, key: K) -> Option<&V> {
+        self.map.get(key).map(|data| data.value())
+    }
+
+    /// Returns a mutable reference to the value associated with the given key, if present and linked
+    pub fn get_mut(&mut self, key: K) -> Option<&mut V> {
+        self.map.get_mut(key).map(|data| data.value_mut())
+    }
+
+    /// Allocates a key, but does not link the data
+    #[inline]
+    pub fn create(&mut self) -> K {
+        self.map.alloc_key()
+    }
+
+    /// Used with `create` when ready to associate data with the allocated key, linking it in to the end of the list
+    pub fn append(&mut self, key: K, value: V) {
+        debug_assert!(!self.contains(key));
+        let data = self.alloc_node(key, value);
+        self.list.push_back(data);
+    }
+
+    /// Like `append`, but inserts the node before `before` in the list
+    ///
+    /// NOTE: This function will panic if `before` is not present in the list
+    pub fn insert_before(&mut self, key: K, before: K, value: V) {
+        let value_opt = self.get_mut(key);
+        debug_assert!(value_opt.is_none());
+        let data = self.alloc_node(key, value);
+        let mut cursor = self.cursor_mut_at(before);
+        cursor.insert_before(data);
+    }
+
+    /// Like `append`, but inserts the node after `after` in the list
+    ///
+    /// NOTE: This function will panic if `after` is not present in the list
+    pub fn insert_after(&mut self, key: K, after: K, value: V) {
+        let value_opt = self.get_mut(key);
+        debug_assert!(value_opt.is_none());
+        let data = self.alloc_node(key, value);
+        let mut cursor = self.cursor_mut_at(after);
+        cursor.insert_after(data);
+    }
+
+    /// Allocates a key and links data in the same operation
+    pub fn push(&mut self, value: V) -> K {
+        let key = self.alloc_key();
+        self.append(key, value);
+        key
+    }
+
+    /// Unlinks the value associated with the given key from this map
+    ///
+    /// NOTE: Removal does not result in deallocation of the underlying data, this
+    /// happens when the map is dropped. To perform early garbage collection, you can
+    /// clone the map, and drop the original.
+    pub fn remove(&mut self, key: K) {
+        if let Some(nn) = self.map.take(key) {
+            let mut cursor = unsafe { self.list.cursor_mut_from_ptr(nn.as_ptr()) };
+            cursor.remove();
+        }
+    }
+
+    /// Returns the first node in the map
+    pub fn first(&self) -> Option<&LayoutNode<K, V>> {
+        self.list.front().get()
+    }
+
+    /// Returns the last node in the map
+    pub fn last(&self) -> Option<&LayoutNode<K, V>> {
+        self.list.back().get()
+    }
+
+    /// Returns a cursor which can be used to traverse the map in order (front to back)
+    pub fn cursor(&self) -> Cursor<'_, LayoutAdapter<K, V>> {
+        self.list.front()
+    }
+
+    /// Returns a cursor which can be used to traverse the map mutably, in order (front to back)
+    pub fn cursor_mut(&mut self) -> CursorMut<'_, LayoutAdapter<K, V>> {
+        self.list.front_mut()
+    }
+
+    /// Returns a cursor which can be used to traverse the map in order (front to back), starting
+    /// at the key given.
+    pub fn cursor_at(&self, key: K) -> Cursor<'_, LayoutAdapter<K, V>> {
+        let ptr = &self.map[key] as *const LayoutNode<K, V>;
+        unsafe { self.list.cursor_from_ptr(ptr) }
+    }
+
+    /// Returns a cursor which can be used to traverse the map mutably, in order (front to back), starting
+    /// at the key given.
+    pub fn cursor_mut_at(&mut self, key: K) -> CursorMut<'_, LayoutAdapter<K, V>> {
+        let ptr = &self.map[key] as *const LayoutNode<K, V>;
+        unsafe { self.list.cursor_mut_from_ptr(ptr) }
+    }
+
+    /// Returns an iterator over the key/value pairs in the map, in order (front to back)
+    pub fn iter<'a>(&'a self) -> impl Iterator<Item = (K, &'a V)> {
+        self.list.iter().map(|item| (item.key(), item.value()))
+    }
+
+    /// Returns an iterator over the keys in the map, in order (front to back)
+    pub fn keys<'a>(&'a self) -> impl Iterator<Item = K> + 'a {
+        self.list.iter().map(|item| item.key())
+    }
+
+    /// Returns an iterator over the values in the map, in order (front to back)
+    pub fn values<'a>(&'a self) -> impl Iterator<Item = &'a V> {
+        self.list.iter().map(|item| item.value())
+    }
+
+    #[inline]
+    fn alloc_key(&mut self) -> K {
+        self.map.alloc_key()
+    }
+
+    fn alloc_node(&mut self, key: K, value: V) -> UnsafeRef<LayoutNode<K, V>> {
+        let nn = self.map.alloc_node(key, LayoutNode::new(key, value));
+        unsafe { UnsafeRef::from_raw(nn.as_ptr()) }
+    }
+}
+impl<K: EntityRef, V: Clone> Index<K> for OrderedArenaMap<K, V> {
+    type Output = V;
+
+    #[inline]
+    fn index(&self, index: K) -> &Self::Output {
+        self.get(index).unwrap()
+    }
+}
+impl<K: EntityRef, V: Clone> IndexMut<K> for OrderedArenaMap<K, V> {
+    #[inline]
+    fn index_mut(&mut self, index: K) -> &mut Self::Output {
+        self.get_mut(index).unwrap()
+    }
+}

--- a/ir/src/hir/mod.rs
+++ b/ir/src/hir/mod.rs
@@ -1,0 +1,17 @@
+mod block;
+mod builder;
+mod dataflow;
+mod function;
+mod immediates;
+mod instruction;
+mod layout;
+mod value;
+
+pub use self::block::{Block, BlockData};
+pub use self::builder::{InstBuilder, InstBuilderBase};
+pub use self::dataflow::DataFlowGraph;
+pub use self::function::{FuncRef, Function, Signature, Visibility};
+pub use self::immediates::Immediate;
+pub use self::instruction::{BranchInfo, CallInfo, Inst, InstAdapter, InstNode, Instruction};
+pub use self::layout::{ArenaMap, LayoutAdapter, LayoutNode, OrderedArenaMap};
+pub use self::value::{Value, ValueData, ValueList, ValueListPool};

--- a/ir/src/hir/value.rs
+++ b/ir/src/hir/value.rs
@@ -1,0 +1,74 @@
+use cranelift_entity::{self as entity, entity_impl};
+
+use miden_diagnostics::SourceSpan;
+
+use crate::types::Type;
+
+use super::{Block, Inst};
+
+pub type ValueList = entity::EntityList<Value>;
+pub type ValueListPool = entity::ListPool<Value>;
+
+/// A handle to a single SSA value
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Value(u32);
+entity_impl!(Value, "v");
+impl Default for Value {
+    #[inline]
+    fn default() -> Self {
+        use cranelift_entity::packed_option::ReservedValue;
+
+        Self::reserved_value()
+    }
+}
+
+/// Data associated with a `Value`.
+///
+/// Values are either block arguments or instructions, and
+/// in addition to being linked to a `Inst` or a `Block`, they
+/// have an associated type, position, and in some cases, a `SourceSpan`.
+#[derive(Debug, Clone)]
+pub enum ValueData {
+    Inst {
+        ty: Type,
+        num: u16,
+        inst: Inst,
+    },
+    Param {
+        ty: Type,
+        num: u16,
+        block: Block,
+        span: SourceSpan,
+    },
+}
+impl ValueData {
+    pub fn ty(&self) -> Type {
+        match self {
+            Self::Inst { ty, .. } | Self::Param { ty, .. } => ty.clone(),
+        }
+    }
+
+    pub fn set_type(&mut self, ty: Type) {
+        match self {
+            Self::Inst {
+                ty: ref mut prev_ty,
+                ..
+            } => *prev_ty = ty,
+            Self::Param {
+                ty: ref mut prev_ty,
+                ..
+            } => *prev_ty = ty,
+        }
+    }
+}
+
+pub struct Values<'a> {
+    pub(super) inner: entity::Iter<'a, Value, ValueData>,
+}
+impl<'a> Iterator for Values<'a> {
+    type Item = Value;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.by_ref().next().map(|kv| kv.0)
+    }
+}

--- a/ir/src/lib.rs
+++ b/ir/src/lib.rs
@@ -1,2 +1,5 @@
+#![deny(warnings)]
+pub mod hir;
 pub mod parser;
 pub mod pass;
+pub mod types;

--- a/ir/src/types.rs
+++ b/ir/src/types.rs
@@ -1,0 +1,177 @@
+use std::fmt;
+
+/// Represents the type of a value
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Type {
+    /// This indicates a failure to type a value, or a value which is untypable
+    Unknown,
+    /// This type is used to indicate the absence of a value, such as a function which returns
+    /// nothing
+    Unit,
+    /// This type is the bottom type, and represents divergence, akin to Rust's Never/! type
+    Never,
+    I1,
+    I8,
+    I16,
+    I32,
+    I64,
+    I128,
+    I256,
+    Isize,
+    F64,
+    /// Field element
+    Felt,
+    /// A pointer to a value in memory
+    Ptr(Box<Type>),
+    /// A compound type of fixed shape and size
+    Struct(Vec<Type>),
+    /// A vector of fixed size
+    Array(Box<Type>, usize),
+}
+impl Type {
+    #[inline]
+    pub fn is_integer(&self) -> bool {
+        match self {
+            Self::I1
+            | Self::I8
+            | Self::I16
+            | Self::I32
+            | Self::I64
+            | Self::I128
+            | Self::I256
+            | Self::Isize
+            | Self::Felt => true,
+            _ => false,
+        }
+    }
+
+    #[inline]
+    pub fn is_float(&self) -> bool {
+        match self {
+            Self::F64 => true,
+            _ => false,
+        }
+    }
+
+    #[inline]
+    pub fn is_felt(&self) -> bool {
+        match self {
+            Self::Felt => true,
+            _ => false,
+        }
+    }
+
+    #[inline]
+    pub fn is_pointer(&self) -> bool {
+        match self {
+            Self::Ptr(_) => true,
+            _ => false,
+        }
+    }
+
+    #[inline]
+    pub fn is_struct(&self) -> bool {
+        match self {
+            Self::Struct(_) => true,
+            _ => false,
+        }
+    }
+
+    #[inline]
+    pub fn is_array(&self) -> bool {
+        match self {
+            Self::Array(_, _) => true,
+            _ => false,
+        }
+    }
+
+    #[inline]
+    pub fn pointee(&self) -> Option<Type> {
+        use core::ops::Deref;
+        match self {
+            Self::Ptr(ty) => Some(ty.deref().clone()),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for Type {
+    /// Print this type for display using the provided module context
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use core::fmt::Write;
+        match self {
+            Self::Unknown => f.write_str("?"),
+            Self::Unit => f.write_str("()"),
+            Self::Never => f.write_char('!'),
+            Self::I1 => f.write_str("i1"),
+            Self::I8 => f.write_str("i8"),
+            Self::I16 => f.write_str("i16"),
+            Self::I32 => f.write_str("i32"),
+            Self::I64 => f.write_str("i64"),
+            Self::I128 => f.write_str("i128"),
+            Self::I256 => f.write_str("i256"),
+            Self::Isize => f.write_str("isize"),
+            Self::F64 => f.write_str("f64"),
+            Self::Felt => f.write_str("felt"),
+            Self::Ptr(inner) => write!(f, "*mut {}", &inner),
+            Self::Struct(fields) => {
+                f.write_str("{")?;
+                for (i, field) in fields.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", {}", field)?;
+                    } else {
+                        write!(f, "{}", field)?;
+                    }
+                }
+                f.write_str("}")
+            }
+            Self::Array(element_ty, arity) => write!(f, "[{}; {}]", &element_ty, arity),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub struct FunctionType {
+    pub results: Vec<Type>,
+    pub params: Vec<Type>,
+}
+impl FunctionType {
+    pub fn new(params: Vec<Type>, results: Vec<Type>) -> Self {
+        Self { results, params }
+    }
+
+    pub fn arity(&self) -> usize {
+        self.params.len()
+    }
+
+    pub fn results(&self) -> &[Type] {
+        self.results.as_slice()
+    }
+
+    pub fn params(&self) -> &[Type] {
+        self.params.as_slice()
+    }
+}
+impl fmt::Display for FunctionType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use core::fmt::Write;
+
+        f.write_str("fn (")?;
+        for (i, ty) in self.params.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", {}", ty)?;
+            } else {
+                write!(f, "{}", ty)?;
+            }
+        }
+        f.write_str(" -> (")?;
+        for (i, ty) in self.results.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", {}", ty)?;
+            } else {
+                write!(f, "{}", ty)?;
+            }
+        }
+        f.write_char(')')
+    }
+}


### PR DESCRIPTION
The stage 1 IR (or HIR), is a sea-of-nodes style, SSA form intermediate representation. It is intended to be a target from higher level languages, so it supports a wider array of operations and control flow than is supported in MASM (and in the stage 2 IR), but provides a useful foundation on which to perform the necessary analyses and transformations in order to lower to MASM.

This commit introduces the basic infrastructure for the IR, namely the minimum data structures necessary to represent functions in the IR, which are composed of blocks containing one or more instructions in a specific order. The set of instructions defined is based on what is provided in MASM, as well as what is needed to represent programs written in Sway or Move (barring some features which we can not yet support in Miden).

Follow on commits will flesh out the IR builder, introduce modules, provide textual output for debugging, and implement control flow and dominator tree analyses.