### PR TITLE
MASM code emitter

### DIFF
--- a/tools/midenc/src/compiler/emitter.rs
+++ b/tools/midenc/src/compiler/emitter.rs
@@ -1,3 +1,4 @@
+use std::{fs::File, io::prelude::*, path::Path};
 use miden_assembly::ast::{self as masm};
 
 /// The emitter for MASM output.
@@ -7,52 +8,16 @@ pub enum MASMAst {
     Module(masm::ModuleAst),
 }
 
-pub struct MASMEmitter {
-    writer: BufferWriter,
-}
-
-impl miden_diagnostics::Emitter for MASMEmitter {
-
-    fn buffer(&self) -> Buffer {
-        self.writer.buffer()
-    }
-
-    fn print(&self, buffer: Buffer) -> std::io::Result<()> {
-        self.writer.print(&buffer)
-    }
-}
-
-impl MASMEmitter {
-
-    pub fn new () -> Self {
-        Self {
-            writer: BufferWriter::new(ColorChoice::Auto),
+impl fmt::Display for MASMAst {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Program(p) => write!("{}", p),
+            Module(m) => write!("{}", m),
         }
     }
 }
 
-impl Pass for Emitter {
-    type Input = MASMAst;
-    type Output = ();
-
-    /// Runs the emitter on the AST 
-    ///
-    /// Errors should be reported via the registered error handler,
-    /// Passes should return `Err` to signal that the pass has failed
-    /// and compilation should be aborted
-    fn run(&mut self, input: Self::Input) -> anyhow::Result<Self::Output> {
-        self.writer.write!("{}", input);
-    }
-
-    /// Implementation of Pass::chain
-    ///
-    /// # Panics
-    /// Panics if called. No chaining is possible after the emitter.
-    fn chain<P>(self, pass: P) -> Chain<Self, P>
-    where
-        Self: Sized,
-        P: for Pass<Input = Self::Output>
-    {
-        panic!("Attempting to chain a pass after the emitter.");
-    }
+fn write_ast_to_file<P: AsRef<Path>>(ast: &MASMAst, path: P) -> io::Result<()> {
+    let mut file = File::create(path);
+    file.write_fmt(format_args!("{}", ast))
 }

--- a/tools/midenc/src/compiler/emitter.rs
+++ b/tools/midenc/src/compiler/emitter.rs
@@ -1,0 +1,58 @@
+use miden_assembly::ast::{self as masm};
+
+/// The emitter for MASM output.
+
+pub enum MASMAst {
+    Program(masm::ProgramAst),
+    Module(masm::ModuleAst),
+}
+
+pub struct MASMEmitter {
+    writer: BufferWriter,
+}
+
+impl miden_diagnostics::Emitter for MASMEmitter {
+
+    fn buffer(&self) -> Buffer {
+        self.writer.buffer()
+    }
+
+    fn print(&self, buffer: Buffer) -> std::io::Result<()> {
+        self.writer.print(&buffer)
+    }
+}
+
+impl MASMEmitter {
+
+    pub fn new () -> Self {
+        Self {
+            writer: BufferWriter::new(ColorChoice::Auto),
+        }
+    }
+}
+
+impl Pass for Emitter {
+    type Input = MASMAst;
+    type Output = ();
+
+    /// Runs the emitter on the AST 
+    ///
+    /// Errors should be reported via the registered error handler,
+    /// Passes should return `Err` to signal that the pass has failed
+    /// and compilation should be aborted
+    fn run(&mut self, input: Self::Input) -> anyhow::Result<Self::Output> {
+        self.writer.write!("{}", input);
+    }
+
+    /// Implementation of Pass::chain
+    ///
+    /// # Panics
+    /// Panics if called. No chaining is possible after the emitter.
+    fn chain<P>(self, pass: P) -> Chain<Self, P>
+    where
+        Self: Sized,
+        P: for Pass<Input = Self::Output>
+    {
+        panic!("Attempting to chain a pass after the emitter.");
+    }
+}

--- a/tools/midenc/src/compiler/mod.rs
+++ b/tools/midenc/src/compiler/mod.rs
@@ -37,6 +37,13 @@ pub fn compile(
     // let artifacts = compile()?;
     // diagnostics.abort_if_errors();
 
+//    for x in artifacts {
+//        let dir = options.get_output_dir();
+//        dir.push(x.name);
+//        dir.set_extension("masm");
+//        self::emitter::write_ast_to_file(x.ast, dir.as_path());
+//    }
+    
     let duration = HumanDuration::since(start);
     diagnostics.success(
         "Finished",

--- a/tools/midenc/src/compiler/options.rs
+++ b/tools/midenc/src/compiler/options.rs
@@ -120,6 +120,13 @@ impl Options {
             output_dir,
         }))
     }
+
+    fn get_output_dir(&self) -> PathBuf {
+        match self.output_dir {
+            Some(ref dir) => dir.clone(),
+            None => self.current_dir.clone(),
+        }
+    }
 }
 
 bitflags::bitflags! {


### PR DESCRIPTION
I'm struggling to figure out how the emitter is supposed to fit in with the other stuff in the `midenc` directory and with `miden-diagnostics`. This draft PR is my current attempt, but I have no idea if it's anywhere close to what we need, and what the exact division of responsibilities is supposed to be between the various files.

For instance, the `Emitter` trait doesn't seem to use file names at all, so presumably the file buffer we need to write to is passed to the emitter from the outside?