### PR TITLE
feat: implement conversion of masm ir to 'real' masm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "arrayref"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,11 +157,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
+name = "blake3"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0231f06152bf547e9c2b5194f247cd97aacf6dcd8b15d8e5ec0663f64580da87"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -240,6 +275,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cranelift-bforest"
 version = "0.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,10 +305,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f333fa641a9ad2bff0b107767dcb972c18c2bfab7969805a1d7e42449ccb0408"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dirs-next"
@@ -371,6 +441,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +466,12 @@ name = "gimli"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "hashbrown"
@@ -465,6 +551,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,12 +634,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "miden-assembly"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c483ade3de7375f869a2c99de2396d0545cb6df96e0e96d693a40e298b4cfea"
+dependencies = [
+ "miden-core",
+ "num_enum",
+]
+
+[[package]]
 name = "miden-codegen-masm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "cranelift-entity",
  "intrusive-collections",
+ "miden-assembly",
  "miden-diagnostics",
  "miden-hir",
  "miden-hir-analysis",
@@ -548,9 +663,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "miden-core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3baf9ff16e3f7a6c045c8ece8d2d7ebf4521eab92de07cc9edb11f3e9c853143"
+dependencies = [
+ "miden-crypto",
+ "winter-crypto",
+ "winter-math",
+ "winter-utils",
+]
+
+[[package]]
+name = "miden-crypto"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32dd571edafdd5e8947e4006a905a1c5373f2f8b08b270fea3c998db5be131cf"
+dependencies = [
+ "blake3",
+ "cc",
+ "glob",
+ "libc",
+ "winter-crypto",
+ "winter-math",
+ "winter-utils",
+]
+
+[[package]]
 name = "miden-diagnostics"
 version = "0.1.0"
-source = "git+https://github.com/0xpolygonmiden/miden-diagnostics#f99efe05b8873723fcbb1ba22c31d15c9e4b5afe"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f3a82597c2a9babcff4c9283a95130a96aaf8e339954a083bb6582fc2520cf1"
 dependencies = [
  "atty",
  "codespan",
@@ -565,7 +708,8 @@ dependencies = [
 [[package]]
 name = "miden-diagnostics-macros"
 version = "0.1.0"
-source = "git+https://github.com/0xpolygonmiden/miden-diagnostics#f99efe05b8873723fcbb1ba22c31d15c9e4b5afe"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "491d10b0eb201ba767ccdf69bf77f9d5662caf55e9ef468264cccb7129edff62"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -579,6 +723,7 @@ dependencies = [
  "anyhow",
  "cranelift-entity",
  "intrusive-collections",
+ "miden-assembly",
  "miden-diagnostics",
  "miden-hir-symbol",
  "miden-hir-type",
@@ -675,6 +820,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70bf6736f74634d299d00086f02986875b3c2d924781a6a2cb6c201e73da0ceb"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ea360eafe1022f7cc56cd7b869ed57330fb2453d0c7831d99b74c65d2f5597"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.31",
+]
+
+[[package]]
 name = "object"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,6 +913,16 @@ checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
 dependencies = [
  "diff",
  "yansi",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit",
 ]
 
 [[package]]
@@ -911,6 +1087,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,6 +1237,12 @@ name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
@@ -1211,6 +1403,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winter-crypto"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a20b2a4499797cbaeb38c980f9f34e6e60d993e8e170a6deb354345f50cbfb"
+dependencies = [
+ "blake3",
+ "sha3",
+ "winter-math",
+ "winter-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,15 +43,16 @@ rustc-hash = "1.1"
 smallvec = { version = "1.9", features = ["union", "const_generics", "const_new"] }
 smallstr = { version = "0.3", features = ["union"] }
 thiserror = "1.0"
+miden-assembly = "0.7"
 miden-codegen-masm = { path = "codegen/masm" }
-miden-diagnostics = { git = "https://github.com/0xpolygonmiden/miden-diagnostics" }
+miden-diagnostics = "0.1"
 miden-hir = { path = "hir" }
 miden-hir-analysis = { path = "hir-analysis" }
 miden-hir-pass = { path = "hir-pass" }
 miden-hir-symbol = { path = "hir-symbol" }
 miden-hir-transform = { path = "hir-transform" }
 miden-hir-type = { path = "hir-type" }
-miden-parsing = { git = "https://github.com/0xpolygonmiden/miden-parsing" }
+miden-parsing = "0.1"
 
 [profile.release]
 opt-level = 2

--- a/codegen/masm/Cargo.toml
+++ b/codegen/masm/Cargo.toml
@@ -15,6 +15,7 @@ anyhow.workspace = true
 thiserror.workspace = true
 cranelift-entity.workspace = true
 intrusive-collections.workspace = true
+miden-assembly.workspace = true
 miden-diagnostics.workspace = true
 miden-hir.workspace = true
 miden-hir-analysis.workspace = true

--- a/codegen/masm/src/masm/function.rs
+++ b/codegen/masm/src/masm/function.rs
@@ -2,7 +2,9 @@ use std::fmt;
 
 use cranelift_entity::{EntityRef, PrimaryMap};
 use intrusive_collections::{intrusive_adapter, LinkedListLink};
+use miden_diagnostics::Spanned;
 use miden_hir::{FunctionIdent, Signature, Type};
+use rustc_hash::FxHashMap;
 use smallvec::{smallvec, SmallVec};
 
 use super::*;
@@ -10,9 +12,11 @@ use super::*;
 intrusive_adapter!(pub FunctionListAdapter = Box<Function>: Function { link: LinkedListLink });
 
 /// This represents a function in Miden Assembly
+#[derive(Spanned)]
 pub struct Function {
     link: LinkedListLink,
     /// The name of this function
+    #[span]
     pub name: FunctionIdent,
     /// The type signature of this function
     pub signature: Signature,
@@ -115,7 +119,92 @@ impl Function {
             imports,
         }
     }
+
+    pub fn to_function_ast(
+        &self,
+        codemap: &miden_diagnostics::CodeMap,
+        imports: &miden_hir::ModuleImportInfo,
+        local_ids: &FxHashMap<FunctionIdent, u16>,
+        proc_ids: &FxHashMap<FunctionIdent, miden_assembly::ProcedureId>,
+    ) -> miden_assembly::ast::ProcedureAst {
+        use miden_assembly::{
+            self as masm,
+            ast::{ProcedureAst, SourceLocation},
+        };
+
+        let name = masm::ProcedureName::try_from(self.name.function.as_str())
+            .expect("invalid function name");
+        let num_locals = u16::try_from(self.locals.len()).expect("too many locals");
+        let start = codemap
+            .location(self)
+            .ok()
+            .map(|loc| {
+                SourceLocation::new(loc.line.to_usize() as u32, loc.column.to_usize() as u32)
+            })
+            .unwrap_or_default();
+        let body = emit_block(
+            self.body,
+            &self.blocks,
+            codemap,
+            imports,
+            local_ids,
+            proc_ids,
+        );
+
+        ProcedureAst {
+            name,
+            docs: None,
+            num_locals,
+            body,
+            start,
+            is_export: self.signature.is_public(),
+        }
+    }
 }
+
+fn emit_block(
+    block_id: BlockId,
+    blocks: &PrimaryMap<BlockId, Block>,
+    codemap: &miden_diagnostics::CodeMap,
+    imports: &miden_hir::ModuleImportInfo,
+    local_ids: &FxHashMap<FunctionIdent, u16>,
+    proc_ids: &FxHashMap<FunctionIdent, miden_assembly::ProcedureId>,
+) -> miden_assembly::ast::CodeBody {
+    use miden_assembly::ast::{CodeBody, Node};
+
+    let current_block = &blocks[block_id];
+    let mut ops = Vec::with_capacity(current_block.ops.len());
+    for op in current_block.ops.iter() {
+        match op.clone() {
+            Op::If(then_blk, else_blk) => {
+                let true_case = emit_block(then_blk, blocks, codemap, imports, local_ids, proc_ids);
+                let false_case =
+                    emit_block(else_blk, blocks, codemap, imports, local_ids, proc_ids);
+                ops.push(Node::IfElse {
+                    true_case,
+                    false_case,
+                });
+            }
+            Op::While(blk) => {
+                let body = emit_block(blk, blocks, codemap, imports, local_ids, proc_ids);
+                ops.push(Node::While { body });
+            }
+            Op::Repeat(n, blk) => {
+                let body = emit_block(blk, blocks, codemap, imports, local_ids, proc_ids);
+                ops.push(Node::Repeat {
+                    times: n as u32,
+                    body,
+                });
+            }
+            op => {
+                ops.extend(op.into_node(codemap, imports, local_ids, proc_ids));
+            }
+        }
+    }
+
+    CodeBody::new(ops)
+}
+
 impl fmt::Debug for Function {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Function")

--- a/codegen/masm/src/masm/module.rs
+++ b/codegen/masm/src/masm/module.rs
@@ -1,13 +1,20 @@
-use core::fmt;
+use std::{collections::BTreeMap, fmt, path::Path};
 
 use intrusive_collections::LinkedList;
 use miden_hir::{FunctionIdent, Ident};
+use rustc_hash::FxHashMap;
 
 use super::{Function, FunctionListAdapter, ModuleImportInfo, Op};
 
+/// This represents a single compiled Miden Assembly module in a form that is
+/// designed to integrate well with the rest of our IR. You can think of this
+/// as an intermediate representation corresponding to the Miden Assembly AST,
+/// i.e. [miden_assembly::ast::ModuleAst].
 pub struct Module {
     /// The name of this module, e.g. `std::math::u64`
     pub name: Ident,
+    /// The module-scoped documentation for this module
+    pub docs: Option<String>,
     /// If this module contains a program entrypoint, this is the
     /// function identifier which should be used for that purpose.
     pub entry: Option<FunctionIdent>,
@@ -16,20 +23,104 @@ pub struct Module {
     /// The functions defined in this module
     pub functions: LinkedList<FunctionListAdapter>,
 }
-
 impl Module {
+    /// Create a new, empty [Module] with the given name.
     pub fn new(name: Ident) -> Self {
         Self {
             name,
+            docs: None,
             entry: None,
             imports: Default::default(),
             functions: Default::default(),
         }
     }
 
+    /// Convert this module into its [miden_assembly::Module] representation.
+    pub fn to_module_ast(&self, codemap: &miden_diagnostics::CodeMap) -> miden_assembly::Module {
+        use miden_assembly::{
+            self as masm,
+            ast::{ModuleAst, ModuleImports},
+        };
+
+        // Create module import table
+        let mut imported = BTreeMap::<String, masm::LibraryPath>::default();
+        let mut invoked = BTreeMap::<masm::ProcedureId, _>::default();
+        let mut proc_ids = FxHashMap::<FunctionIdent, masm::ProcedureId>::default();
+        for import in self.imports.iter() {
+            let path = masm::LibraryPath::new(import.name.as_str()).expect("invalid module name");
+            imported.insert(import.alias.to_string(), path.clone());
+            if let Some(imported_fns) = self.imports.imported(&import.alias) {
+                for import_fn in imported_fns.iter().copied() {
+                    let fname = import_fn.to_string();
+                    let name = masm::ProcedureName::try_from(fname.as_str())
+                        .expect("invalid function name");
+                    let id = masm::ProcedureId::from_name(fname.as_str(), &path);
+                    invoked.insert(id, (name, path.clone()));
+                    proc_ids.insert(import_fn, id);
+                }
+            }
+        }
+        let imports = ModuleImports::new(imported, invoked);
+
+        // Translate functions
+        let mut local_ids = FxHashMap::default();
+        for (id, function) in self.functions.iter().enumerate() {
+            local_ids.insert(function.name, id as u16);
+        }
+        let mut procs = Vec::with_capacity(self.num_imported_functions());
+        for function in self.functions.iter() {
+            procs.push(function.to_function_ast(codemap, &self.imports, &local_ids, &proc_ids));
+        }
+
+        // Construct module
+        let path = masm::LibraryPath::new(self.name.as_str()).expect("invalid module name");
+        let ast = ModuleAst::new(procs, vec![], self.docs.clone())
+            .expect("invalid module body")
+            .with_import_info(imports);
+        masm::Module { path, ast }
+    }
+
+    fn num_imported_functions(&self) -> usize {
+        self.imports
+            .iter()
+            .map(|i| {
+                self.imports
+                    .imported(&i.alias)
+                    .map(|imported| imported.len())
+                    .unwrap_or(0)
+            })
+            .sum()
+    }
+
+    /// Write this module to a new file under `dir`, assuming `dir` is the root directory for a program.
+    ///
+    /// For example, if this module is named `std::math::u64`, then it will be written to `<dir>/std/math/u64.masm`
+    pub fn write_to_directory<P: AsRef<Path>>(
+        &self,
+        codemap: &miden_diagnostics::CodeMap,
+        dir: P,
+    ) -> std::io::Result<()> {
+        use std::fs::File;
+
+        let mut path = dir.as_ref().to_path_buf();
+        assert!(path.is_dir());
+        for component in self.name.as_str().split("::") {
+            path.push(component);
+        }
+        assert!(path.set_extension("masm"));
+
+        let mut out = File::create(&path)?;
+        self.emit(codemap, &mut out)
+    }
+
     /// Write this module as Miden Assembly text to `out`
-    pub fn emit(&self, _out: &mut dyn std::io::Write) -> std::io::Result<()> {
-        todo!()
+    pub fn emit(
+        &self,
+        codemap: &miden_diagnostics::CodeMap,
+        out: &mut dyn std::io::Write,
+    ) -> std::io::Result<()> {
+        let ast = self.to_module_ast(codemap);
+        out.write_fmt(format_args!("{}", &ast.ast))
     }
 }
 impl fmt::Display for Module {
@@ -46,8 +137,12 @@ impl fmt::Display for Module {
             writeln!(f)?;
         }
 
-        for function in self.functions.iter() {
-            writeln!(f, "{}\n", function.display(&self.imports))?;
+        for (i, function) in self.functions.iter().enumerate() {
+            if i > 0 {
+                writeln!(f, "\n{}", function.display(&self.imports))?;
+            } else {
+                writeln!(f, "{}", function.display(&self.imports))?;
+            }
         }
 
         if let Some(entry) = self.entry {

--- a/codegen/masm/src/masm/program.rs
+++ b/codegen/masm/src/masm/program.rs
@@ -1,16 +1,23 @@
-use std::path::Path;
+use std::{collections::BTreeMap, path::Path};
 
-use miden_hir::{self as hir, DataSegmentTable, FunctionIdent};
+use miden_hir::{self as hir, DataSegmentTable, FunctionIdent, Ident};
 
 use super::*;
 
+/// A [Program] represents a complete set of modules which are intended to
+/// be shipped together as an artifact, either as an executable, or as a library
+/// to be integrated into a larger executable.
 #[derive(Default)]
 pub struct Program {
+    /// The set of modules which belong to this program
     pub modules: Vec<Module>,
+    /// The function identifier for the program entrypoint, if this is an executable module
     pub entrypoint: Option<FunctionIdent>,
+    /// The data segment table for this program
     pub segments: DataSegmentTable,
 }
 impl Program {
+    /// Create a new, empty [Program]
     pub fn new() -> Self {
         Self::default()
     }
@@ -21,6 +28,66 @@ impl Program {
 
     pub fn is_library(&self) -> bool {
         self.entrypoint.is_none()
+    }
+
+    /// Write this [Program] to the given output directory.
+    ///
+    /// The provided [miden_diagnostics::CodeMap] is used for computing source locations.
+    pub fn write_to_directory<P: AsRef<Path>>(
+        &self,
+        codemap: &miden_diagnostics::CodeMap,
+        path: P,
+    ) -> std::io::Result<()> {
+        use miden_assembly as masm;
+
+        let path = path.as_ref();
+        assert!(path.is_dir());
+
+        let program = self.to_program_ast();
+        program.write_to_file(path.join(masm::LibraryPath::EXEC_PATH))?;
+
+        for module in self.modules.iter() {
+            module.write_to_directory(codemap, path)?;
+        }
+
+        Ok(())
+    }
+
+    /// Convert this program to its [miden_assembly::ast::ProgramAst] representation
+    pub fn to_program_ast(&self) -> miden_assembly::ast::ProgramAst {
+        use miden_assembly::{
+            self as masm,
+            ast::{Instruction, ModuleImports, Node, ProgramAst},
+        };
+
+        if let Some(entry) = self.entrypoint {
+            let entry_import = Import::try_from(entry.module).expect("invalid module name");
+            let entry_module_path =
+                masm::LibraryPath::new(entry_import.name.as_str()).expect("invalid module path");
+            let entry_id =
+                masm::ProcedureId::from_name(entry.function.as_str(), &entry_module_path);
+            let entry_name = masm::ProcedureName::try_from(
+                FunctionIdent {
+                    module: Ident::with_empty_span(entry_import.alias),
+                    ..entry
+                }
+                .to_string(),
+            )
+            .expect("invalid entrypoint function name");
+            let imported =
+                BTreeMap::from([(entry_import.alias.to_string(), entry_module_path.clone())]);
+            let invoked = BTreeMap::from([(entry_id, (entry_name, entry_module_path))]);
+            let imports = ModuleImports::new(imported, invoked);
+
+            // TODO: Write data segments, initialize function table
+            let body = vec![Node::Instruction(Instruction::ExecImported(entry_id))];
+
+            ProgramAst::new(body, vec![])
+                .expect("invalid program")
+                .with_import_info(imports)
+        } else {
+            todo!("0xPolygonMiden/miden-vm#1108")
+        }
     }
 }
 impl From<&hir::Program> for Program {
@@ -35,8 +102,4 @@ impl From<&hir::Program> for Program {
     }
 }
 
-impl Program {
-    pub fn write_to_directory<P: AsRef<Path>>(&self, _path: P) -> std::io::Result<()> {
-        todo!()
-    }
-}
+impl Program {}

--- a/hir/Cargo.toml
+++ b/hir/Cargo.toml
@@ -14,6 +14,7 @@ edition.workspace = true
 anyhow.workspace = true
 cranelift-entity.workspace = true
 intrusive-collections.workspace = true
+miden-assembly.workspace = true
 miden-diagnostics.workspace = true
 miden-hir-symbol.workspace = true
 miden-hir-type.workspace = true


### PR DESCRIPTION
As the PR title states, this enables conversion from our internal MASM IR to the "real" MASM representation provided by the `miden-assembly` crate. We can then emit to disk using those APIs, compile via the assembler, or run with the Miden VM.

NOTE: This PR omits a couple things pending some other work:

1. Emission of MASL libraries is blocked by 0xPolygonMiden/miden-vm#1108
2. The initialization of root context memory (i.e. writing data segments to the heap) is not yet implemented. We'll probably implement something here in the near future, but I'm punting a bit while I work on some other things
3. The function table that we'll want to write to memory to support `dynexec` is on hold until #32 is implemented