### PR TITLE
ci: only run push workflow on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+    - main
     paths-ignore:
     - '*.md'
   pull_request:


### PR DESCRIPTION
Right now we're running both the `push` and `pull_request` workflows on every PR, which is redundant