### PR TITLE
Demangle function names in Rust compilation tests comparison

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,6 +803,7 @@ dependencies = [
  "miden-diagnostics",
  "miden-hir",
  "miden-hir-type",
+ "rustc-demangle",
  "sha2",
  "smallvec",
  "thiserror",

--- a/frontend-wasm/Cargo.toml
+++ b/frontend-wasm/Cargo.toml
@@ -29,3 +29,4 @@ wat = "1.0.69"
 expect-test = "1.4.1"
 wasmprinter = "0.2.63"
 sha2 = "0.10"
+rustc-demangle = {version = "0.1.19", features = ["std"]}    

--- a/frontend-wasm/tests/expected/dlmalloc.mir
+++ b/frontend-wasm/tests/expected/dlmalloc.mir
@@ -4,11 +4,11 @@ global external gv1 : i32 = 0x001001c8 { id = gvar1 };
 global external gv2 : i32 = 0x001001d0 { id = gvar2 };
 
 
-pub fn _ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$13dispose_chunk17h577eb103dc04307bE(i32, i32, i32) {
+pub fn dlmalloc::dlmalloc::Dlmalloc<A>::dispose_chunk(i32, i32, i32) {
 block0(v0: i32, v1: i32, v2: i32):
     v3 = const.i32 0  : i32
-    v4 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1, v2)  : i32
-    v5 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6pinuse17h92d5107047b03ba7E(v1)  : i32
+    v4 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v1, v2)  : i32
+    v5 = call noname::dlmalloc::dlmalloc::Chunk::pinuse(v1)  : i32
     v6 = neq v5, 0  : i1
     condbr v6, block4(v1, v2), block5
 
@@ -28,7 +28,7 @@ block3:
     ret 
 
 block4(v93: i32, v94: i32):
-    v89 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6cinuse17h58499de57c2d37e2E(v4)  : i32
+    v89 = call noname::dlmalloc::dlmalloc::Chunk::cinuse(v4)  : i32
     v90 = eq v89, 0  : i1
     v91 = cast v90  : i32
     v92 = neq v91, 0  : i1
@@ -38,7 +38,7 @@ block5:
     v7 = cast v1  : u32
     v8 = inttoptr v7  : *mut i32
     v9 = load v8  : i32
-    v10 = call noname::_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(v1)  : i32
+    v10 = call noname::dlmalloc::dlmalloc::Chunk::mmapped(v1)  : i32
     v11 = neq v10, 0  : i1
     condbr v11, block6, block7
 
@@ -47,7 +47,7 @@ block6:
     v73 = add v2, v9  : i32
     v74 = const.i32 16  : i32
     v75 = add v73, v74  : i32
-    v76 = call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$4free17h993c5f05ba1214bcE(v0, v72, v75)  : i32
+    v76 = call noname::<dlmalloc::sys::System as dlmalloc::Allocator>::free(v0, v72, v75)  : i32
     v77 = eq v76, 0  : i1
     v78 = cast v77  : i32
     v79 = neq v78, 0  : i1
@@ -55,7 +55,7 @@ block6:
 
 block7:
     v12 = add v9, v2  : i32
-    v13 = call noname::_ZN8dlmalloc8dlmalloc5Chunk12minus_offset17h7c3eec81761249d9E(v1, v9)  : i32
+    v13 = call noname::dlmalloc::dlmalloc::Chunk::minus_offset(v1, v9)  : i32
     v14 = cast v0  : u32
     v15 = add v14, 424  : u32
     v16 = inttoptr v15  : *mut i32
@@ -92,7 +92,7 @@ block10:
     v32 = add v31, 416  : u32
     v33 = inttoptr v32  : *mut i32
     store v33, v12
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E(v13, v12, v4)
+    call noname::dlmalloc::dlmalloc::Chunk::set_free_with_pinuse(v13, v12, v4)
     ret 
 
 block11:
@@ -110,7 +110,7 @@ block11:
     condbr v50, block13, block14
 
 block12:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v0, v13)
+    call noname::dlmalloc::dlmalloc::Dlmalloc<A>::unlink_large_chunk(v0, v13)
     br block4(v13, v12)
 
 block13:
@@ -166,7 +166,7 @@ block16:
     condbr v102, block19, block20
 
 block17:
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E(v93, v94, v88)
+    call noname::dlmalloc::dlmalloc::Chunk::set_free_with_pinuse(v93, v94, v88)
     br block2(v94, v95, v93)
 
 block18:
@@ -183,7 +183,7 @@ block18:
     v203 = add v202, 416  : u32
     v204 = inttoptr v203  : *mut i32
     store v204, v201
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v93, v201)
+    call noname::dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_free_chunk(v93, v201)
     ret 
 
 block19:
@@ -226,7 +226,7 @@ block20:
     condbr v109, block18, block21
 
 block21:
-    v110 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v88)  : i32
+    v110 = call noname::dlmalloc::dlmalloc::Chunk::size(v88)  : i32
     v111 = add v110, v94  : i32
     v112 = const.i32 256  : i32
     v113 = cast v110  : u32
@@ -237,7 +237,7 @@ block21:
     condbr v117, block23, block24
 
 block22:
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v93, v111)
+    call noname::dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_free_chunk(v93, v111)
     v153 = cast v95  : u32
     v154 = add v153, 424  : u32
     v155 = inttoptr v154  : *mut i32
@@ -262,7 +262,7 @@ block23:
     condbr v128, block25, block26
 
 block24:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v95, v88)
+    call noname::dlmalloc::dlmalloc::Dlmalloc<A>::unlink_large_chunk(v95, v88)
     br block22
 
 block25:
@@ -339,7 +339,7 @@ block29:
     condbr v233, block32, block33
 
 block30:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E(v212, v213, v205)
+    call noname::dlmalloc::dlmalloc::Dlmalloc<A>::insert_large_chunk(v212, v213, v205)
     ret 
 
 block31(v247: i32):
@@ -377,14 +377,14 @@ block33:
     br block31(v237)
 }
 
-pub fn _ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(i32, i32) {
+pub fn dlmalloc::dlmalloc::Dlmalloc<A>::unlink_large_chunk(i32, i32) {
 block0(v0: i32, v1: i32):
     v2 = const.i32 0  : i32
     v3 = cast v1  : u32
     v4 = add v3, 24  : u32
     v5 = inttoptr v4  : *mut i32
     v6 = load v5  : i32
-    v7 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk4next17he250edbec5d87123E(v1)  : i32
+    v7 = call noname::dlmalloc::dlmalloc::TreeChunk::next(v1)  : i32
     v8 = neq v7, v1  : i1
     v9 = cast v8  : i32
     v10 = neq v9, 0  : i1
@@ -407,14 +407,14 @@ block3:
     br block7(v39, v23)
 
 block4:
-    v26 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk4prev17h7a0f1d46544cc14aE(v1)  : i32
-    v27 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk4next17he250edbec5d87123E(v1)  : i32
-    v28 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v27)  : i32
+    v26 = call noname::dlmalloc::dlmalloc::TreeChunk::prev(v1)  : i32
+    v27 = call noname::dlmalloc::dlmalloc::TreeChunk::next(v1)  : i32
+    v28 = call noname::dlmalloc::dlmalloc::TreeChunk::chunk(v27)  : i32
     v29 = cast v26  : u32
     v30 = add v29, 12  : u32
     v31 = inttoptr v30  : *mut i32
     store v31, v28
-    v32 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v26)  : i32
+    v32 = call noname::dlmalloc::dlmalloc::TreeChunk::chunk(v26)  : i32
     v33 = cast v27  : u32
     v34 = add v33, 8  : u32
     v35 = inttoptr v34  : *mut i32
@@ -583,7 +583,7 @@ block19:
     ret 
 }
 
-pub fn _ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E(i32, i32, i32) {
+pub fn dlmalloc::dlmalloc::Dlmalloc<A>::insert_large_chunk(i32, i32, i32) {
 block0(v0: i32, v1: i32, v2: i32):
     v3 = const.i32 0  : i32
     v4 = const.i32 0  : i32
@@ -611,7 +611,7 @@ block2(v42: i32):
     v47 = const.i32 2  : i32
     v48 = shl v42, v47  : i32
     v49 = add v0, v48  : i32
-    v50 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v37)  : i32
+    v50 = call noname::dlmalloc::dlmalloc::TreeChunk::chunk(v37)  : i32
     v51 = cast v46  : u32
     v52 = add v51, 412  : u32
     v53 = inttoptr v52  : *mut i32
@@ -686,13 +686,13 @@ block7:
     v61 = cast v49  : u32
     v62 = inttoptr v61  : *mut i32
     v63 = load v62  : i32
-    v65 = call noname::_ZN8dlmalloc8dlmalloc24leftshift_for_tree_index17h31d064fdd867f502E(v42)  : i32
+    v65 = call noname::dlmalloc::dlmalloc::leftshift_for_tree_index(v42)  : i32
     v66 = shl v2, v65  : i32
     br block8(v63, v66)
 
 block8(v67: i32, v97: i32):
-    v68 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v67)  : i32
-    v69 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v68)  : i32
+    v68 = call noname::dlmalloc::dlmalloc::TreeChunk::chunk(v67)  : i32
+    v69 = call noname::dlmalloc::dlmalloc::Chunk::size(v68)  : i32
     v71 = neq v69, v70  : i1
     v72 = cast v71  : i32
     v73 = neq v72, 0  : i1
@@ -728,7 +728,7 @@ block10:
     condbr v113, block8(v112, v104), block12
 
 block11:
-    v74 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v67)  : i32
+    v74 = call noname::dlmalloc::dlmalloc::TreeChunk::chunk(v67)  : i32
     v75 = cast v74  : u32
     v76 = add v75, 8  : u32
     v77 = inttoptr v76  : *mut i32
@@ -760,7 +760,7 @@ block12:
     br block9
 }
 
-pub fn _ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$23release_unused_segments17h25622465f0742468E(i32) -> i32 {
+pub fn dlmalloc::dlmalloc::Dlmalloc<A>::release_unused_segments(i32) -> i32 {
 block0(v0: i32):
     v2 = const.i32 0  : i32
     v3 = const.i32 136  : i32
@@ -822,7 +822,7 @@ block5(v15: i32, v27: i32, v102: i32, v108: i32, v114: i32):
     v34 = cast v32  : u32
     v35 = shr v33, v34  : u32
     v36 = cast v35  : i32
-    v37 = call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$16can_release_part17h43bfb7d8666fcc31E(v27, v36)  : i32
+    v37 = call noname::<dlmalloc::sys::System as dlmalloc::Allocator>::can_release_part(v27, v36)  : i32
     v38 = eq v37, 0  : i1
     v39 = cast v38  : i32
     v40 = neq v39, 0  : i1
@@ -841,27 +841,27 @@ block8(v115: i32, v119: i32, v122: i32, v125: i32):
     br block7(v115, v119, v122, v15, v125)
 
 block9:
-    v41 = call noname::_ZN8dlmalloc8dlmalloc7Segment9is_extern17h6f6db2c70b891fd9E(v15)  : i32
+    v41 = call noname::dlmalloc::dlmalloc::Segment::is_extern(v15)  : i32
     v42 = neq v41, 0  : i1
     condbr v42, block8(v114, v19, v27, v108), block10
 
 block10:
-    v43 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v26)  : i32
+    v43 = call noname::dlmalloc::dlmalloc::Chunk::to_mem(v26)  : i32
     v44 = const.i32 8  : i32
-    v45 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v43, v44)  : i32
+    v45 = call noname::dlmalloc::dlmalloc::align_up(v43, v44)  : i32
     v46 = sub v45, v43  : i32
     v47 = add v26, v46  : i32
-    v48 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v47)  : i32
-    v49 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v48 = call noname::dlmalloc::dlmalloc::Chunk::size(v47)  : i32
+    v49 = call noname::dlmalloc::dlmalloc::Chunk::mem_offset()  : i32
     v50 = const.i32 8  : i32
-    v51 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v49, v50)  : i32
+    v51 = call noname::dlmalloc::dlmalloc::align_up(v49, v50)  : i32
     v52 = const.i32 20  : i32
     v53 = const.i32 8  : i32
-    v54 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v52, v53)  : i32
+    v54 = call noname::dlmalloc::dlmalloc::align_up(v52, v53)  : i32
     v55 = const.i32 16  : i32
     v56 = const.i32 8  : i32
-    v57 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v55, v56)  : i32
-    v58 = call noname::_ZN8dlmalloc8dlmalloc5Chunk5inuse17h2d327e4c36b84dfeE(v47)  : i32
+    v57 = call noname::dlmalloc::dlmalloc::align_up(v55, v56)  : i32
+    v58 = call noname::dlmalloc::dlmalloc::Chunk::inuse(v47)  : i32
     v59 = neq v58, 0  : i1
     condbr v59, block8(v114, v19, v27, v108), block11
 
@@ -890,7 +890,7 @@ block12:
     condbr v77, block14, block15
 
 block13:
-    v89 = call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$4free17h993c5f05ba1214bcE(v27, v26, v23)  : i32
+    v89 = call noname::<dlmalloc::sys::System as dlmalloc::Allocator>::free(v27, v26, v23)  : i32
     v90 = neq v89, 0  : i1
     condbr v90, block16, block17
 
@@ -908,7 +908,7 @@ block14:
     br block13
 
 block15:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v27, v47)
+    call noname::dlmalloc::dlmalloc::Dlmalloc<A>::unlink_large_chunk(v27, v47)
     br block13
 
 block16:
@@ -929,20 +929,20 @@ block16:
     br block7(v114, v103, v86, v101, v109)
 
 block17:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E(v86, v47, v48)
+    call noname::dlmalloc::dlmalloc::Dlmalloc<A>::insert_large_chunk(v86, v47, v48)
     br block8(v113, v103, v86, v107)
 
 block18:
     br block6
 }
 
-pub fn _ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$4free17h501de2a6604ba1ffE(i32, i32) {
+pub fn dlmalloc::dlmalloc::Dlmalloc<A>::free(i32, i32) {
 block0(v0: i32, v1: i32):
     v2 = const.i32 0  : i32
-    v3 = call noname::_ZN8dlmalloc8dlmalloc5Chunk8from_mem17h11dd30c74f483706E(v1)  : i32
-    v4 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v3)  : i32
-    v5 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v3, v4)  : i32
-    v6 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6pinuse17h92d5107047b03ba7E(v3)  : i32
+    v3 = call noname::dlmalloc::dlmalloc::Chunk::from_mem(v1)  : i32
+    v4 = call noname::dlmalloc::dlmalloc::Chunk::size(v3)  : i32
+    v5 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v3, v4)  : i32
+    v6 = call noname::dlmalloc::dlmalloc::Chunk::pinuse(v3)  : i32
     v7 = neq v6, 0  : i1
     condbr v7, block3(v3, v4), block4
 
@@ -953,7 +953,7 @@ block2:
     br block1
 
 block3(v94: i32, v95: i32):
-    v90 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6cinuse17h58499de57c2d37e2E(v5)  : i32
+    v90 = call noname::dlmalloc::dlmalloc::Chunk::cinuse(v5)  : i32
     v91 = eq v90, 0  : i1
     v92 = cast v91  : i32
     v93 = neq v92, 0  : i1
@@ -963,7 +963,7 @@ block4:
     v8 = cast v3  : u32
     v9 = inttoptr v8  : *mut i32
     v10 = load v9  : i32
-    v11 = call noname::_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(v3)  : i32
+    v11 = call noname::dlmalloc::dlmalloc::Chunk::mmapped(v3)  : i32
     v12 = neq v11, 0  : i1
     condbr v12, block5, block6
 
@@ -972,7 +972,7 @@ block5:
     v74 = add v4, v10  : i32
     v75 = const.i32 16  : i32
     v76 = add v74, v75  : i32
-    v77 = call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$4free17h993c5f05ba1214bcE(v0, v73, v76)  : i32
+    v77 = call noname::<dlmalloc::sys::System as dlmalloc::Allocator>::free(v0, v73, v76)  : i32
     v78 = eq v77, 0  : i1
     v79 = cast v78  : i32
     v80 = neq v79, 0  : i1
@@ -980,7 +980,7 @@ block5:
 
 block6:
     v13 = add v10, v4  : i32
-    v14 = call noname::_ZN8dlmalloc8dlmalloc5Chunk12minus_offset17h7c3eec81761249d9E(v3, v10)  : i32
+    v14 = call noname::dlmalloc::dlmalloc::Chunk::minus_offset(v3, v10)  : i32
     v15 = cast v0  : u32
     v16 = add v15, 424  : u32
     v17 = inttoptr v16  : *mut i32
@@ -1017,7 +1017,7 @@ block9:
     v33 = add v32, 416  : u32
     v34 = inttoptr v33  : *mut i32
     store v34, v13
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E(v14, v13, v5)
+    call noname::dlmalloc::dlmalloc::Chunk::set_free_with_pinuse(v14, v13, v5)
     ret 
 
 block10:
@@ -1035,7 +1035,7 @@ block10:
     condbr v51, block12, block13
 
 block11:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v0, v14)
+    call noname::dlmalloc::dlmalloc::Dlmalloc<A>::unlink_large_chunk(v0, v14)
     br block3(v14, v13)
 
 block12:
@@ -1100,7 +1100,7 @@ block16:
     condbr v103, block21, block22
 
 block17:
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E(v94, v95, v89)
+    call noname::dlmalloc::dlmalloc::Chunk::set_free_with_pinuse(v94, v95, v89)
     br block15(v95, v96, v94)
 
 block18:
@@ -1142,7 +1142,7 @@ block20:
     v196 = add v195, 416  : u32
     v197 = inttoptr v196  : *mut i32
     store v197, v194
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v94, v194)
+    call noname::dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_free_chunk(v94, v194)
     ret 
 
 block21:
@@ -1185,7 +1185,7 @@ block22:
     condbr v110, block20, block23
 
 block23:
-    v111 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v89)  : i32
+    v111 = call noname::dlmalloc::dlmalloc::Chunk::size(v89)  : i32
     v112 = add v111, v95  : i32
     v113 = const.i32 256  : i32
     v114 = cast v111  : u32
@@ -1196,7 +1196,7 @@ block23:
     condbr v118, block25, block26
 
 block24:
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v94, v112)
+    call noname::dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_free_chunk(v94, v112)
     v154 = cast v96  : u32
     v155 = add v154, 424  : u32
     v156 = inttoptr v155  : *mut i32
@@ -1221,7 +1221,7 @@ block25:
     condbr v129, block27, block28
 
 block26:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v96, v89)
+    call noname::dlmalloc::dlmalloc::Dlmalloc<A>::unlink_large_chunk(v96, v89)
     br block24
 
 block27:
@@ -1265,19 +1265,19 @@ block30:
     br block18
 
 block31:
-    v217 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v217 = call noname::dlmalloc::dlmalloc::Chunk::mem_offset()  : i32
     v218 = const.i32 8  : i32
-    v219 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v217, v218)  : i32
+    v219 = call noname::dlmalloc::dlmalloc::align_up(v217, v218)  : i32
     v220 = const.i32 20  : i32
     v221 = const.i32 8  : i32
-    v222 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v220, v221)  : i32
+    v222 = call noname::dlmalloc::dlmalloc::align_up(v220, v221)  : i32
     v223 = const.i32 16  : i32
     v224 = const.i32 8  : i32
-    v225 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v223, v224)  : i32
+    v225 = call noname::dlmalloc::dlmalloc::align_up(v223, v224)  : i32
     v226 = const.i32 0  : i32
     v227 = const.i32 16  : i32
     v228 = const.i32 8  : i32
-    v229 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v227, v228)  : i32
+    v229 = call noname::dlmalloc::dlmalloc::align_up(v227, v228)  : i32
     v230 = const.i32 2  : i32
     v231 = shl v229, v230  : i32
     v232 = sub v226, v231  : i32
@@ -1312,15 +1312,15 @@ block32:
     condbr v257, block2, block33
 
 block33:
-    v258 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v258 = call noname::dlmalloc::dlmalloc::Chunk::mem_offset()  : i32
     v259 = const.i32 8  : i32
-    v260 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v258, v259)  : i32
+    v260 = call noname::dlmalloc::dlmalloc::align_up(v258, v259)  : i32
     v261 = const.i32 20  : i32
     v262 = const.i32 8  : i32
-    v263 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v261, v262)  : i32
+    v263 = call noname::dlmalloc::dlmalloc::align_up(v261, v262)  : i32
     v264 = const.i32 16  : i32
     v265 = const.i32 8  : i32
-    v266 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v264, v265)  : i32
+    v266 = call noname::dlmalloc::dlmalloc::align_up(v264, v265)  : i32
     v267 = const.i32 0  : i32
     v268 = cast v207  : u32
     v269 = add v268, 420  : u32
@@ -1337,7 +1337,7 @@ block33:
     condbr v279, block34(v207, v267), block35
 
 block34(v449: i32, v452: i32):
-    v450 = call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$23release_unused_segments17h25622465f0742468E(v449)  : i32
+    v450 = call noname::dlmalloc::dlmalloc::Dlmalloc<A>::release_unused_segments(v449)  : i32
     v451 = const.i32 0  : i32
     v453 = sub v451, v452  : i32
     v454 = neq v450, v453  : i1
@@ -1359,7 +1359,7 @@ block35:
 
 block36(v314: i32, v318: i32, v339: i32, v359: i32, v414: i32):
     v313 = const.i32 0  : i32
-    v315 = call noname::_ZN8dlmalloc8dlmalloc7Segment9is_extern17h6f6db2c70b891fd9E(v314)  : i32
+    v315 = call noname::dlmalloc::dlmalloc::Segment::is_extern(v314)  : i32
     v316 = neq v315, 0  : i1
     condbr v316, block34(v318, v313), block43
 
@@ -1387,7 +1387,7 @@ block39:
     condbr v310, block37(v309), block42
 
 block40:
-    v299 = call noname::_ZN8dlmalloc8dlmalloc7Segment3top17he7e9e2493151d036E(v289)  : i32
+    v299 = call noname::dlmalloc::dlmalloc::Segment::top(v289)  : i32
     v300 = cast v299  : u32
     v301 = cast v293  : u32
     v302 = gt v300, v301  : i1
@@ -1412,7 +1412,7 @@ block43:
     v327 = cast v325  : u32
     v328 = shr v326, v327  : u32
     v329 = cast v328  : i32
-    v330 = call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$16can_release_part17h43bfb7d8666fcc31E(v318, v329)  : i32
+    v330 = call noname::<dlmalloc::sys::System as dlmalloc::Allocator>::can_release_part(v318, v329)  : i32
     v331 = eq v330, 0  : i1
     v332 = cast v331  : i32
     v333 = neq v332, 0  : i1
@@ -1435,7 +1435,7 @@ block45:
     br block46(v359)
 
 block46(v348: i32):
-    v349 = call noname::_ZN8dlmalloc8dlmalloc7Segment5holds17h8f6de4ee6718009bE(v347, v348)  : i32
+    v349 = call noname::dlmalloc::dlmalloc::Segment::holds(v347, v348)  : i32
     v350 = eq v349, 0  : i1
     v351 = cast v350  : i32
     v352 = neq v351, 0  : i1
@@ -1450,7 +1450,7 @@ block47:
     v368 = inttoptr v367  : *mut i32
     v369 = load v368  : i32
     v371 = sub v369, v339  : i32
-    v372 = call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$9free_part17h74489c9e7a3aa967E(v318, v365, v369, v371)  : i32
+    v372 = call noname::<dlmalloc::sys::System as dlmalloc::Allocator>::free_part(v318, v365, v369, v371)  : i32
     v373 = const.i32 0  : i32
     v374 = eq v370, 0  : i1
     v375 = cast v374  : i32
@@ -1506,11 +1506,11 @@ block52:
     v402 = add v401, 428  : u32
     v403 = inttoptr v402  : *mut i32
     v404 = load v403  : i32
-    v405 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v404)  : i32
+    v405 = call noname::dlmalloc::dlmalloc::Chunk::to_mem(v404)  : i32
     v406 = const.i32 8  : i32
-    v407 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v405, v406)  : i32
+    v407 = call noname::dlmalloc::dlmalloc::align_up(v405, v406)  : i32
     v408 = sub v407, v405  : i32
-    v409 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v404, v408)  : i32
+    v409 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v404, v408)  : i32
     v410 = cast v362  : u32
     v411 = add v410, 428  : u32
     v412 = inttoptr v411  : *mut i32
@@ -1529,16 +1529,16 @@ block52:
     v427 = add v426, 4  : u32
     v428 = inttoptr v427  : *mut i32
     store v428, v425
-    v429 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v429 = call noname::dlmalloc::dlmalloc::Chunk::mem_offset()  : i32
     v430 = const.i32 8  : i32
-    v431 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v429, v430)  : i32
+    v431 = call noname::dlmalloc::dlmalloc::align_up(v429, v430)  : i32
     v432 = const.i32 20  : i32
     v433 = const.i32 8  : i32
-    v434 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v432, v433)  : i32
+    v434 = call noname::dlmalloc::dlmalloc::align_up(v432, v433)  : i32
     v435 = const.i32 16  : i32
     v436 = const.i32 8  : i32
-    v437 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v435, v436)  : i32
-    v438 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v409, v420)  : i32
+    v437 = call noname::dlmalloc::dlmalloc::align_up(v435, v436)  : i32
+    v438 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v409, v420)  : i32
     v439 = const.i32 2097152  : i32
     v440 = cast v362  : u32
     v441 = add v440, 440  : u32
@@ -1601,7 +1601,7 @@ block55:
     condbr v513, block59, block60
 
 block56:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E(v481, v482, v474)
+    call noname::dlmalloc::dlmalloc::Dlmalloc<A>::insert_large_chunk(v481, v482, v474)
     v483 = cast v481  : u32
     v484 = add v483, 448  : u32
     v485 = inttoptr v484  : *mut i32
@@ -1616,7 +1616,7 @@ block56:
     condbr v492, block2, block57
 
 block57:
-    v493 = call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$23release_unused_segments17h25622465f0742468E(v481)  : i32
+    v493 = call noname::dlmalloc::dlmalloc::Dlmalloc<A>::release_unused_segments(v481)  : i32
     ret 
 
 block58(v527: i32):
@@ -1654,7 +1654,7 @@ block60:
     br block58(v517)
 }
 
-pub fn _ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$6malloc17h1ae2390053e3628cE(i32, i32) -> i32 {
+pub fn dlmalloc::dlmalloc::Dlmalloc<A>::malloc(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
     v3 = const.i32 0  : i32
     v4 = const.i64 0  : i64
@@ -1713,7 +1713,7 @@ block7:
     v170 = add v1, v169  : i32
     v171 = const.i32 16  : i32
     v172 = const.i32 8  : i32
-    v173 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v171, v172)  : i32
+    v173 = call noname::dlmalloc::dlmalloc::align_up(v171, v172)  : i32
     v174 = const.i32 -5  : i32
     v175 = add v173, v174  : i32
     v176 = cast v175  : u32
@@ -1723,7 +1723,7 @@ block7:
     v180 = neq v179, 0  : i1
     v181 = select v180, v168, v170  : i32
     v182 = const.i32 8  : i32
-    v183 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v181, v182)  : i32
+    v183 = call noname::dlmalloc::dlmalloc::align_up(v181, v182)  : i32
     v184 = cast v0  : u32
     v185 = add v184, 408  : u32
     v186 = inttoptr v185  : *mut i32
@@ -1745,20 +1745,20 @@ block7:
     condbr v201, block23, block24
 
 block8:
-    v15 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v15 = call noname::dlmalloc::dlmalloc::Chunk::mem_offset()  : i32
     v16 = const.i32 8  : i32
-    v17 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v15, v16)  : i32
+    v17 = call noname::dlmalloc::dlmalloc::align_up(v15, v16)  : i32
     v18 = const.i32 20  : i32
     v19 = const.i32 8  : i32
-    v20 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v18, v19)  : i32
+    v20 = call noname::dlmalloc::dlmalloc::align_up(v18, v19)  : i32
     v21 = const.i32 16  : i32
     v22 = const.i32 8  : i32
-    v23 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v21, v22)  : i32
+    v23 = call noname::dlmalloc::dlmalloc::align_up(v21, v22)  : i32
     v24 = const.i32 0  : i32
     v25 = const.i32 0  : i32
     v26 = const.i32 16  : i32
     v27 = const.i32 8  : i32
-    v28 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v26, v27)  : i32
+    v28 = call noname::dlmalloc::dlmalloc::align_up(v26, v27)  : i32
     v29 = const.i32 2  : i32
     v30 = shl v28, v29  : i32
     v31 = sub v25, v30  : i32
@@ -1788,7 +1788,7 @@ block9:
     v52 = const.i32 4  : i32
     v53 = add v1, v52  : i32
     v54 = const.i32 8  : i32
-    v55 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v53, v54)  : i32
+    v55 = call noname::dlmalloc::dlmalloc::align_up(v53, v54)  : i32
     v56 = cast v0  : u32
     v57 = add v56, 412  : u32
     v58 = inttoptr v57  : *mut i32
@@ -1854,7 +1854,7 @@ block13:
     br block11(v96)
 
 block14:
-    v110 = call noname::_ZN8dlmalloc8dlmalloc24leftshift_for_tree_index17h31d064fdd867f502E(v101)  : i32
+    v110 = call noname::dlmalloc::dlmalloc::leftshift_for_tree_index(v101)  : i32
     v111 = shl v98, v110  : i32
     v112 = const.i32 0  : i32
     v113 = const.i32 0  : i32
@@ -1865,8 +1865,8 @@ block15:
     br block6(v63, v109, v101, v59, v100, v98, v99, v7)
 
 block16(v114: i32, v124: i32, v139: i32, v141: i32, v497: i32, v503: i32, v509: i32, v516: i32, v691: i32):
-    v115 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v114)  : i32
-    v116 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v115)  : i32
+    v115 = call noname::dlmalloc::dlmalloc::TreeChunk::chunk(v114)  : i32
+    v116 = call noname::dlmalloc::dlmalloc::Chunk::size(v115)  : i32
     v118 = cast v116  : u32
     v119 = cast v117  : u32
     v120 = lt v118, v119  : i1
@@ -1968,8 +1968,8 @@ block24:
 block25:
     v238 = const.i32 3  : i32
     v239 = shl v206, v238  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_inuse_and_pinuse17h515e5a69a6d1edc6E(v214, v239)
-    v240 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v236)  : i32
+    call noname::dlmalloc::dlmalloc::Chunk::set_inuse_and_pinuse(v214, v239)
+    v240 = call noname::dlmalloc::dlmalloc::Chunk::to_mem(v236)  : i32
     br block2(v7, v240)
 
 block26:
@@ -1998,7 +1998,7 @@ block28:
     condbr v250, block35, block36
 
 block29(v655: i32, v683: i32):
-    v489 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v291)  : i32
+    v489 = call noname::dlmalloc::dlmalloc::Chunk::to_mem(v291)  : i32
     v490 = eq v489, 0  : i1
     v491 = cast v490  : i32
     v492 = neq v491, 0  : i1
@@ -2024,7 +2024,7 @@ block31(v1479: i32):
     v469 = add v468, 416  : u32
     v470 = inttoptr v469  : *mut i32
     store v470, v358
-    v473 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v352)  : i32
+    v473 = call noname::dlmalloc::dlmalloc::Chunk::to_mem(v352)  : i32
     br block2(v1479, v473)
 
 block32:
@@ -2054,7 +2054,7 @@ block32:
 
 block33:
     v412 = add v296, v292  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_inuse_and_pinuse17h515e5a69a6d1edc6E(v291, v412)
+    call noname::dlmalloc::dlmalloc::Chunk::set_inuse_and_pinuse(v291, v412)
     br block29(v294, v7)
 
 block34:
@@ -2091,10 +2091,10 @@ block35:
     v314 = const.i32 31  : i32
     v315 = band v192, v314  : i32
     v316 = shl v313, v315  : i32
-    v317 = call noname::_ZN8dlmalloc8dlmalloc9left_bits17hb6cbe146b8019d98E(v316)  : i32
+    v317 = call noname::dlmalloc::dlmalloc::left_bits(v316)  : i32
     v318 = shl v196, v315  : i32
     v319 = band v317, v318  : i32
-    v320 = call noname::_ZN8dlmalloc8dlmalloc9least_bit17h4bca52ead665dc5aE(v319)  : i32
+    v320 = call noname::dlmalloc::dlmalloc::least_bit(v319)  : i32
     v321 = popcnt v320  : i32
     v322 = const.i32 3  : i32
     v323 = shl v321, v322  : i32
@@ -2123,7 +2123,7 @@ block36:
     condbr v257, block3(v0, v183, v7), block37
 
 block37:
-    v258 = call noname::_ZN8dlmalloc8dlmalloc9least_bit17h4bca52ead665dc5aE(v254)  : i32
+    v258 = call noname::dlmalloc::dlmalloc::least_bit(v254)  : i32
     v259 = popcnt v258  : i32
     v260 = const.i32 2  : i32
     v261 = shl v259, v260  : i32
@@ -2131,22 +2131,22 @@ block37:
     v263 = cast v262  : u32
     v264 = inttoptr v263  : *mut i32
     v265 = load v264  : i32
-    v266 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v265)  : i32
-    v267 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v266)  : i32
+    v266 = call noname::dlmalloc::dlmalloc::TreeChunk::chunk(v265)  : i32
+    v267 = call noname::dlmalloc::dlmalloc::Chunk::size(v266)  : i32
     v268 = sub v267, v183  : i32
-    v269 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk14leftmost_child17h20605933c801b44bE(v265)  : i32
+    v269 = call noname::dlmalloc::dlmalloc::TreeChunk::leftmost_child(v265)  : i32
     v270 = eq v269, 0  : i1
     v271 = cast v270  : i32
     v272 = neq v271, 0  : i1
     condbr v272, block38(v265, v183, v268), block39
 
 block38(v290: i32, v292: i32, v296: i32):
-    v291 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v290)  : i32
-    v293 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v291, v292)  : i32
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v0, v290)
+    v291 = call noname::dlmalloc::dlmalloc::TreeChunk::chunk(v290)  : i32
+    v293 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v291, v292)  : i32
+    call noname::dlmalloc::dlmalloc::Dlmalloc<A>::unlink_large_chunk(v0, v290)
     v297 = const.i32 16  : i32
     v298 = const.i32 8  : i32
-    v299 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v297, v298)  : i32
+    v299 = call noname::dlmalloc::dlmalloc::align_up(v297, v298)  : i32
     v300 = cast v296  : u32
     v301 = cast v299  : u32
     v302 = lt v300, v301  : i1
@@ -2158,8 +2158,8 @@ block39:
     br block40(v269, v268, v265)
 
 block40(v273: i32, v278: i32, v285: i32):
-    v274 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v273)  : i32
-    v275 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v274)  : i32
+    v274 = call noname::dlmalloc::dlmalloc::TreeChunk::chunk(v273)  : i32
+    v275 = call noname::dlmalloc::dlmalloc::Chunk::size(v274)  : i32
     v277 = sub v275, v276  : i32
     v279 = cast v277  : u32
     v280 = cast v278  : u32
@@ -2169,7 +2169,7 @@ block40(v273: i32, v278: i32, v285: i32):
     v284 = select v283, v277, v278  : i32
     v286 = neq v282, 0  : i1
     v287 = select v286, v273, v285  : i32
-    v288 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk14leftmost_child17h20605933c801b44bE(v273)  : i32
+    v288 = call noname::dlmalloc::dlmalloc::TreeChunk::leftmost_child(v273)  : i32
     v289 = neq v288, 0  : i1
     condbr v289, block40(v288, v284, v287), block42
 
@@ -2180,9 +2180,9 @@ block42:
     br block41
 
 block43:
-    v305 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v293)  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(v291, v292)
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v305, v296)
+    v305 = call noname::dlmalloc::dlmalloc::TreeChunk::chunk(v293)  : i32
+    call noname::dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_inuse_chunk(v291, v292)
+    call noname::dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_free_chunk(v305, v296)
     v306 = cast v294  : u32
     v307 = add v306, 416  : u32
     v308 = inttoptr v307  : *mut i32
@@ -2194,12 +2194,12 @@ block44:
     br block30
 
 block45:
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(v328, v183)
-    v354 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v352, v353)  : i32
+    call noname::dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_inuse_chunk(v328, v183)
+    v354 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v352, v353)  : i32
     v356 = const.i32 3  : i32
     v357 = shl v321, v356  : i32
     v358 = sub v357, v353  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v354, v358)
+    call noname::dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_free_chunk(v354, v358)
     v360 = cast v0  : u32
     v361 = add v360, 416  : u32
     v362 = inttoptr v361  : *mut i32
@@ -2315,7 +2315,7 @@ block56(v526: i32, v554: i32):
 block57:
     v500 = const.i32 1  : i32
     v504 = shl v500, v501  : i32
-    v505 = call noname::_ZN8dlmalloc8dlmalloc9left_bits17hb6cbe146b8019d98E(v504)  : i32
+    v505 = call noname::dlmalloc::dlmalloc::left_bits(v504)  : i32
     v510 = band v505, v506  : i32
     v511 = eq v510, 0  : i1
     v512 = cast v511  : i32
@@ -2323,7 +2323,7 @@ block57:
     condbr v513, block3(v514, v557, v688), block58
 
 block58:
-    v517 = call noname::_ZN8dlmalloc8dlmalloc9least_bit17h4bca52ead665dc5aE(v510)  : i32
+    v517 = call noname::dlmalloc::dlmalloc::least_bit(v510)  : i32
     v518 = popcnt v517  : i32
     v519 = const.i32 2  : i32
     v520 = shl v518, v519  : i32
@@ -2338,8 +2338,8 @@ block59:
     br block5(v526, v554, v557, v560, v566, v693)
 
 block60(v530: i32, v531: i32, v540: i32):
-    v532 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v530)  : i32
-    v533 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v532)  : i32
+    v532 = call noname::dlmalloc::dlmalloc::TreeChunk::chunk(v530)  : i32
+    v533 = call noname::dlmalloc::dlmalloc::Chunk::size(v532)  : i32
     v535 = cast v533  : u32
     v536 = cast v534  : u32
     v537 = gte v535, v536  : i1
@@ -2354,7 +2354,7 @@ block60(v530: i32, v531: i32, v540: i32):
     v547 = select v546, v530, v531  : i32
     v548 = neq v545, 0  : i1
     v549 = select v548, v539, v540  : i32
-    v550 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk14leftmost_child17h20605933c801b44bE(v530)  : i32
+    v550 = call noname::dlmalloc::dlmalloc::TreeChunk::leftmost_child(v530)  : i32
     v551 = neq v550, 0  : i1
     condbr v551, block60(v550, v547, v549), block62
 
@@ -2377,12 +2377,12 @@ block63:
     condbr v578, block64, block65
 
 block64:
-    v587 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v561)  : i32
-    v589 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v587, v573)  : i32
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v565, v586)
+    v587 = call noname::dlmalloc::dlmalloc::TreeChunk::chunk(v561)  : i32
+    v589 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v587, v573)  : i32
+    call noname::dlmalloc::dlmalloc::Dlmalloc<A>::unlink_large_chunk(v565, v586)
     v592 = const.i32 16  : i32
     v593 = const.i32 8  : i32
-    v594 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v592, v593)  : i32
+    v594 = call noname::dlmalloc::dlmalloc::align_up(v592, v593)  : i32
     v595 = cast v579  : u32
     v596 = cast v594  : u32
     v597 = lt v595, v596  : i1
@@ -2403,18 +2403,18 @@ block66:
     br block64
 
 block67(v696: i32):
-    v652 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v587)  : i32
+    v652 = call noname::dlmalloc::dlmalloc::Chunk::to_mem(v587)  : i32
     v653 = neq v652, 0  : i1
     condbr v653, block2(v696, v652), block75
 
 block68:
     v649 = add v591, v588  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_inuse_and_pinuse17h515e5a69a6d1edc6E(v587, v649)
+    call noname::dlmalloc::dlmalloc::Chunk::set_inuse_and_pinuse(v587, v649)
     br block67(v697)
 
 block69:
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(v587, v588)
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v589, v591)
+    call noname::dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_inuse_chunk(v587, v588)
+    call noname::dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_free_chunk(v589, v591)
     v600 = const.i32 256  : i32
     v601 = cast v591  : u32
     v602 = cast v600  : u32
@@ -2447,7 +2447,7 @@ block70:
     condbr v625, block73, block74
 
 block71:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E(v590, v589, v591)
+    call noname::dlmalloc::dlmalloc::Dlmalloc<A>::insert_large_chunk(v590, v589, v591)
     br block67(v692)
 
 block72(v639: i32):
@@ -2523,7 +2523,7 @@ block77(v1321: i32, v1326: i32):
     br block141(v1342)
 
 block78(v1263: i32, v1264: i32):
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E(v1093, v1263, v1264)
+    call noname::dlmalloc::dlmalloc::Chunk::set_free_with_pinuse(v1093, v1263, v1264)
     v1265 = const.i32 256  : i32
     v1266 = cast v1263  : u32
     v1267 = cast v1265  : u32
@@ -2547,8 +2547,8 @@ block79:
     v1258 = add v1257, 416  : u32
     v1259 = inttoptr v1258  : *mut i32
     store v1259, v1256
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_inuse_and_pinuse17h515e5a69a6d1edc6E(v1196, v1255)
-    v1260 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1196)  : i32
+    call noname::dlmalloc::dlmalloc::Chunk::set_inuse_and_pinuse(v1196, v1255)
+    v1260 = call noname::dlmalloc::dlmalloc::Chunk::to_mem(v1196)  : i32
     br block2(v682, v1260)
 
 block80:
@@ -2565,8 +2565,8 @@ block80:
     v1245 = add v1244, 416  : u32
     v1246 = inttoptr v1245  : *mut i32
     store v1246, v1243
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v1093, v1243)
-    v1247 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1089)  : i32
+    call noname::dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_free_chunk(v1093, v1243)
+    v1247 = call noname::dlmalloc::dlmalloc::Chunk::to_mem(v1089)  : i32
     br block2(v1482, v1247)
 
 block81:
@@ -2588,7 +2588,7 @@ block81:
     v1233 = inttoptr v1232  : *mut i32
     v1234 = load v1233  : i32
     v1235 = add v1234, v815  : i32
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$8init_top17he4cefe3b36a3bd87E(v792, v1230, v1235)
+    call noname::dlmalloc::dlmalloc::Dlmalloc<A>::init_top(v792, v1230, v1235)
     br block76(v792, v1092, v1484, v1509)
 
 block82:
@@ -2606,7 +2606,7 @@ block83:
     v1197 = sub v661, v662  : i32
     v1198 = const.i32 16  : i32
     v1199 = const.i32 8  : i32
-    v1200 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1198, v1199)  : i32
+    v1200 = call noname::dlmalloc::dlmalloc::align_up(v1198, v1199)  : i32
     v1201 = cast v1197  : u32
     v1202 = cast v1200  : u32
     v1203 = lt v1201, v1202  : i1
@@ -2636,7 +2636,7 @@ block85:
     v1180 = add v1179, 428  : u32
     v1181 = inttoptr v1180  : *mut i32
     v1182 = load v1181  : i32
-    v1183 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1182, v662)  : i32
+    v1183 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v1182, v662)  : i32
     v1184 = cast v654  : u32
     v1185 = add v1184, 428  : u32
     v1186 = inttoptr v1185  : *mut i32
@@ -2647,31 +2647,31 @@ block85:
     v1190 = add v1189, 4  : u32
     v1191 = inttoptr v1190  : *mut i32
     store v1191, v1188
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(v1182, v662)
-    v1192 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1182)  : i32
+    call noname::dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_inuse_chunk(v1182, v662)
+    v1192 = call noname::dlmalloc::dlmalloc::Chunk::to_mem(v1182)  : i32
     br block2(v682, v1192)
 
 block86:
     v699 = const.i32 4  : i32
     v700 = add v682, v699  : i32
-    v701 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v701 = call noname::dlmalloc::dlmalloc::Chunk::mem_offset()  : i32
     v702 = sub v662, v701  : i32
     v703 = const.i32 8  : i32
-    v704 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v701, v703)  : i32
+    v704 = call noname::dlmalloc::dlmalloc::align_up(v701, v703)  : i32
     v705 = add v702, v704  : i32
     v706 = const.i32 20  : i32
     v707 = const.i32 8  : i32
-    v708 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v706, v707)  : i32
+    v708 = call noname::dlmalloc::dlmalloc::align_up(v706, v707)  : i32
     v709 = add v705, v708  : i32
     v710 = const.i32 16  : i32
     v711 = const.i32 8  : i32
-    v712 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v710, v711)  : i32
+    v712 = call noname::dlmalloc::dlmalloc::align_up(v710, v711)  : i32
     v713 = add v709, v712  : i32
     v714 = const.i32 8  : i32
     v715 = add v713, v714  : i32
     v716 = const.i32 65536  : i32
-    v717 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v715, v716)  : i32
-    call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$5alloc17hdbf1e2bcc01bc909E(v700, v654, v717)
+    v717 = call noname::dlmalloc::dlmalloc::align_up(v715, v716)  : i32
+    call noname::<dlmalloc::sys::System as dlmalloc::Allocator>::alloc(v700, v654, v717)
     v718 = const.i32 0  : i32
     v719 = cast v682  : u32
     v720 = add v719, 4  : u32
@@ -2766,12 +2766,12 @@ block92(v814: i32, v817: i32, v1091: i32, v1483: i32, v1508: i32):
     br block104(v817)
 
 block93:
-    v785 = call noname::_ZN8dlmalloc8dlmalloc7Segment9is_extern17h6f6db2c70b891fd9E(v775)  : i32
+    v785 = call noname::dlmalloc::dlmalloc::Segment::is_extern(v775)  : i32
     v786 = neq v785, 0  : i1
     condbr v786, block92(v815, v818, v1092, v1484, v1509), block98
 
 block94(v775: i32):
-    v776 = call noname::_ZN8dlmalloc8dlmalloc7Segment3top17he7e9e2493151d036E(v775)  : i32
+    v776 = call noname::dlmalloc::dlmalloc::Segment::top(v775)  : i32
     v777 = eq v774, v776  : i1
     v778 = cast v777  : i32
     v779 = neq v778, 0  : i1
@@ -2791,7 +2791,7 @@ block97:
     br block92(v737, v773, v662, v682, v718)
 
 block98:
-    v787 = call noname::_ZN8dlmalloc8dlmalloc7Segment9sys_flags17h224550055bf7775bE(v775)  : i32
+    v787 = call noname::dlmalloc::dlmalloc::Segment::sys_flags(v775)  : i32
     v789 = neq v787, v729  : i1
     v790 = cast v789  : i32
     v791 = neq v790, 0  : i1
@@ -2802,7 +2802,7 @@ block99:
     v794 = add v793, 428  : u32
     v795 = inttoptr v794  : *mut i32
     v796 = load v795  : i32
-    v797 = call noname::_ZN8dlmalloc8dlmalloc7Segment5holds17h8f6de4ee6718009bE(v775, v796)  : i32
+    v797 = call noname::dlmalloc::dlmalloc::Segment::holds(v775, v796)  : i32
     v798 = neq v797, 0  : i1
     condbr v798, block81, block100
 
@@ -2825,16 +2825,16 @@ block101:
     v1080 = add v1079, 4  : u32
     v1081 = inttoptr v1080  : *mut i32
     store v1081, v1078
-    v1082 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v913)  : i32
+    v1082 = call noname::dlmalloc::dlmalloc::Chunk::to_mem(v913)  : i32
     v1083 = const.i32 8  : i32
-    v1084 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1082, v1083)  : i32
-    v1085 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1071)  : i32
+    v1084 = call noname::dlmalloc::dlmalloc::align_up(v1082, v1083)  : i32
+    v1085 = call noname::dlmalloc::dlmalloc::Chunk::to_mem(v1071)  : i32
     v1086 = const.i32 8  : i32
-    v1087 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1085, v1086)  : i32
+    v1087 = call noname::dlmalloc::dlmalloc::align_up(v1085, v1086)  : i32
     v1088 = sub v1084, v1082  : i32
     v1089 = add v913, v1088  : i32
-    v1093 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1089, v1091)  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(v1089, v1090)
+    v1093 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v1089, v1091)  : i32
+    call noname::dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_inuse_chunk(v1089, v1090)
     v1094 = sub v1087, v1085  : i32
     v1095 = add v1071, v1094  : i32
     v1096 = add v1090, v1089  : i32
@@ -2856,7 +2856,7 @@ block102(v840: i32, v846: i32, v912: i32, v925: i32, v1506: i32):
     br block111(v846)
 
 block103:
-    v832 = call noname::_ZN8dlmalloc8dlmalloc7Segment9is_extern17h6f6db2c70b891fd9E(v819)  : i32
+    v832 = call noname::dlmalloc::dlmalloc::Segment::is_extern(v819)  : i32
     v833 = neq v832, 0  : i1
     condbr v833, block102(v841, v847, v913, v926, v1507), block108
 
@@ -2883,7 +2883,7 @@ block107:
     br block102(v799, v817, v804, v814, v1508)
 
 block108:
-    v834 = call noname::_ZN8dlmalloc8dlmalloc7Segment9sys_flags17h224550055bf7775bE(v819)  : i32
+    v834 = call noname::dlmalloc::dlmalloc::Segment::sys_flags(v819)  : i32
     v837 = eq v834, v788  : i1
     v838 = cast v837  : i32
     v839 = neq v838, 0  : i1
@@ -2893,21 +2893,21 @@ block109:
     br block102(v841, v847, v913, v926, v1507)
 
 block110(v872: i32, v880: i32, v907: i32, v910: i32, v923: i32, v961: i32, v980: i32, v1446: i32, v1490: i32, v1504: i32):
-    v873 = call noname::_ZN8dlmalloc8dlmalloc7Segment3top17he7e9e2493151d036E(v872)  : i32
+    v873 = call noname::dlmalloc::dlmalloc::Segment::top(v872)  : i32
     v874 = const.i32 20  : i32
     v875 = const.i32 8  : i32
-    v876 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v874, v875)  : i32
+    v876 = call noname::dlmalloc::dlmalloc::align_up(v874, v875)  : i32
     v877 = sub v873, v876  : i32
     v878 = const.i32 -23  : i32
     v879 = add v877, v878  : i32
-    v881 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v879)  : i32
+    v881 = call noname::dlmalloc::dlmalloc::Chunk::to_mem(v879)  : i32
     v882 = const.i32 8  : i32
-    v883 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v881, v882)  : i32
+    v883 = call noname::dlmalloc::dlmalloc::align_up(v881, v882)  : i32
     v884 = sub v883, v881  : i32
     v885 = add v879, v884  : i32
     v886 = const.i32 16  : i32
     v887 = const.i32 8  : i32
-    v888 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v886, v887)  : i32
+    v888 = call noname::dlmalloc::dlmalloc::align_up(v886, v887)  : i32
     v889 = add v880, v888  : i32
     v890 = cast v885  : u32
     v891 = cast v889  : u32
@@ -2915,22 +2915,22 @@ block110(v872: i32, v880: i32, v907: i32, v910: i32, v923: i32, v961: i32, v980:
     v893 = cast v892  : i32
     v894 = neq v893, 0  : i1
     v895 = select v894, v880, v885  : i32
-    v896 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v895)  : i32
-    v897 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v895, v876)  : i32
-    v898 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v896 = call noname::dlmalloc::dlmalloc::Chunk::to_mem(v895)  : i32
+    v897 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v895, v876)  : i32
+    v898 = call noname::dlmalloc::dlmalloc::Chunk::mem_offset()  : i32
     v899 = const.i32 8  : i32
-    v900 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v898, v899)  : i32
+    v900 = call noname::dlmalloc::dlmalloc::align_up(v898, v899)  : i32
     v901 = const.i32 20  : i32
     v902 = const.i32 8  : i32
-    v903 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v901, v902)  : i32
+    v903 = call noname::dlmalloc::dlmalloc::align_up(v901, v902)  : i32
     v904 = const.i32 16  : i32
     v905 = const.i32 8  : i32
-    v906 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v904, v905)  : i32
-    v915 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v910)  : i32
+    v906 = call noname::dlmalloc::dlmalloc::align_up(v904, v905)  : i32
+    v915 = call noname::dlmalloc::dlmalloc::Chunk::to_mem(v910)  : i32
     v916 = const.i32 8  : i32
-    v917 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v915, v916)  : i32
+    v917 = call noname::dlmalloc::dlmalloc::align_up(v915, v916)  : i32
     v918 = sub v917, v915  : i32
-    v919 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v910, v918)  : i32
+    v919 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v910, v918)  : i32
     v920 = cast v907  : u32
     v921 = add v920, 428  : u32
     v922 = inttoptr v921  : *mut i32
@@ -2950,16 +2950,16 @@ block110(v872: i32, v880: i32, v907: i32, v910: i32, v923: i32, v961: i32, v980:
     v939 = add v938, 4  : u32
     v940 = inttoptr v939  : *mut i32
     store v940, v937
-    v941 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v941 = call noname::dlmalloc::dlmalloc::Chunk::mem_offset()  : i32
     v942 = const.i32 8  : i32
-    v943 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v941, v942)  : i32
+    v943 = call noname::dlmalloc::dlmalloc::align_up(v941, v942)  : i32
     v944 = const.i32 20  : i32
     v945 = const.i32 8  : i32
-    v946 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v944, v945)  : i32
+    v946 = call noname::dlmalloc::dlmalloc::align_up(v944, v945)  : i32
     v947 = const.i32 16  : i32
     v948 = const.i32 8  : i32
-    v949 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v947, v948)  : i32
-    v950 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v919, v932)  : i32
+    v949 = call noname::dlmalloc::dlmalloc::align_up(v947, v948)  : i32
+    v950 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v919, v932)  : i32
     v951 = const.i32 2097152  : i32
     v952 = cast v907  : u32
     v953 = add v952, 440  : u32
@@ -2972,7 +2972,7 @@ block110(v872: i32, v880: i32, v907: i32, v910: i32, v923: i32, v961: i32, v980:
     v959 = add v958, 4  : u32
     v960 = inttoptr v959  : *mut i32
     store v960, v957
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(v895, v876)
+    call noname::dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_inuse_chunk(v895, v876)
     v964 = cast v961  : u32
     v965 = inttoptr v964  : *mut i64
     v966 = load v965  : i64
@@ -3034,7 +3034,7 @@ block113:
     condbr v869, block111(v868), block116
 
 block114:
-    v858 = call noname::_ZN8dlmalloc8dlmalloc7Segment3top17he7e9e2493151d036E(v848)  : i32
+    v858 = call noname::dlmalloc::dlmalloc::Segment::top(v848)  : i32
     v859 = cast v858  : u32
     v860 = cast v852  : u32
     v861 = gt v859, v860  : i1
@@ -3050,8 +3050,8 @@ block116:
 
 block117(v997: i32):
     v998 = const.i32 4  : i32
-    v999 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v997, v998)  : i32
-    v1000 = call noname::_ZN8dlmalloc8dlmalloc5Chunk14fencepost_head17he07aaa52f3b50dfdE()  : i32
+    v999 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v997, v998)  : i32
+    v1000 = call noname::dlmalloc::dlmalloc::Chunk::fencepost_head()  : i32
     v1001 = cast v997  : u32
     v1002 = add v1001, 4  : u32
     v1003 = inttoptr v1002  : *mut i32
@@ -3076,8 +3076,8 @@ block119:
 
 block120:
     v1017 = sub v1012, v1013  : i32
-    v1018 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1013, v1017)  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E(v1013, v1017, v1018)
+    v1018 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v1013, v1017)  : i32
+    call noname::dlmalloc::dlmalloc::Chunk::set_free_with_pinuse(v1013, v1017, v1018)
     v1019 = const.i32 256  : i32
     v1020 = cast v1017  : u32
     v1021 = cast v1019  : u32
@@ -3110,7 +3110,7 @@ block121:
     condbr v1045, block124, block125
 
 block122:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E(v907, v1013, v1017)
+    call noname::dlmalloc::dlmalloc::Dlmalloc<A>::insert_large_chunk(v907, v1013, v1017)
     br block76(v1025, v1445, v1489, v1503)
 
 block123(v1059: i32):
@@ -3167,7 +3167,7 @@ block126:
     v1172 = add v1171, 4  : u32
     v1173 = inttoptr v1172  : *mut i32
     store v1173, v1170
-    v1174 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1089)  : i32
+    v1174 = call noname::dlmalloc::dlmalloc::Chunk::to_mem(v1089)  : i32
     br block2(v1483, v1174)
 
 block127:
@@ -3181,12 +3181,12 @@ block127:
     condbr v1111, block80, block128
 
 block128:
-    v1112 = call noname::_ZN8dlmalloc8dlmalloc5Chunk5inuse17h2d327e4c36b84dfeE(v1095)  : i32
+    v1112 = call noname::dlmalloc::dlmalloc::Chunk::inuse(v1095)  : i32
     v1113 = neq v1112, 0  : i1
     condbr v1113, block78(v1097, v1095), block129
 
 block129:
-    v1114 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v1095)  : i32
+    v1114 = call noname::dlmalloc::dlmalloc::Chunk::size(v1095)  : i32
     v1115 = const.i32 256  : i32
     v1116 = cast v1114  : u32
     v1117 = cast v1115  : u32
@@ -3197,7 +3197,7 @@ block129:
 
 block130:
     v1155 = add v1114, v1097  : i32
-    v1157 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1095, v1153)  : i32
+    v1157 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v1095, v1153)  : i32
     br block78(v1155, v1157)
 
 block131:
@@ -3215,7 +3215,7 @@ block131:
     condbr v1131, block133, block134
 
 block132:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v841, v1095)
+    call noname::dlmalloc::dlmalloc::Dlmalloc<A>::unlink_large_chunk(v841, v1095)
     br block130
 
 block133:
@@ -3249,7 +3249,7 @@ block134:
     br block130
 
 block135:
-    v1206 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1196, v662)  : i32
+    v1206 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v1196, v662)  : i32
     v1207 = cast v654  : u32
     v1208 = add v1207, 416  : u32
     v1209 = inttoptr v1208  : *mut i32
@@ -3258,9 +3258,9 @@ block135:
     v1211 = add v1210, 424  : u32
     v1212 = inttoptr v1211  : *mut i32
     store v1212, v1206
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v1206, v1197)
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(v1196, v662)
-    v1213 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1196)  : i32
+    call noname::dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_free_chunk(v1206, v1197)
+    call noname::dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_inuse_chunk(v1196, v662)
+    v1213 = call noname::dlmalloc::dlmalloc::Chunk::to_mem(v1196)  : i32
     br block2(v682, v1213)
 
 block136:
@@ -3287,8 +3287,8 @@ block136:
     condbr v1295, block139, block140
 
 block137:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E(v841, v1261, v1263)
-    v1275 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1089)  : i32
+    call noname::dlmalloc::dlmalloc::Dlmalloc<A>::insert_large_chunk(v841, v1261, v1263)
+    v1275 = call noname::dlmalloc::dlmalloc::Chunk::to_mem(v1089)  : i32
     br block2(v1482, v1275)
 
 block138(v1309: i32):
@@ -3308,7 +3308,7 @@ block138(v1309: i32):
     v1317 = add v1316, 8  : u32
     v1318 = inttoptr v1317  : *mut i32
     store v1318, v1309
-    v1320 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1273)  : i32
+    v1320 = call noname::dlmalloc::dlmalloc::Chunk::to_mem(v1273)  : i32
     br block2(v1485, v1320)
 
 block139:
@@ -3379,20 +3379,20 @@ block141(v1344: i32):
     condbr v1385, block141(v1381), block143
 
 block142:
-    v1386 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v1386 = call noname::dlmalloc::dlmalloc::Chunk::mem_offset()  : i32
     v1387 = const.i32 8  : i32
-    v1388 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1386, v1387)  : i32
+    v1388 = call noname::dlmalloc::dlmalloc::align_up(v1386, v1387)  : i32
     v1389 = const.i32 20  : i32
     v1390 = const.i32 8  : i32
-    v1391 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1389, v1390)  : i32
+    v1391 = call noname::dlmalloc::dlmalloc::align_up(v1389, v1390)  : i32
     v1392 = const.i32 16  : i32
     v1393 = const.i32 8  : i32
-    v1394 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1392, v1393)  : i32
-    v1396 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1395)  : i32
+    v1394 = call noname::dlmalloc::dlmalloc::align_up(v1392, v1393)  : i32
+    v1396 = call noname::dlmalloc::dlmalloc::Chunk::to_mem(v1395)  : i32
     v1397 = const.i32 8  : i32
-    v1398 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1396, v1397)  : i32
+    v1398 = call noname::dlmalloc::dlmalloc::align_up(v1396, v1397)  : i32
     v1399 = sub v1398, v1396  : i32
-    v1400 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1326, v1399)  : i32
+    v1400 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v1326, v1399)  : i32
     v1401 = cast v1343  : u32
     v1402 = add v1401, 428  : u32
     v1403 = inttoptr v1402  : *mut i32
@@ -3412,16 +3412,16 @@ block142:
     v1416 = add v1415, 4  : u32
     v1417 = inttoptr v1416  : *mut i32
     store v1417, v1414
-    v1418 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v1418 = call noname::dlmalloc::dlmalloc::Chunk::mem_offset()  : i32
     v1419 = const.i32 8  : i32
-    v1420 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1418, v1419)  : i32
+    v1420 = call noname::dlmalloc::dlmalloc::align_up(v1418, v1419)  : i32
     v1421 = const.i32 20  : i32
     v1422 = const.i32 8  : i32
-    v1423 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1421, v1422)  : i32
+    v1423 = call noname::dlmalloc::dlmalloc::align_up(v1421, v1422)  : i32
     v1424 = const.i32 16  : i32
     v1425 = const.i32 8  : i32
-    v1426 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1424, v1425)  : i32
-    v1427 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1400, v1409)  : i32
+    v1426 = call noname::dlmalloc::dlmalloc::align_up(v1424, v1425)  : i32
+    v1427 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v1400, v1409)  : i32
     v1428 = const.i32 2097152  : i32
     v1429 = cast v1343  : u32
     v1430 = add v1429, 440  : u32
@@ -3449,7 +3449,7 @@ block144:
     v1464 = add v1463, 428  : u32
     v1465 = inttoptr v1464  : *mut i32
     v1466 = load v1465  : i32
-    v1467 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1466, v1444)  : i32
+    v1467 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v1466, v1444)  : i32
     v1468 = cast v1438  : u32
     v1469 = add v1468, 428  : u32
     v1470 = inttoptr v1469  : *mut i32
@@ -3460,19 +3460,19 @@ block144:
     v1474 = add v1473, 4  : u32
     v1475 = inttoptr v1474  : *mut i32
     store v1475, v1472
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(v1466, v1444)
-    v1476 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1466)  : i32
+    call noname::dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_inuse_chunk(v1466, v1444)
+    v1476 = call noname::dlmalloc::dlmalloc::Chunk::to_mem(v1466)  : i32
     br block2(v1488, v1476)
 }
 
-pub fn _ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$8init_top17he4cefe3b36a3bd87E(i32, i32, i32) {
+pub fn dlmalloc::dlmalloc::Dlmalloc<A>::init_top(i32, i32, i32) {
 block0(v0: i32, v1: i32, v2: i32):
     v3 = const.i32 0  : i32
-    v4 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1)  : i32
+    v4 = call noname::dlmalloc::dlmalloc::Chunk::to_mem(v1)  : i32
     v5 = const.i32 8  : i32
-    v6 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v4, v5)  : i32
+    v6 = call noname::dlmalloc::dlmalloc::align_up(v4, v5)  : i32
     v7 = sub v6, v4  : i32
-    v8 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1, v7)  : i32
+    v8 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v1, v7)  : i32
     v9 = sub v2, v7  : i32
     v10 = cast v0  : u32
     v11 = add v10, 420  : u32
@@ -3488,16 +3488,16 @@ block0(v0: i32, v1: i32, v2: i32):
     v19 = add v18, 4  : u32
     v20 = inttoptr v19  : *mut i32
     store v20, v17
-    v21 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v21 = call noname::dlmalloc::dlmalloc::Chunk::mem_offset()  : i32
     v22 = const.i32 8  : i32
-    v23 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v21, v22)  : i32
+    v23 = call noname::dlmalloc::dlmalloc::align_up(v21, v22)  : i32
     v24 = const.i32 20  : i32
     v25 = const.i32 8  : i32
-    v26 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v24, v25)  : i32
+    v26 = call noname::dlmalloc::dlmalloc::align_up(v24, v25)  : i32
     v27 = const.i32 16  : i32
     v28 = const.i32 8  : i32
-    v29 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v27, v28)  : i32
-    v30 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v8, v9)  : i32
+    v29 = call noname::dlmalloc::dlmalloc::align_up(v27, v28)  : i32
+    v30 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v8, v9)  : i32
     v31 = const.i32 2097152  : i32
     v32 = cast v0  : u32
     v33 = add v32, 440  : u32
@@ -3516,12 +3516,12 @@ block1:
     ret 
 }
 
-pub fn _ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$8memalign17he8794c5d1cb954f9E(i32, i32, i32) -> i32 {
+pub fn dlmalloc::dlmalloc::Dlmalloc<A>::memalign(i32, i32, i32) -> i32 {
 block0(v0: i32, v1: i32, v2: i32):
     v4 = const.i32 0  : i32
     v5 = const.i32 16  : i32
     v6 = const.i32 8  : i32
-    v7 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v5, v6)  : i32
+    v7 = call noname::dlmalloc::dlmalloc::align_up(v5, v6)  : i32
     v8 = cast v7  : u32
     v9 = cast v1  : u32
     v10 = lte v8, v9  : i1
@@ -3533,20 +3533,20 @@ block1(v3: i32):
     ret v3
 
 block2(v48: i32):
-    v16 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v16 = call noname::dlmalloc::dlmalloc::Chunk::mem_offset()  : i32
     v17 = const.i32 8  : i32
-    v18 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v16, v17)  : i32
+    v18 = call noname::dlmalloc::dlmalloc::align_up(v16, v17)  : i32
     v19 = const.i32 20  : i32
     v20 = const.i32 8  : i32
-    v21 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v19, v20)  : i32
+    v21 = call noname::dlmalloc::dlmalloc::align_up(v19, v20)  : i32
     v22 = const.i32 16  : i32
     v23 = const.i32 8  : i32
-    v24 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v22, v23)  : i32
+    v24 = call noname::dlmalloc::dlmalloc::align_up(v22, v23)  : i32
     v25 = const.i32 0  : i32
     v26 = const.i32 0  : i32
     v27 = const.i32 16  : i32
     v28 = const.i32 8  : i32
-    v29 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v27, v28)  : i32
+    v29 = call noname::dlmalloc::dlmalloc::align_up(v27, v28)  : i32
     v30 = const.i32 2  : i32
     v31 = shl v29, v30  : i32
     v32 = sub v26, v31  : i32
@@ -3576,7 +3576,7 @@ block2(v48: i32):
 block3:
     v13 = const.i32 16  : i32
     v14 = const.i32 8  : i32
-    v15 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v13, v14)  : i32
+    v15 = call noname::dlmalloc::dlmalloc::align_up(v13, v14)  : i32
     br block2(v15)
 
 block4(v140: i32):
@@ -3588,7 +3588,7 @@ block5:
     v59 = add v50, v58  : i32
     v60 = const.i32 16  : i32
     v61 = const.i32 8  : i32
-    v62 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v60, v61)  : i32
+    v62 = call noname::dlmalloc::dlmalloc::align_up(v60, v61)  : i32
     v63 = const.i32 -5  : i32
     v64 = add v62, v63  : i32
     v65 = cast v64  : u32
@@ -3598,22 +3598,22 @@ block5:
     v69 = neq v68, 0  : i1
     v70 = select v69, v57, v59  : i32
     v71 = const.i32 8  : i32
-    v72 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v70, v71)  : i32
+    v72 = call noname::dlmalloc::dlmalloc::align_up(v70, v71)  : i32
     v73 = add v48, v72  : i32
     v74 = const.i32 16  : i32
     v75 = const.i32 8  : i32
-    v76 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v74, v75)  : i32
+    v76 = call noname::dlmalloc::dlmalloc::align_up(v74, v75)  : i32
     v77 = add v73, v76  : i32
     v78 = const.i32 -4  : i32
     v79 = add v77, v78  : i32
-    v80 = call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$6malloc17h1ae2390053e3628cE(v0, v79)  : i32
+    v80 = call noname::dlmalloc::dlmalloc::Dlmalloc<A>::malloc(v0, v79)  : i32
     v81 = eq v80, 0  : i1
     v82 = cast v81  : i32
     v83 = neq v82, 0  : i1
     condbr v83, block4(v25), block6
 
 block6:
-    v84 = call noname::_ZN8dlmalloc8dlmalloc5Chunk8from_mem17h11dd30c74f483706E(v80)  : i32
+    v84 = call noname::dlmalloc::dlmalloc::Chunk::from_mem(v80)  : i32
     v85 = const.i32 -1  : i32
     v86 = add v48, v85  : i32
     v87 = band v86, v80  : i32
@@ -3621,7 +3621,7 @@ block6:
     condbr v88, block8, block9
 
 block7(v120: i32):
-    v121 = call noname::_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(v120)  : i32
+    v121 = call noname::dlmalloc::dlmalloc::Chunk::mmapped(v120)  : i32
     v122 = neq v121, 0  : i1
     condbr v122, block12, block13
 
@@ -3630,11 +3630,11 @@ block8:
     v90 = const.i32 0  : i32
     v91 = sub v90, v48  : i32
     v92 = band v89, v91  : i32
-    v93 = call noname::_ZN8dlmalloc8dlmalloc5Chunk8from_mem17h11dd30c74f483706E(v92)  : i32
+    v93 = call noname::dlmalloc::dlmalloc::Chunk::from_mem(v92)  : i32
     v94 = const.i32 16  : i32
     v95 = const.i32 8  : i32
-    v96 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v94, v95)  : i32
-    v97 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v84)  : i32
+    v96 = call noname::dlmalloc::dlmalloc::align_up(v94, v95)  : i32
+    v97 = call noname::dlmalloc::dlmalloc::Chunk::size(v84)  : i32
     v98 = const.i32 0  : i32
     v99 = sub v93, v84  : i32
     v100 = cast v99  : u32
@@ -3646,7 +3646,7 @@ block8:
     v106 = add v93, v105  : i32
     v107 = sub v106, v84  : i32
     v108 = sub v97, v107  : i32
-    v109 = call noname::_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(v84)  : i32
+    v109 = call noname::dlmalloc::dlmalloc::Chunk::mmapped(v84)  : i32
     v110 = neq v109, 0  : i1
     condbr v110, block10, block11
 
@@ -3668,21 +3668,21 @@ block10:
     br block7(v106)
 
 block11:
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v106, v108)
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v84, v107)
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$13dispose_chunk17h577eb103dc04307bE(v56, v84, v107)
+    call noname::dlmalloc::dlmalloc::Chunk::set_inuse(v106, v108)
+    call noname::dlmalloc::dlmalloc::Chunk::set_inuse(v84, v107)
+    call noname::dlmalloc::dlmalloc::Dlmalloc<A>::dispose_chunk(v56, v84, v107)
     br block7(v106)
 
 block12:
-    v138 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v120)  : i32
-    v139 = call noname::_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(v137)  : i32
+    v138 = call noname::dlmalloc::dlmalloc::Chunk::to_mem(v120)  : i32
+    v139 = call noname::dlmalloc::dlmalloc::Chunk::mmapped(v137)  : i32
     br block4(v138)
 
 block13:
-    v123 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v120)  : i32
+    v123 = call noname::dlmalloc::dlmalloc::Chunk::size(v120)  : i32
     v124 = const.i32 16  : i32
     v125 = const.i32 8  : i32
-    v126 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v124, v125)  : i32
+    v126 = call noname::dlmalloc::dlmalloc::align_up(v124, v125)  : i32
     v128 = add v126, v72  : i32
     v129 = cast v123  : u32
     v130 = cast v128  : u32
@@ -3692,11 +3692,11 @@ block13:
     condbr v133, block12, block14
 
 block14:
-    v134 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v120, v127)  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v120, v127)
+    v134 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v120, v127)  : i32
+    call noname::dlmalloc::dlmalloc::Chunk::set_inuse(v120, v127)
     v135 = sub v123, v127  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v134, v135)
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$13dispose_chunk17h577eb103dc04307bE(v56, v134, v135)
+    call noname::dlmalloc::dlmalloc::Chunk::set_inuse(v134, v135)
+    call noname::dlmalloc::dlmalloc::Dlmalloc<A>::dispose_chunk(v56, v134, v135)
     br block12
 }
 
@@ -3717,10 +3717,10 @@ block0(v0: i32, v1: i32):
     v6 = sub v4, v5  : i32
     v7 = global.symbol @__stack_pointer  : *mut i32
     store v7, v6
-    call noname::_ZN8dlmalloc3sys23enable_alloc_after_fork17h64eb1fc0ff7b2689E()
+    call noname::dlmalloc::sys::enable_alloc_after_fork()
     v8 = const.i32 15  : i32
     v9 = add v6, v8  : i32
-    v10 = call noname::_ZN73_$LT$dlmalloc..global..Instance$u20$as$u20$core..ops..deref..DerefMut$GT$9deref_mut17h16955ef502c5c4e5E(v9)  : i32
+    v10 = call noname::<dlmalloc::global::Instance as core::ops::deref::DerefMut>::deref_mut(v9)  : i32
     v11 = const.i32 9  : i32
     v12 = cast v1  : u32
     v13 = cast v11  : u32
@@ -3735,7 +3735,7 @@ block1(v2: i32):
 block2(v25: i32):
     v20 = const.i32 15  : i32
     v21 = add v6, v20  : i32
-    call noname::_ZN68_$LT$dlmalloc..global..Instance$u20$as$u20$core..ops..drop..Drop$GT$4drop17he19d8d9c8ea92454E(v21)
+    call noname::<dlmalloc::global::Instance as core::ops::drop::Drop>::drop(v21)
     v22 = const.i32 16  : i32
     v23 = add v19, v22  : i32
     v24 = global.symbol @__stack_pointer  : *mut i32
@@ -3743,11 +3743,11 @@ block2(v25: i32):
     br block1(v25)
 
 block3:
-    v18 = call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$6malloc17h1ae2390053e3628cE(v10, v0)  : i32
+    v18 = call noname::dlmalloc::dlmalloc::Dlmalloc<A>::malloc(v10, v0)  : i32
     br block2(v18)
 
 block4:
-    v17 = call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$8memalign17he8794c5d1cb954f9E(v10, v1, v0)  : i32
+    v17 = call noname::dlmalloc::dlmalloc::Dlmalloc<A>::memalign(v10, v1, v0)  : i32
     br block2(v17)
 }
 
@@ -3759,14 +3759,14 @@ block0(v0: i32, v1: i32, v2: i32):
     v6 = sub v4, v5  : i32
     v7 = global.symbol @__stack_pointer  : *mut i32
     store v7, v6
-    call noname::_ZN8dlmalloc3sys23enable_alloc_after_fork17h64eb1fc0ff7b2689E()
+    call noname::dlmalloc::sys::enable_alloc_after_fork()
     v8 = const.i32 15  : i32
     v9 = add v6, v8  : i32
-    v10 = call noname::_ZN73_$LT$dlmalloc..global..Instance$u20$as$u20$core..ops..deref..DerefMut$GT$9deref_mut17h16955ef502c5c4e5E(v9)  : i32
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$4free17h501de2a6604ba1ffE(v10, v0)
+    v10 = call noname::<dlmalloc::global::Instance as core::ops::deref::DerefMut>::deref_mut(v9)  : i32
+    call noname::dlmalloc::dlmalloc::Dlmalloc<A>::free(v10, v0)
     v11 = const.i32 15  : i32
     v12 = add v6, v11  : i32
-    call noname::_ZN68_$LT$dlmalloc..global..Instance$u20$as$u20$core..ops..drop..Drop$GT$4drop17he19d8d9c8ea92454E(v12)
+    call noname::<dlmalloc::global::Instance as core::ops::drop::Drop>::drop(v12)
     v13 = const.i32 16  : i32
     v14 = add v6, v13  : i32
     v15 = global.symbol @__stack_pointer  : *mut i32
@@ -3785,10 +3785,10 @@ block0(v0: i32, v1: i32, v2: i32, v3: i32):
     v8 = sub v6, v7  : i32
     v9 = global.symbol @__stack_pointer  : *mut i32
     store v9, v8
-    call noname::_ZN8dlmalloc3sys23enable_alloc_after_fork17h64eb1fc0ff7b2689E()
+    call noname::dlmalloc::sys::enable_alloc_after_fork()
     v10 = const.i32 15  : i32
     v11 = add v8, v10  : i32
-    v12 = call noname::_ZN73_$LT$dlmalloc..global..Instance$u20$as$u20$core..ops..deref..DerefMut$GT$9deref_mut17h16955ef502c5c4e5E(v11)  : i32
+    v12 = call noname::<dlmalloc::global::Instance as core::ops::deref::DerefMut>::deref_mut(v11)  : i32
     v13 = const.i32 9  : i32
     v14 = cast v2  : u32
     v15 = cast v13  : u32
@@ -3803,7 +3803,7 @@ block1(v4: i32):
 block2(v369: i32, v381: i32):
     v376 = const.i32 15  : i32
     v377 = add v369, v376  : i32
-    call noname::_ZN68_$LT$dlmalloc..global..Instance$u20$as$u20$core..ops..drop..Drop$GT$4drop17he19d8d9c8ea92454E(v377)
+    call noname::<dlmalloc::global::Instance as core::ops::drop::Drop>::drop(v377)
     v378 = const.i32 16  : i32
     v379 = add v369, v378  : i32
     v380 = global.symbol @__stack_pointer  : *mut i32
@@ -3811,20 +3811,20 @@ block2(v369: i32, v381: i32):
     br block1(v381)
 
 block3(v366: i32, v375: i32):
-    v367 = call noname::_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(v366)  : i32
-    v368 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v366)  : i32
+    v367 = call noname::dlmalloc::dlmalloc::Chunk::mmapped(v366)  : i32
+    v368 = call noname::dlmalloc::dlmalloc::Chunk::to_mem(v366)  : i32
     br block2(v375, v368)
 
 block4(v335: i32, v337: i32, v346: i32, v351: i32, v370: i32, v382: i32):
-    v342 = call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$6malloc17h1ae2390053e3628cE(v335, v337)  : i32
+    v342 = call noname::dlmalloc::dlmalloc::Dlmalloc<A>::malloc(v335, v337)  : i32
     v343 = eq v342, 0  : i1
     v344 = cast v343  : i32
     v345 = neq v344, 0  : i1
     condbr v345, block2(v370, v382), block45
 
 block5:
-    v321 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v75, v74)  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v75, v74)
+    v321 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v75, v74)  : i32
+    call noname::dlmalloc::dlmalloc::Chunk::set_inuse(v75, v74)
     v322 = cast v12  : u32
     v323 = add v322, 428  : u32
     v324 = inttoptr v323  : *mut i32
@@ -3851,24 +3851,24 @@ block6:
     v318 = neq v317, 0  : i1
     v319 = select v318, v1, v3  : i32
     v320 = call noname::memcpy(v19, v0, v319)  : i32
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$4free17h501de2a6604ba1ffE(v12, v0)
+    call noname::dlmalloc::dlmalloc::Dlmalloc<A>::free(v12, v0)
     br block2(v8, v19)
 
 block7:
-    v22 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v22 = call noname::dlmalloc::dlmalloc::Chunk::mem_offset()  : i32
     v23 = const.i32 8  : i32
-    v24 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v22, v23)  : i32
+    v24 = call noname::dlmalloc::dlmalloc::align_up(v22, v23)  : i32
     v25 = const.i32 20  : i32
     v26 = const.i32 8  : i32
-    v27 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v25, v26)  : i32
+    v27 = call noname::dlmalloc::dlmalloc::align_up(v25, v26)  : i32
     v28 = const.i32 16  : i32
     v29 = const.i32 8  : i32
-    v30 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v28, v29)  : i32
+    v30 = call noname::dlmalloc::dlmalloc::align_up(v28, v29)  : i32
     v31 = const.i32 0  : i32
     v32 = const.i32 0  : i32
     v33 = const.i32 16  : i32
     v34 = const.i32 8  : i32
-    v35 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v33, v34)  : i32
+    v35 = call noname::dlmalloc::dlmalloc::align_up(v33, v34)  : i32
     v36 = const.i32 2  : i32
     v37 = shl v35, v36  : i32
     v38 = sub v32, v37  : i32
@@ -3895,7 +3895,7 @@ block7:
     condbr v58, block2(v8, v31), block10
 
 block8:
-    v19 = call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$8memalign17he8794c5d1cb954f9E(v12, v2, v3)  : i32
+    v19 = call noname::dlmalloc::dlmalloc::Dlmalloc<A>::memalign(v12, v2, v3)  : i32
     v20 = neq v19, 0  : i1
     condbr v20, block6, block9
 
@@ -3909,7 +3909,7 @@ block10:
     v61 = add v3, v60  : i32
     v62 = const.i32 16  : i32
     v63 = const.i32 8  : i32
-    v64 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v62, v63)  : i32
+    v64 = call noname::dlmalloc::dlmalloc::align_up(v62, v63)  : i32
     v65 = const.i32 -5  : i32
     v66 = add v64, v65  : i32
     v67 = cast v66  : u32
@@ -3919,11 +3919,11 @@ block10:
     v71 = neq v70, 0  : i1
     v72 = select v71, v59, v61  : i32
     v73 = const.i32 8  : i32
-    v74 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v72, v73)  : i32
-    v75 = call noname::_ZN8dlmalloc8dlmalloc5Chunk8from_mem17h11dd30c74f483706E(v0)  : i32
-    v76 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v75)  : i32
-    v77 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v75, v76)  : i32
-    v78 = call noname::_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(v75)  : i32
+    v74 = call noname::dlmalloc::dlmalloc::align_up(v72, v73)  : i32
+    v75 = call noname::dlmalloc::dlmalloc::Chunk::from_mem(v0)  : i32
+    v76 = call noname::dlmalloc::dlmalloc::Chunk::size(v75)  : i32
+    v77 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v75, v76)  : i32
+    v78 = call noname::dlmalloc::dlmalloc::Chunk::mmapped(v75)  : i32
     v79 = neq v78, 0  : i1
     condbr v79, block17, block18
 
@@ -3948,7 +3948,7 @@ block13:
     v292 = sub v76, v74  : i32
     v293 = const.i32 16  : i32
     v294 = const.i32 8  : i32
-    v295 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v293, v294)  : i32
+    v295 = call noname::dlmalloc::dlmalloc::align_up(v293, v294)  : i32
     v296 = cast v292  : u32
     v297 = cast v295  : u32
     v298 = lt v296, v297  : i1
@@ -3972,7 +3972,7 @@ block14:
 block15:
     v243 = const.i32 16  : i32
     v244 = const.i32 8  : i32
-    v245 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v243, v244)  : i32
+    v245 = call noname::dlmalloc::dlmalloc::align_up(v243, v244)  : i32
     v246 = cast v108  : u32
     v247 = cast v245  : u32
     v248 = lt v246, v247  : i1
@@ -3995,7 +3995,7 @@ block16:
     condbr v220, block30, block31
 
 block17:
-    v115 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v75)  : i32
+    v115 = call noname::dlmalloc::dlmalloc::Chunk::size(v75)  : i32
     v116 = const.i32 256  : i32
     v117 = cast v74  : u32
     v118 = cast v116  : u32
@@ -4033,12 +4033,12 @@ block20:
     condbr v98, block14, block21
 
 block21:
-    v99 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6cinuse17h58499de57c2d37e2E(v77)  : i32
+    v99 = call noname::dlmalloc::dlmalloc::Chunk::cinuse(v77)  : i32
     v100 = neq v99, 0  : i1
     condbr v100, block4(v12, v3, v0, v75, v8, v31), block22
 
 block22:
-    v101 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v77)  : i32
+    v101 = call noname::dlmalloc::dlmalloc::Chunk::size(v77)  : i32
     v102 = add v101, v76  : i32
     v103 = cast v102  : u32
     v104 = cast v74  : u32
@@ -4058,7 +4058,7 @@ block23:
     condbr v114, block16, block24
 
 block24:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v12, v77)
+    call noname::dlmalloc::dlmalloc::Dlmalloc<A>::unlink_large_chunk(v12, v77)
     br block15
 
 block25:
@@ -4081,10 +4081,10 @@ block26:
     v145 = add v143, v144  : i32
     v147 = const.i32 31  : i32
     v148 = add v74, v147  : i32
-    v149 = call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$9page_size17h0fdd55b2693d440cE(v136)  : i32
-    v150 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v148, v149)  : i32
+    v149 = call noname::<dlmalloc::sys::System as dlmalloc::Allocator>::page_size(v136)  : i32
+    v150 = call noname::dlmalloc::dlmalloc::align_up(v148, v149)  : i32
     v151 = const.i32 1  : i32
-    v152 = call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$5remap17hf5ff3c6a92680f40E(v12, v141, v145, v150, v151)  : i32
+    v152 = call noname::<dlmalloc::sys::System as dlmalloc::Allocator>::remap(v12, v141, v145, v150, v151)  : i32
     v153 = eq v152, 0  : i1
     v154 = cast v153  : i32
     v155 = neq v154, 0  : i1
@@ -4112,15 +4112,15 @@ block29:
     v161 = add v160, 4  : u32
     v162 = inttoptr v161  : *mut i32
     store v162, v159
-    v163 = call noname::_ZN8dlmalloc8dlmalloc5Chunk14fencepost_head17he07aaa52f3b50dfdE()  : i32
-    v164 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v156, v159)  : i32
+    v163 = call noname::dlmalloc::dlmalloc::Chunk::fencepost_head()  : i32
+    v164 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v156, v159)  : i32
     v165 = cast v164  : u32
     v166 = add v165, 4  : u32
     v167 = inttoptr v166  : *mut i32
     store v167, v163
     v168 = const.i32 -12  : i32
     v169 = add v157, v168  : i32
-    v170 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v156, v169)  : i32
+    v170 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v156, v169)  : i32
     v171 = const.i32 0  : i32
     v172 = cast v170  : u32
     v173 = add v172, 4  : u32
@@ -4197,15 +4197,15 @@ block31:
     br block15
 
 block32:
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v251, v102)
+    call noname::dlmalloc::dlmalloc::Chunk::set_inuse(v251, v102)
     v257 = neq v251, 0  : i1
     condbr v257, block3(v251, v372), block35
 
 block33:
-    v253 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v75, v74)  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v251, v252)
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v253, v242)
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$13dispose_chunk17h577eb103dc04307bE(v12, v253, v242)
+    v253 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v75, v74)  : i32
+    call noname::dlmalloc::dlmalloc::Chunk::set_inuse(v251, v252)
+    call noname::dlmalloc::dlmalloc::Chunk::set_inuse(v253, v242)
+    call noname::dlmalloc::dlmalloc::Dlmalloc<A>::dispose_chunk(v12, v253, v242)
     v255 = neq v251, 0  : i1
     condbr v255, block3(v251, v372), block34
 
@@ -4219,7 +4219,7 @@ block36:
     v268 = sub v262, v74  : i32
     v269 = const.i32 16  : i32
     v270 = const.i32 8  : i32
-    v271 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v269, v270)  : i32
+    v271 = call noname::dlmalloc::dlmalloc::align_up(v269, v270)  : i32
     v272 = cast v268  : u32
     v273 = cast v271  : u32
     v274 = gte v272, v273  : i1
@@ -4240,15 +4240,15 @@ block37(v282: i32, v286: i32):
     condbr v291, block3(v290, v373), block40
 
 block38:
-    v279 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v75, v74)  : i32
-    v280 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v279, v268)  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v75, v74)
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v279, v268)
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk12clear_pinuse17h3c1a99d0f5bddc22E(v280)
+    v279 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v75, v74)  : i32
+    v280 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v279, v268)  : i32
+    call noname::dlmalloc::dlmalloc::Chunk::set_inuse(v75, v74)
+    call noname::dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_free_chunk(v279, v268)
+    call noname::dlmalloc::dlmalloc::Chunk::clear_pinuse(v280)
     br block37(v279, v268)
 
 block39:
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v75, v262)
+    call noname::dlmalloc::dlmalloc::Chunk::set_inuse(v75, v262)
     v277 = const.i32 0  : i32
     v278 = const.i32 0  : i32
     br block37(v278, v277)
@@ -4257,10 +4257,10 @@ block40:
     br block4(v281, v3, v0, v290, v8, v31)
 
 block41:
-    v301 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v75, v74)  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v75, v74)
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v301, v292)
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$13dispose_chunk17h577eb103dc04307bE(v12, v301, v292)
+    v301 = call noname::dlmalloc::dlmalloc::Chunk::plus_offset(v75, v74)  : i32
+    call noname::dlmalloc::dlmalloc::Chunk::set_inuse(v75, v74)
+    call noname::dlmalloc::dlmalloc::Chunk::set_inuse(v301, v292)
+    call noname::dlmalloc::dlmalloc::Dlmalloc<A>::dispose_chunk(v12, v301, v292)
     br block12
 
 block42:
@@ -4273,10 +4273,10 @@ block44:
     br block4(v12, v3, v0, v75, v8, v31)
 
 block45:
-    v352 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v351)  : i32
+    v352 = call noname::dlmalloc::dlmalloc::Chunk::size(v351)  : i32
     v353 = const.i32 -8  : i32
     v354 = const.i32 -4  : i32
-    v355 = call noname::_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(v351)  : i32
+    v355 = call noname::dlmalloc::dlmalloc::Chunk::mmapped(v351)  : i32
     v356 = neq v355, 0  : i1
     v357 = select v356, v353, v354  : i32
     v358 = add v352, v357  : i32
@@ -4287,7 +4287,7 @@ block45:
     v363 = neq v362, 0  : i1
     v364 = select v363, v358, v337  : i32
     v365 = call noname::memcpy(v342, v346, v364)  : i32
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$4free17h501de2a6604ba1ffE(v335, v346)
+    call noname::dlmalloc::dlmalloc::Dlmalloc<A>::free(v335, v346)
     br block2(v370, v365)
 }
 
@@ -4299,7 +4299,7 @@ block0(v0: i32, v1: i32):
 block1:
 }
 
-pub fn _ZN5alloc7raw_vec11finish_grow17hcefa6a06206fd52bE(i32, i32, i32, i32) {
+pub fn alloc::raw_vec::finish_grow(i32, i32, i32, i32) {
 block0(v0: i32, v1: i32, v2: i32, v3: i32):
     v4 = const.i32 0  : i32
     v5 = eq v1, 0  : i1
@@ -4442,7 +4442,7 @@ block18:
     ret 
 }
 
-pub fn _ZN5alloc7raw_vec19RawVec$LT$T$C$A$GT$16reserve_for_push17h2205b68aee7ddaceE(i32) {
+pub fn alloc::raw_vec::RawVec<T,A>::reserve_for_push(i32) {
 block0(v0: i32):
     v1 = const.i32 0  : i32
     v2 = global.load (@__stack_pointer) as *mut i8  : i32
@@ -4486,7 +4486,7 @@ block2:
     v53 = add v4, v52  : i32
     v56 = const.i32 20  : i32
     v57 = add v51, v56  : i32
-    call noname::_ZN5alloc7raw_vec11finish_grow17hcefa6a06206fd52bE(v53, v28, v21, v57)
+    call noname::alloc::raw_vec::finish_grow(v53, v28, v21, v57)
     v58 = cast v51  : u32
     v59 = add v58, 12  : u32
     v60 = inttoptr v59  : *mut i32
@@ -4558,7 +4558,7 @@ block8:
     condbr v80, block9, block10
 
 block9:
-    call noname::_ZN5alloc7raw_vec17capacity_overflow17h6c250c8ca346b5adE()
+    call noname::alloc::raw_vec::capacity_overflow()
     unreachable 
 
 block10:
@@ -4567,7 +4567,7 @@ block10:
     v83 = cast v82  : u32
     v84 = inttoptr v83  : *mut i32
     v85 = load v84  : i32
-    call noname::_ZN5alloc5alloc18handle_alloc_error17h4f3cb0c5afb21c76E(v61, v85)
+    call noname::alloc::alloc::handle_alloc_error(v61, v85)
     unreachable 
 }
 
@@ -4591,7 +4591,7 @@ block0:
     store v13, v10
     v14 = const.i32 4  : i32
     v15 = add v4, v14  : i32
-    call noname::_ZN5alloc7raw_vec19RawVec$LT$T$C$A$GT$16reserve_for_push17h2205b68aee7ddaceE(v15)
+    call noname::alloc::raw_vec::RawVec<T,A>::reserve_for_push(v15)
     v16 = cast v4  : u32
     v17 = add v16, 4  : u32
     v18 = inttoptr v17  : *mut i32
@@ -4644,22 +4644,22 @@ block5:
     br block4
 }
 
-pub fn _ZN5alloc7raw_vec17capacity_overflow17h6c250c8ca346b5adE() {
+pub fn alloc::raw_vec::capacity_overflow() {
 block0:
     unreachable 
 
 block1:
 }
 
-pub fn _ZN5alloc5alloc18handle_alloc_error17h4f3cb0c5afb21c76E(i32, i32) {
+pub fn alloc::alloc::handle_alloc_error(i32, i32) {
 block0(v0: i32, v1: i32):
-    call noname::_ZN5alloc5alloc18handle_alloc_error8rt_error17h63de615f6e977af2E(v0, v1)
+    call noname::alloc::alloc::handle_alloc_error::rt_error(v0, v1)
     unreachable 
 
 block1:
 }
 
-pub fn _ZN5alloc5alloc18handle_alloc_error8rt_error17h63de615f6e977af2E(i32, i32) {
+pub fn alloc::alloc::handle_alloc_error::rt_error(i32, i32) {
 block0(v0: i32, v1: i32):
     call noname::__rust_alloc_error_handler(v1, v0)
     unreachable 
@@ -4674,7 +4674,7 @@ block0(v0: i32, v1: i32):
 block1:
 }
 
-pub fn _ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(i32, i32) -> i32 {
+pub fn dlmalloc::dlmalloc::align_up(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
     v3 = add v0, v1  : i32
     v4 = const.i32 -1  : i32
@@ -4688,7 +4688,7 @@ block1(v2: i32):
     ret v2
 }
 
-pub fn _ZN8dlmalloc8dlmalloc9left_bits17hb6cbe146b8019d98E(i32) -> i32 {
+pub fn dlmalloc::dlmalloc::left_bits(i32) -> i32 {
 block0(v0: i32):
     v2 = const.i32 1  : i32
     v3 = shl v0, v2  : i32
@@ -4701,7 +4701,7 @@ block1(v1: i32):
     ret v1
 }
 
-pub fn _ZN8dlmalloc8dlmalloc9least_bit17h4bca52ead665dc5aE(i32) -> i32 {
+pub fn dlmalloc::dlmalloc::least_bit(i32) -> i32 {
 block0(v0: i32):
     v2 = const.i32 0  : i32
     v3 = sub v2, v0  : i32
@@ -4712,7 +4712,7 @@ block1(v1: i32):
     ret v1
 }
 
-pub fn _ZN8dlmalloc8dlmalloc24leftshift_for_tree_index17h31d064fdd867f502E(i32) -> i32 {
+pub fn dlmalloc::dlmalloc::leftshift_for_tree_index(i32) -> i32 {
 block0(v0: i32):
     v2 = const.i32 0  : i32
     v3 = const.i32 25  : i32
@@ -4733,7 +4733,7 @@ block1(v1: i32):
     ret v1
 }
 
-pub fn _ZN8dlmalloc8dlmalloc5Chunk14fencepost_head17he07aaa52f3b50dfdE() -> i32 {
+pub fn dlmalloc::dlmalloc::Chunk::fencepost_head() -> i32 {
 block0:
     v1 = const.i32 7  : i32
     br block1(v1)
@@ -4742,7 +4742,7 @@ block1(v0: i32):
     ret v0
 }
 
-pub fn _ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(i32) -> i32 {
+pub fn dlmalloc::dlmalloc::Chunk::size(i32) -> i32 {
 block0(v0: i32):
     v2 = cast v0  : u32
     v3 = add v2, 4  : u32
@@ -4756,7 +4756,7 @@ block1(v1: i32):
     ret v1
 }
 
-pub fn _ZN8dlmalloc8dlmalloc5Chunk6cinuse17h58499de57c2d37e2E(i32) -> i32 {
+pub fn dlmalloc::dlmalloc::Chunk::cinuse(i32) -> i32 {
 block0(v0: i32):
     v2 = cast v0  : u32
     v3 = add v2, 4  : u32
@@ -4776,7 +4776,7 @@ block1(v1: i32):
     ret v1
 }
 
-pub fn _ZN8dlmalloc8dlmalloc5Chunk6pinuse17h92d5107047b03ba7E(i32) -> i32 {
+pub fn dlmalloc::dlmalloc::Chunk::pinuse(i32) -> i32 {
 block0(v0: i32):
     v2 = cast v0  : u32
     v3 = add v2, 4  : u32
@@ -4790,7 +4790,7 @@ block1(v1: i32):
     ret v1
 }
 
-pub fn _ZN8dlmalloc8dlmalloc5Chunk12clear_pinuse17h3c1a99d0f5bddc22E(i32) {
+pub fn dlmalloc::dlmalloc::Chunk::clear_pinuse(i32) {
 block0(v0: i32):
     v1 = cast v0  : u32
     v2 = add v1, 4  : u32
@@ -4808,7 +4808,7 @@ block1:
     ret 
 }
 
-pub fn _ZN8dlmalloc8dlmalloc5Chunk5inuse17h2d327e4c36b84dfeE(i32) -> i32 {
+pub fn dlmalloc::dlmalloc::Chunk::inuse(i32) -> i32 {
 block0(v0: i32):
     v2 = cast v0  : u32
     v3 = add v2, 4  : u32
@@ -4825,7 +4825,7 @@ block1(v1: i32):
     ret v1
 }
 
-pub fn _ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(i32) -> i32 {
+pub fn dlmalloc::dlmalloc::Chunk::mmapped(i32) -> i32 {
 block0(v0: i32):
     v2 = cast v0  : u32
     v3 = add v2, 4  : u32
@@ -4842,7 +4842,7 @@ block1(v1: i32):
     ret v1
 }
 
-pub fn _ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(i32, i32) {
+pub fn dlmalloc::dlmalloc::Chunk::set_inuse(i32, i32) {
 block0(v0: i32, v1: i32):
     v2 = cast v0  : u32
     v3 = add v2, 4  : u32
@@ -4874,7 +4874,7 @@ block1:
     ret 
 }
 
-pub fn _ZN8dlmalloc8dlmalloc5Chunk20set_inuse_and_pinuse17h515e5a69a6d1edc6E(i32, i32) {
+pub fn dlmalloc::dlmalloc::Chunk::set_inuse_and_pinuse(i32, i32) {
 block0(v0: i32, v1: i32):
     v2 = const.i32 3  : i32
     v3 = bor v1, v2  : i32
@@ -4899,7 +4899,7 @@ block1:
     ret 
 }
 
-pub fn _ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(i32, i32) {
+pub fn dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_inuse_chunk(i32, i32) {
 block0(v0: i32, v1: i32):
     v2 = const.i32 3  : i32
     v3 = bor v1, v2  : i32
@@ -4913,7 +4913,7 @@ block1:
     ret 
 }
 
-pub fn _ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(i32, i32) {
+pub fn dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_free_chunk(i32, i32) {
 block0(v0: i32, v1: i32):
     v2 = const.i32 1  : i32
     v3 = bor v1, v2  : i32
@@ -4931,7 +4931,7 @@ block1:
     ret 
 }
 
-pub fn _ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E(i32, i32, i32) {
+pub fn dlmalloc::dlmalloc::Chunk::set_free_with_pinuse(i32, i32, i32) {
 block0(v0: i32, v1: i32, v2: i32):
     v3 = cast v2  : u32
     v4 = add v3, 4  : u32
@@ -4959,7 +4959,7 @@ block1:
     ret 
 }
 
-pub fn _ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(i32, i32) -> i32 {
+pub fn dlmalloc::dlmalloc::Chunk::plus_offset(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
     v3 = add v0, v1  : i32
     br block1(v3)
@@ -4968,7 +4968,7 @@ block1(v2: i32):
     ret v2
 }
 
-pub fn _ZN8dlmalloc8dlmalloc5Chunk12minus_offset17h7c3eec81761249d9E(i32, i32) -> i32 {
+pub fn dlmalloc::dlmalloc::Chunk::minus_offset(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
     v3 = sub v0, v1  : i32
     br block1(v3)
@@ -4977,7 +4977,7 @@ block1(v2: i32):
     ret v2
 }
 
-pub fn _ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(i32) -> i32 {
+pub fn dlmalloc::dlmalloc::Chunk::to_mem(i32) -> i32 {
 block0(v0: i32):
     v2 = const.i32 8  : i32
     v3 = add v0, v2  : i32
@@ -4987,7 +4987,7 @@ block1(v1: i32):
     ret v1
 }
 
-pub fn _ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E() -> i32 {
+pub fn dlmalloc::dlmalloc::Chunk::mem_offset() -> i32 {
 block0:
     v1 = const.i32 8  : i32
     br block1(v1)
@@ -4996,7 +4996,7 @@ block1(v0: i32):
     ret v0
 }
 
-pub fn _ZN8dlmalloc8dlmalloc5Chunk8from_mem17h11dd30c74f483706E(i32) -> i32 {
+pub fn dlmalloc::dlmalloc::Chunk::from_mem(i32) -> i32 {
 block0(v0: i32):
     v2 = const.i32 -8  : i32
     v3 = add v0, v2  : i32
@@ -5006,7 +5006,7 @@ block1(v1: i32):
     ret v1
 }
 
-pub fn _ZN8dlmalloc8dlmalloc9TreeChunk14leftmost_child17h20605933c801b44bE(i32) -> i32 {
+pub fn dlmalloc::dlmalloc::TreeChunk::leftmost_child(i32) -> i32 {
 block0(v0: i32):
     v2 = const.i32 0  : i32
     v3 = cast v0  : u32
@@ -5031,7 +5031,7 @@ block3:
     br block2(v12)
 }
 
-pub fn _ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(i32) -> i32 {
+pub fn dlmalloc::dlmalloc::TreeChunk::chunk(i32) -> i32 {
 block0(v0: i32):
     br block1(v0)
 
@@ -5039,7 +5039,7 @@ block1(v1: i32):
     ret v1
 }
 
-pub fn _ZN8dlmalloc8dlmalloc9TreeChunk4next17he250edbec5d87123E(i32) -> i32 {
+pub fn dlmalloc::dlmalloc::TreeChunk::next(i32) -> i32 {
 block0(v0: i32):
     v2 = cast v0  : u32
     v3 = add v2, 12  : u32
@@ -5051,7 +5051,7 @@ block1(v1: i32):
     ret v1
 }
 
-pub fn _ZN8dlmalloc8dlmalloc9TreeChunk4prev17h7a0f1d46544cc14aE(i32) -> i32 {
+pub fn dlmalloc::dlmalloc::TreeChunk::prev(i32) -> i32 {
 block0(v0: i32):
     v2 = cast v0  : u32
     v3 = add v2, 8  : u32
@@ -5063,7 +5063,7 @@ block1(v1: i32):
     ret v1
 }
 
-pub fn _ZN8dlmalloc8dlmalloc7Segment9is_extern17h6f6db2c70b891fd9E(i32) -> i32 {
+pub fn dlmalloc::dlmalloc::Segment::is_extern(i32) -> i32 {
 block0(v0: i32):
     v2 = cast v0  : u32
     v3 = add v2, 12  : u32
@@ -5077,7 +5077,7 @@ block1(v1: i32):
     ret v1
 }
 
-pub fn _ZN8dlmalloc8dlmalloc7Segment9sys_flags17h224550055bf7775bE(i32) -> i32 {
+pub fn dlmalloc::dlmalloc::Segment::sys_flags(i32) -> i32 {
 block0(v0: i32):
     v2 = cast v0  : u32
     v3 = add v2, 12  : u32
@@ -5094,7 +5094,7 @@ block1(v1: i32):
     ret v1
 }
 
-pub fn _ZN8dlmalloc8dlmalloc7Segment5holds17h8f6de4ee6718009bE(i32, i32) -> i32 {
+pub fn dlmalloc::dlmalloc::Segment::holds(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
     v3 = const.i32 0  : i32
     v4 = const.i32 0  : i32
@@ -5127,7 +5127,7 @@ block3:
     br block2(v21)
 }
 
-pub fn _ZN8dlmalloc8dlmalloc7Segment3top17he7e9e2493151d036E(i32) -> i32 {
+pub fn dlmalloc::dlmalloc::Segment::top(i32) -> i32 {
 block0(v0: i32):
     v2 = cast v0  : u32
     v3 = inttoptr v2  : *mut i32
@@ -5143,7 +5143,7 @@ block1(v1: i32):
     ret v1
 }
 
-pub fn _ZN73_$LT$dlmalloc..global..Instance$u20$as$u20$core..ops..deref..DerefMut$GT$9deref_mut17h16955ef502c5c4e5E(i32) -> i32 {
+pub fn <dlmalloc::global::Instance as core::ops::deref::DerefMut>::deref_mut(i32) -> i32 {
 block0(v0: i32):
     v2 = const.i32 1048580  : i32
     br block1(v2)
@@ -5152,7 +5152,7 @@ block1(v1: i32):
     ret v1
 }
 
-pub fn _ZN68_$LT$dlmalloc..global..Instance$u20$as$u20$core..ops..drop..Drop$GT$4drop17he19d8d9c8ea92454E(i32) {
+pub fn <dlmalloc::global::Instance as core::ops::drop::Drop>::drop(i32) {
 block0(v0: i32):
     br block1
 
@@ -5160,7 +5160,7 @@ block1:
     ret 
 }
 
-pub fn _ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$5alloc17hdbf1e2bcc01bc909E(i32, i32, i32) {
+pub fn <dlmalloc::sys::System as dlmalloc::Allocator>::alloc(i32, i32, i32) {
 block0(v0: i32, v1: i32, v2: i32):
     v3 = const.i32 0  : i32
     v4 = const.i32 16  : i32
@@ -5201,7 +5201,7 @@ block1:
     ret 
 }
 
-pub fn _ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$5remap17hf5ff3c6a92680f40E(i32, i32, i32, i32, i32) -> i32 {
+pub fn <dlmalloc::sys::System as dlmalloc::Allocator>::remap(i32, i32, i32, i32, i32) -> i32 {
 block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32):
     v6 = const.i32 0  : i32
     br block1(v6)
@@ -5210,7 +5210,7 @@ block1(v5: i32):
     ret v5
 }
 
-pub fn _ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$9free_part17h74489c9e7a3aa967E(i32, i32, i32, i32) -> i32 {
+pub fn <dlmalloc::sys::System as dlmalloc::Allocator>::free_part(i32, i32, i32, i32) -> i32 {
 block0(v0: i32, v1: i32, v2: i32, v3: i32):
     v5 = const.i32 0  : i32
     br block1(v5)
@@ -5219,7 +5219,7 @@ block1(v4: i32):
     ret v4
 }
 
-pub fn _ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$4free17h993c5f05ba1214bcE(i32, i32, i32) -> i32 {
+pub fn <dlmalloc::sys::System as dlmalloc::Allocator>::free(i32, i32, i32) -> i32 {
 block0(v0: i32, v1: i32, v2: i32):
     v4 = const.i32 0  : i32
     br block1(v4)
@@ -5228,7 +5228,7 @@ block1(v3: i32):
     ret v3
 }
 
-pub fn _ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$16can_release_part17h43bfb7d8666fcc31E(i32, i32) -> i32 {
+pub fn <dlmalloc::sys::System as dlmalloc::Allocator>::can_release_part(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
     v3 = const.i32 0  : i32
     br block1(v3)
@@ -5237,7 +5237,7 @@ block1(v2: i32):
     ret v2
 }
 
-pub fn _ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$9page_size17h0fdd55b2693d440cE(i32) -> i32 {
+pub fn <dlmalloc::sys::System as dlmalloc::Allocator>::page_size(i32) -> i32 {
 block0(v0: i32):
     v2 = const.i32 65536  : i32
     br block1(v2)
@@ -5246,7 +5246,7 @@ block1(v1: i32):
     ret v1
 }
 
-pub fn _ZN8dlmalloc3sys23enable_alloc_after_fork17h64eb1fc0ff7b2689E() {
+pub fn dlmalloc::sys::enable_alloc_after_fork() {
 block0:
     br block1
 
@@ -5256,14 +5256,14 @@ block1:
 
 pub fn memcpy(i32, i32, i32) -> i32 {
 block0(v0: i32, v1: i32, v2: i32):
-    v4 = call noname::_ZN17compiler_builtins3mem6memcpy17h7b83c85e899060b3E(v0, v1, v2)  : i32
+    v4 = call noname::compiler_builtins::mem::memcpy(v0, v1, v2)  : i32
     br block1(v4)
 
 block1(v3: i32):
     ret v3
 }
 
-pub fn _ZN17compiler_builtins3mem6memcpy17h7b83c85e899060b3E(i32, i32, i32) -> i32 {
+pub fn compiler_builtins::mem::memcpy(i32, i32, i32) -> i32 {
 block0(v0: i32, v1: i32, v2: i32):
     v4 = const.i32 0  : i32
     v5 = const.i32 15  : i32

--- a/frontend-wasm/tests/expected/dlmalloc.mir
+++ b/frontend-wasm/tests/expected/dlmalloc.mir
@@ -9,391 +9,372 @@ block0(v0: i32, v1: i32, v2: i32):
     v3 = const.i32 0  : i32
     v4 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1, v2)  : i32
     v5 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6pinuse17h92d5107047b03ba7E(v1)  : i32
-    v6 = const.i32 0  : i32
-    v7 = neq v5, v6  : i1
-    condbr v7, block4(v1, v2), block5
+    v6 = neq v5, 0  : i1
+    condbr v6, block4(v1, v2), block5
 
 block1:
     ret 
 
-block2(v221: i32, v229: i32, v230: i32):
-    v222 = const.i32 256  : i32
-    v223 = cast v221  : u32
-    v224 = cast v222  : u32
-    v225 = lt v223, v224  : i1
-    v226 = cast v225  : i32
-    v227 = const.i32 0  : i32
-    v228 = neq v226, v227  : i1
-    condbr v228, block29, block30
+block2(v205: i32, v212: i32, v213: i32):
+    v206 = const.i32 256  : i32
+    v207 = cast v205  : u32
+    v208 = cast v206  : u32
+    v209 = lt v207, v208  : i1
+    v210 = cast v209  : i32
+    v211 = neq v210, 0  : i1
+    condbr v211, block29, block30
 
 block3:
     ret 
 
-block4(v103: i32, v104: i32):
-    v97 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6cinuse17h58499de57c2d37e2E(v4)  : i32
-    v98 = const.i32 0  : i32
-    v99 = eq v97, v98  : i1
-    v100 = cast v99  : i32
-    v101 = const.i32 0  : i32
-    v102 = neq v100, v101  : i1
-    condbr v102, block16, block17
+block4(v93: i32, v94: i32):
+    v89 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6cinuse17h58499de57c2d37e2E(v4)  : i32
+    v90 = eq v89, 0  : i1
+    v91 = cast v90  : i32
+    v92 = neq v91, 0  : i1
+    condbr v92, block16, block17
 
 block5:
-    v8 = cast v1  : u32
-    v9 = inttoptr v8  : *mut i32
-    v10 = load v9  : i32
-    v11 = call noname::_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(v1)  : i32
-    v12 = const.i32 0  : i32
-    v13 = neq v11, v12  : i1
-    condbr v13, block6, block7
+    v7 = cast v1  : u32
+    v8 = inttoptr v7  : *mut i32
+    v9 = load v8  : i32
+    v10 = call noname::_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(v1)  : i32
+    v11 = neq v10, 0  : i1
+    condbr v11, block6, block7
 
 block6:
-    v78 = sub v1, v10  : i32
-    v79 = add v2, v10  : i32
-    v80 = const.i32 16  : i32
-    v81 = add v79, v80  : i32
-    v82 = call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$4free17h993c5f05ba1214bcE(v0, v78, v81)  : i32
-    v83 = const.i32 0  : i32
-    v84 = eq v82, v83  : i1
-    v85 = cast v84  : i32
-    v86 = const.i32 0  : i32
-    v87 = neq v85, v86  : i1
-    condbr v87, block3, block15
+    v72 = sub v1, v9  : i32
+    v73 = add v2, v9  : i32
+    v74 = const.i32 16  : i32
+    v75 = add v73, v74  : i32
+    v76 = call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$4free17h993c5f05ba1214bcE(v0, v72, v75)  : i32
+    v77 = eq v76, 0  : i1
+    v78 = cast v77  : i32
+    v79 = neq v78, 0  : i1
+    condbr v79, block3, block15
 
 block7:
-    v14 = add v10, v2  : i32
-    v15 = call noname::_ZN8dlmalloc8dlmalloc5Chunk12minus_offset17h7c3eec81761249d9E(v1, v10)  : i32
-    v16 = cast v0  : u32
-    v17 = add v16, 424  : u32
-    v18 = inttoptr v17  : *mut i32
-    v19 = load v18  : i32
-    v20 = neq v15, v19  : i1
-    v21 = cast v20  : i32
-    v22 = const.i32 0  : i32
-    v23 = neq v21, v22  : i1
-    condbr v23, block8, block9
+    v12 = add v9, v2  : i32
+    v13 = call noname::_ZN8dlmalloc8dlmalloc5Chunk12minus_offset17h7c3eec81761249d9E(v1, v9)  : i32
+    v14 = cast v0  : u32
+    v15 = add v14, 424  : u32
+    v16 = inttoptr v15  : *mut i32
+    v17 = load v16  : i32
+    v18 = neq v13, v17  : i1
+    v19 = cast v18  : i32
+    v20 = neq v19, 0  : i1
+    condbr v20, block8, block9
 
 block8:
-    v38 = const.i32 256  : i32
-    v39 = cast v10  : u32
-    v40 = cast v38  : u32
-    v41 = lt v39, v40  : i1
-    v42 = cast v41  : i32
-    v43 = const.i32 0  : i32
-    v44 = neq v42, v43  : i1
-    condbr v44, block11, block12
+    v34 = const.i32 256  : i32
+    v35 = cast v9  : u32
+    v36 = cast v34  : u32
+    v37 = lt v35, v36  : i1
+    v38 = cast v37  : i32
+    v39 = neq v38, 0  : i1
+    condbr v39, block11, block12
 
 block9:
-    v24 = cast v4  : u32
-    v25 = add v24, 4  : u32
-    v26 = inttoptr v25  : *mut i32
-    v27 = load v26  : i32
-    v28 = const.i32 3  : i32
-    v29 = band v27, v28  : i32
-    v30 = const.i32 3  : i32
-    v31 = neq v29, v30  : i1
-    v32 = cast v31  : i32
-    v33 = const.i32 0  : i32
-    v34 = neq v32, v33  : i1
-    condbr v34, block4(v15, v14), block10
+    v21 = cast v4  : u32
+    v22 = add v21, 4  : u32
+    v23 = inttoptr v22  : *mut i32
+    v24 = load v23  : i32
+    v25 = const.i32 3  : i32
+    v26 = band v24, v25  : i32
+    v27 = const.i32 3  : i32
+    v28 = neq v26, v27  : i1
+    v29 = cast v28  : i32
+    v30 = neq v29, 0  : i1
+    condbr v30, block4(v13, v12), block10
 
 block10:
-    v35 = cast v0  : u32
-    v36 = add v35, 416  : u32
-    v37 = inttoptr v36  : *mut i32
-    store v37, v14
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E(v15, v14, v4)
+    v31 = cast v0  : u32
+    v32 = add v31, 416  : u32
+    v33 = inttoptr v32  : *mut i32
+    store v33, v12
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E(v13, v12, v4)
     ret 
 
 block11:
-    v45 = cast v15  : u32
-    v46 = add v45, 12  : u32
-    v47 = inttoptr v46  : *mut i32
-    v48 = load v47  : i32
-    v49 = cast v15  : u32
-    v50 = add v49, 8  : u32
-    v51 = inttoptr v50  : *mut i32
-    v52 = load v51  : i32
-    v53 = eq v48, v52  : i1
-    v54 = cast v53  : i32
-    v55 = const.i32 0  : i32
-    v56 = neq v54, v55  : i1
-    condbr v56, block13, block14
+    v40 = cast v13  : u32
+    v41 = add v40, 12  : u32
+    v42 = inttoptr v41  : *mut i32
+    v43 = load v42  : i32
+    v44 = cast v13  : u32
+    v45 = add v44, 8  : u32
+    v46 = inttoptr v45  : *mut i32
+    v47 = load v46  : i32
+    v48 = eq v43, v47  : i1
+    v49 = cast v48  : i32
+    v50 = neq v49, 0  : i1
+    condbr v50, block13, block14
 
 block12:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v0, v15)
-    br block4(v15, v14)
+    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v0, v13)
+    br block4(v13, v12)
 
 block13:
-    v63 = cast v0  : u32
-    v64 = add v63, 408  : u32
-    v65 = inttoptr v64  : *mut i32
-    v66 = load v65  : i32
-    v67 = const.i32 -2  : i32
-    v68 = const.i32 3  : i32
-    v69 = cast v10  : u32
-    v70 = cast v68  : u32
-    v71 = shr v69, v70  : u32
-    v72 = cast v71  : i32
-    v73 = shl v67, v72  : i32
-    v74 = band v66, v73  : i32
-    v75 = cast v0  : u32
-    v76 = add v75, 408  : u32
-    v77 = inttoptr v76  : *mut i32
-    store v77, v74
-    br block4(v15, v14)
+    v57 = cast v0  : u32
+    v58 = add v57, 408  : u32
+    v59 = inttoptr v58  : *mut i32
+    v60 = load v59  : i32
+    v61 = const.i32 -2  : i32
+    v62 = const.i32 3  : i32
+    v63 = cast v9  : u32
+    v64 = cast v62  : u32
+    v65 = shr v63, v64  : u32
+    v66 = cast v65  : i32
+    v67 = shl v61, v66  : i32
+    v68 = band v60, v67  : i32
+    v69 = cast v0  : u32
+    v70 = add v69, 408  : u32
+    v71 = inttoptr v70  : *mut i32
+    store v71, v68
+    br block4(v13, v12)
 
 block14:
-    v57 = cast v52  : u32
-    v58 = add v57, 12  : u32
-    v59 = inttoptr v58  : *mut i32
-    store v59, v48
-    v60 = cast v48  : u32
-    v61 = add v60, 8  : u32
-    v62 = inttoptr v61  : *mut i32
-    store v62, v52
-    br block4(v15, v14)
+    v51 = cast v47  : u32
+    v52 = add v51, 12  : u32
+    v53 = inttoptr v52  : *mut i32
+    store v53, v43
+    v54 = cast v43  : u32
+    v55 = add v54, 8  : u32
+    v56 = inttoptr v55  : *mut i32
+    store v56, v47
+    br block4(v13, v12)
 
 block15:
-    v88 = cast v0  : u32
-    v89 = add v88, 432  : u32
-    v90 = inttoptr v89  : *mut i32
-    v91 = load v90  : i32
-    v92 = sub v91, v81  : i32
-    v93 = cast v0  : u32
-    v94 = add v93, 432  : u32
-    v95 = inttoptr v94  : *mut i32
-    store v95, v92
+    v80 = cast v0  : u32
+    v81 = add v80, 432  : u32
+    v82 = inttoptr v81  : *mut i32
+    v83 = load v82  : i32
+    v84 = sub v83, v75  : i32
+    v85 = cast v0  : u32
+    v86 = add v85, 432  : u32
+    v87 = inttoptr v86  : *mut i32
+    store v87, v84
     ret 
 
 block16:
-    v106 = cast v0  : u32
-    v107 = add v106, 428  : u32
-    v108 = inttoptr v107  : *mut i32
-    v109 = load v108  : i32
-    v110 = eq v96, v109  : i1
-    v111 = cast v110  : i32
-    v112 = const.i32 0  : i32
-    v113 = neq v111, v112  : i1
-    condbr v113, block19, block20
+    v96 = cast v0  : u32
+    v97 = add v96, 428  : u32
+    v98 = inttoptr v97  : *mut i32
+    v99 = load v98  : i32
+    v100 = eq v88, v99  : i1
+    v101 = cast v100  : i32
+    v102 = neq v101, 0  : i1
+    condbr v102, block19, block20
 
 block17:
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E(v103, v104, v96)
-    br block2(v104, v105, v103)
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E(v93, v94, v88)
+    br block2(v94, v95, v93)
 
 block18:
-    v210 = cast v105  : u32
-    v211 = add v210, 424  : u32
-    v212 = inttoptr v211  : *mut i32
-    store v212, v103
-    v213 = cast v105  : u32
-    v214 = add v213, 416  : u32
-    v215 = inttoptr v214  : *mut i32
-    v216 = load v215  : i32
-    v217 = add v216, v104  : i32
-    v218 = cast v105  : u32
-    v219 = add v218, 416  : u32
-    v220 = inttoptr v219  : *mut i32
-    store v220, v217
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v103, v217)
+    v194 = cast v95  : u32
+    v195 = add v194, 424  : u32
+    v196 = inttoptr v195  : *mut i32
+    store v196, v93
+    v197 = cast v95  : u32
+    v198 = add v197, 416  : u32
+    v199 = inttoptr v198  : *mut i32
+    v200 = load v199  : i32
+    v201 = add v200, v94  : i32
+    v202 = cast v95  : u32
+    v203 = add v202, 416  : u32
+    v204 = inttoptr v203  : *mut i32
+    store v204, v201
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v93, v201)
     ret 
 
 block19:
-    v178 = cast v105  : u32
-    v179 = add v178, 428  : u32
-    v180 = inttoptr v179  : *mut i32
-    store v180, v103
-    v181 = cast v105  : u32
-    v182 = add v181, 420  : u32
-    v183 = inttoptr v182  : *mut i32
-    v184 = load v183  : i32
-    v185 = add v184, v104  : i32
-    v186 = cast v105  : u32
-    v187 = add v186, 420  : u32
-    v188 = inttoptr v187  : *mut i32
-    store v188, v185
-    v189 = const.i32 1  : i32
-    v190 = bor v185, v189  : i32
-    v191 = cast v103  : u32
-    v192 = add v191, 4  : u32
-    v193 = inttoptr v192  : *mut i32
-    store v193, v190
-    v194 = cast v105  : u32
-    v195 = add v194, 424  : u32
-    v196 = inttoptr v195  : *mut i32
-    v197 = load v196  : i32
-    v198 = neq v103, v197  : i1
-    v199 = cast v198  : i32
-    v200 = const.i32 0  : i32
-    v201 = neq v199, v200  : i1
-    condbr v201, block3, block28
+    v163 = cast v95  : u32
+    v164 = add v163, 428  : u32
+    v165 = inttoptr v164  : *mut i32
+    store v165, v93
+    v166 = cast v95  : u32
+    v167 = add v166, 420  : u32
+    v168 = inttoptr v167  : *mut i32
+    v169 = load v168  : i32
+    v170 = add v169, v94  : i32
+    v171 = cast v95  : u32
+    v172 = add v171, 420  : u32
+    v173 = inttoptr v172  : *mut i32
+    store v173, v170
+    v174 = const.i32 1  : i32
+    v175 = bor v170, v174  : i32
+    v176 = cast v93  : u32
+    v177 = add v176, 4  : u32
+    v178 = inttoptr v177  : *mut i32
+    store v178, v175
+    v179 = cast v95  : u32
+    v180 = add v179, 424  : u32
+    v181 = inttoptr v180  : *mut i32
+    v182 = load v181  : i32
+    v183 = neq v93, v182  : i1
+    v184 = cast v183  : i32
+    v185 = neq v184, 0  : i1
+    condbr v185, block3, block28
 
 block20:
-    v114 = cast v105  : u32
-    v115 = add v114, 424  : u32
-    v116 = inttoptr v115  : *mut i32
-    v117 = load v116  : i32
-    v118 = eq v96, v117  : i1
-    v119 = cast v118  : i32
-    v120 = const.i32 0  : i32
-    v121 = neq v119, v120  : i1
-    condbr v121, block18, block21
+    v103 = cast v95  : u32
+    v104 = add v103, 424  : u32
+    v105 = inttoptr v104  : *mut i32
+    v106 = load v105  : i32
+    v107 = eq v88, v106  : i1
+    v108 = cast v107  : i32
+    v109 = neq v108, 0  : i1
+    condbr v109, block18, block21
 
 block21:
-    v122 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v96)  : i32
-    v123 = add v122, v104  : i32
-    v124 = const.i32 256  : i32
-    v125 = cast v122  : u32
-    v126 = cast v124  : u32
-    v127 = lt v125, v126  : i1
-    v128 = cast v127  : i32
-    v129 = const.i32 0  : i32
-    v130 = neq v128, v129  : i1
-    condbr v130, block23, block24
+    v110 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v88)  : i32
+    v111 = add v110, v94  : i32
+    v112 = const.i32 256  : i32
+    v113 = cast v110  : u32
+    v114 = cast v112  : u32
+    v115 = lt v113, v114  : i1
+    v116 = cast v115  : i32
+    v117 = neq v116, 0  : i1
+    condbr v117, block23, block24
 
 block22:
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v103, v123)
-    v167 = cast v105  : u32
-    v168 = add v167, 424  : u32
-    v169 = inttoptr v168  : *mut i32
-    v170 = load v169  : i32
-    v171 = neq v164, v170  : i1
-    v172 = cast v171  : i32
-    v173 = const.i32 0  : i32
-    v174 = neq v172, v173  : i1
-    condbr v174, block2(v165, v166, v164), block27
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v93, v111)
+    v153 = cast v95  : u32
+    v154 = add v153, 424  : u32
+    v155 = inttoptr v154  : *mut i32
+    v156 = load v155  : i32
+    v157 = neq v150, v156  : i1
+    v158 = cast v157  : i32
+    v159 = neq v158, 0  : i1
+    condbr v159, block2(v151, v152, v150), block27
 
 block23:
-    v131 = cast v96  : u32
-    v132 = add v131, 12  : u32
-    v133 = inttoptr v132  : *mut i32
-    v134 = load v133  : i32
-    v135 = cast v96  : u32
-    v136 = add v135, 8  : u32
-    v137 = inttoptr v136  : *mut i32
-    v138 = load v137  : i32
-    v139 = eq v134, v138  : i1
-    v140 = cast v139  : i32
-    v141 = const.i32 0  : i32
-    v142 = neq v140, v141  : i1
-    condbr v142, block25, block26
+    v118 = cast v88  : u32
+    v119 = add v118, 12  : u32
+    v120 = inttoptr v119  : *mut i32
+    v121 = load v120  : i32
+    v122 = cast v88  : u32
+    v123 = add v122, 8  : u32
+    v124 = inttoptr v123  : *mut i32
+    v125 = load v124  : i32
+    v126 = eq v121, v125  : i1
+    v127 = cast v126  : i32
+    v128 = neq v127, 0  : i1
+    condbr v128, block25, block26
 
 block24:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v105, v96)
+    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v95, v88)
     br block22
 
 block25:
-    v149 = cast v105  : u32
-    v150 = add v149, 408  : u32
-    v151 = inttoptr v150  : *mut i32
-    v152 = load v151  : i32
-    v153 = const.i32 -2  : i32
-    v154 = const.i32 3  : i32
-    v155 = cast v122  : u32
-    v156 = cast v154  : u32
-    v157 = shr v155, v156  : u32
-    v158 = cast v157  : i32
-    v159 = shl v153, v158  : i32
-    v160 = band v152, v159  : i32
-    v161 = cast v105  : u32
-    v162 = add v161, 408  : u32
-    v163 = inttoptr v162  : *mut i32
-    store v163, v160
+    v135 = cast v95  : u32
+    v136 = add v135, 408  : u32
+    v137 = inttoptr v136  : *mut i32
+    v138 = load v137  : i32
+    v139 = const.i32 -2  : i32
+    v140 = const.i32 3  : i32
+    v141 = cast v110  : u32
+    v142 = cast v140  : u32
+    v143 = shr v141, v142  : u32
+    v144 = cast v143  : i32
+    v145 = shl v139, v144  : i32
+    v146 = band v138, v145  : i32
+    v147 = cast v95  : u32
+    v148 = add v147, 408  : u32
+    v149 = inttoptr v148  : *mut i32
+    store v149, v146
     br block22
 
 block26:
-    v143 = cast v138  : u32
-    v144 = add v143, 12  : u32
-    v145 = inttoptr v144  : *mut i32
-    store v145, v134
-    v146 = cast v134  : u32
-    v147 = add v146, 8  : u32
-    v148 = inttoptr v147  : *mut i32
-    store v148, v138
+    v129 = cast v125  : u32
+    v130 = add v129, 12  : u32
+    v131 = inttoptr v130  : *mut i32
+    store v131, v121
+    v132 = cast v121  : u32
+    v133 = add v132, 8  : u32
+    v134 = inttoptr v133  : *mut i32
+    store v134, v125
     br block22
 
 block27:
-    v175 = cast v166  : u32
-    v176 = add v175, 416  : u32
-    v177 = inttoptr v176  : *mut i32
-    store v177, v165
+    v160 = cast v152  : u32
+    v161 = add v160, 416  : u32
+    v162 = inttoptr v161  : *mut i32
+    store v162, v151
     br block3
 
 block28:
-    v202 = const.i32 0  : i32
-    v203 = cast v105  : u32
-    v204 = add v203, 416  : u32
-    v205 = inttoptr v204  : *mut i32
-    store v205, v202
-    v206 = const.i32 0  : i32
-    v207 = cast v105  : u32
-    v208 = add v207, 424  : u32
-    v209 = inttoptr v208  : *mut i32
-    store v209, v206
+    v186 = const.i32 0  : i32
+    v187 = cast v95  : u32
+    v188 = add v187, 416  : u32
+    v189 = inttoptr v188  : *mut i32
+    store v189, v186
+    v190 = const.i32 0  : i32
+    v191 = cast v95  : u32
+    v192 = add v191, 424  : u32
+    v193 = inttoptr v192  : *mut i32
+    store v193, v190
     ret 
 
 block29:
-    v231 = const.i32 -8  : i32
-    v232 = band v221, v231  : i32
-    v233 = add v229, v232  : i32
-    v234 = const.i32 144  : i32
-    v235 = add v233, v234  : i32
-    v236 = cast v229  : u32
-    v237 = add v236, 408  : u32
-    v238 = inttoptr v237  : *mut i32
-    v239 = load v238  : i32
-    v240 = const.i32 1  : i32
-    v241 = const.i32 3  : i32
-    v242 = cast v221  : u32
-    v243 = cast v241  : u32
-    v244 = shr v242, v243  : u32
-    v245 = cast v244  : i32
-    v246 = shl v240, v245  : i32
-    v247 = band v239, v246  : i32
-    v248 = const.i32 0  : i32
-    v249 = eq v247, v248  : i1
-    v250 = cast v249  : i32
-    v251 = const.i32 0  : i32
-    v252 = neq v250, v251  : i1
-    condbr v252, block32, block33
+    v214 = const.i32 -8  : i32
+    v215 = band v205, v214  : i32
+    v216 = add v212, v215  : i32
+    v217 = const.i32 144  : i32
+    v218 = add v216, v217  : i32
+    v219 = cast v212  : u32
+    v220 = add v219, 408  : u32
+    v221 = inttoptr v220  : *mut i32
+    v222 = load v221  : i32
+    v223 = const.i32 1  : i32
+    v224 = const.i32 3  : i32
+    v225 = cast v205  : u32
+    v226 = cast v224  : u32
+    v227 = shr v225, v226  : u32
+    v228 = cast v227  : i32
+    v229 = shl v223, v228  : i32
+    v230 = band v222, v229  : i32
+    v231 = eq v230, 0  : i1
+    v232 = cast v231  : i32
+    v233 = neq v232, 0  : i1
+    condbr v233, block32, block33
 
 block30:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E(v229, v230, v221)
+    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E(v212, v213, v205)
     ret 
 
-block31(v266: i32):
-    v263 = cast v235  : u32
-    v264 = add v263, 8  : u32
-    v265 = inttoptr v264  : *mut i32
-    store v265, v230
-    v267 = cast v266  : u32
-    v268 = add v267, 12  : u32
-    v269 = inttoptr v268  : *mut i32
-    store v269, v262
-    v270 = cast v262  : u32
-    v271 = add v270, 12  : u32
-    v272 = inttoptr v271  : *mut i32
-    store v272, v261
-    v273 = cast v262  : u32
-    v274 = add v273, 8  : u32
-    v275 = inttoptr v274  : *mut i32
-    store v275, v266
+block31(v247: i32):
+    v244 = cast v218  : u32
+    v245 = add v244, 8  : u32
+    v246 = inttoptr v245  : *mut i32
+    store v246, v213
+    v248 = cast v247  : u32
+    v249 = add v248, 12  : u32
+    v250 = inttoptr v249  : *mut i32
+    store v250, v243
+    v251 = cast v243  : u32
+    v252 = add v251, 12  : u32
+    v253 = inttoptr v252  : *mut i32
+    store v253, v242
+    v254 = cast v243  : u32
+    v255 = add v254, 8  : u32
+    v256 = inttoptr v255  : *mut i32
+    store v256, v247
     br block1
 
 block32:
-    v257 = bor v239, v246  : i32
-    v258 = cast v229  : u32
-    v259 = add v258, 408  : u32
-    v260 = inttoptr v259  : *mut i32
-    store v260, v257
-    br block31(v235)
+    v238 = bor v222, v229  : i32
+    v239 = cast v212  : u32
+    v240 = add v239, 408  : u32
+    v241 = inttoptr v240  : *mut i32
+    store v241, v238
+    br block31(v218)
 
 block33:
-    v253 = cast v235  : u32
-    v254 = add v253, 8  : u32
-    v255 = inttoptr v254  : *mut i32
-    v256 = load v255  : i32
-    br block31(v256)
+    v234 = cast v218  : u32
+    v235 = add v234, 8  : u32
+    v236 = inttoptr v235  : *mut i32
+    v237 = load v236  : i32
+    br block31(v237)
 }
 
 pub fn _ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(i32, i32) {
@@ -406,97 +387,88 @@ block0(v0: i32, v1: i32):
     v7 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk4next17he250edbec5d87123E(v1)  : i32
     v8 = neq v7, v1  : i1
     v9 = cast v8  : i32
-    v10 = const.i32 0  : i32
-    v11 = neq v9, v10  : i1
-    condbr v11, block4, block5
+    v10 = neq v9, 0  : i1
+    condbr v10, block4, block5
 
 block1:
     ret 
 
-block2(v107: i32):
-    v72 = const.i32 0  : i32
-    v73 = eq v6, v72  : i1
-    v74 = cast v73  : i32
-    v75 = const.i32 0  : i32
-    v76 = neq v74, v75  : i1
-    condbr v76, block10, block11
+block2(v96: i32):
+    v65 = eq v6, 0  : i1
+    v66 = cast v65  : i32
+    v67 = neq v66, 0  : i1
+    condbr v67, block10, block11
 
 block3:
-    v39 = const.i32 16  : i32
-    v40 = add v1, v39  : i32
-    v41 = const.i32 0  : i32
-    v42 = neq v18, v41  : i1
-    v43 = select v42, v15, v40  : i32
-    br block7(v43, v25)
+    v36 = const.i32 16  : i32
+    v37 = add v1, v36  : i32
+    v38 = neq v17, 0  : i1
+    v39 = select v38, v14, v37  : i32
+    br block7(v39, v23)
 
 block4:
-    v29 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk4prev17h7a0f1d46544cc14aE(v1)  : i32
-    v30 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk4next17he250edbec5d87123E(v1)  : i32
-    v31 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v30)  : i32
-    v32 = cast v29  : u32
-    v33 = add v32, 12  : u32
-    v34 = inttoptr v33  : *mut i32
-    store v34, v31
-    v35 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v29)  : i32
-    v36 = cast v30  : u32
-    v37 = add v36, 8  : u32
-    v38 = inttoptr v37  : *mut i32
-    store v38, v35
-    br block2(v30)
+    v26 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk4prev17h7a0f1d46544cc14aE(v1)  : i32
+    v27 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk4next17he250edbec5d87123E(v1)  : i32
+    v28 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v27)  : i32
+    v29 = cast v26  : u32
+    v30 = add v29, 12  : u32
+    v31 = inttoptr v30  : *mut i32
+    store v31, v28
+    v32 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v26)  : i32
+    v33 = cast v27  : u32
+    v34 = add v33, 8  : u32
+    v35 = inttoptr v34  : *mut i32
+    store v35, v32
+    br block2(v27)
 
 block5:
-    v12 = const.i32 20  : i32
-    v13 = const.i32 16  : i32
-    v14 = const.i32 20  : i32
-    v15 = add v1, v14  : i32
-    v16 = cast v15  : u32
-    v17 = inttoptr v16  : *mut i32
-    v18 = load v17  : i32
-    v19 = const.i32 0  : i32
-    v20 = neq v18, v19  : i1
-    v21 = select v20, v12, v13  : i32
-    v22 = add v1, v21  : i32
-    v23 = cast v22  : u32
-    v24 = inttoptr v23  : *mut i32
-    v25 = load v24  : i32
-    v26 = const.i32 0  : i32
-    v27 = neq v25, v26  : i1
-    condbr v27, block3, block6
+    v11 = const.i32 20  : i32
+    v12 = const.i32 16  : i32
+    v13 = const.i32 20  : i32
+    v14 = add v1, v13  : i32
+    v15 = cast v14  : u32
+    v16 = inttoptr v15  : *mut i32
+    v17 = load v16  : i32
+    v18 = neq v17, 0  : i1
+    v19 = select v18, v11, v12  : i32
+    v20 = add v1, v19  : i32
+    v21 = cast v20  : u32
+    v22 = inttoptr v21  : *mut i32
+    v23 = load v22  : i32
+    v24 = neq v23, 0  : i1
+    condbr v24, block3, block6
 
 block6:
-    v28 = const.i32 0  : i32
-    br block2(v28)
+    v25 = const.i32 0  : i32
+    br block2(v25)
 
-block7(v44: i32, v45: i32):
-    v46 = const.i32 20  : i32
-    v47 = add v45, v46  : i32
-    v48 = const.i32 16  : i32
-    v49 = add v45, v48  : i32
-    v50 = cast v47  : u32
-    v51 = inttoptr v50  : *mut i32
-    v52 = load v51  : i32
-    v53 = const.i32 0  : i32
-    v54 = neq v52, v53  : i1
-    v55 = select v54, v47, v49  : i32
-    v56 = const.i32 20  : i32
-    v57 = const.i32 16  : i32
-    v58 = const.i32 0  : i32
-    v59 = neq v52, v58  : i1
-    v60 = select v59, v56, v57  : i32
-    v61 = add v45, v60  : i32
-    v62 = cast v61  : u32
-    v63 = inttoptr v62  : *mut i32
-    v64 = load v63  : i32
-    v65 = const.i32 0  : i32
-    v66 = neq v64, v65  : i1
-    condbr v66, block7(v55, v64), block9
+block7(v40: i32, v41: i32):
+    v42 = const.i32 20  : i32
+    v43 = add v41, v42  : i32
+    v44 = const.i32 16  : i32
+    v45 = add v41, v44  : i32
+    v46 = cast v43  : u32
+    v47 = inttoptr v46  : *mut i32
+    v48 = load v47  : i32
+    v49 = neq v48, 0  : i1
+    v50 = select v49, v43, v45  : i32
+    v51 = const.i32 20  : i32
+    v52 = const.i32 16  : i32
+    v53 = neq v48, 0  : i1
+    v54 = select v53, v51, v52  : i32
+    v55 = add v41, v54  : i32
+    v56 = cast v55  : u32
+    v57 = inttoptr v56  : *mut i32
+    v58 = load v57  : i32
+    v59 = neq v58, 0  : i1
+    condbr v59, block7(v50, v58), block9
 
 block8:
-    v67 = const.i32 0  : i32
-    v68 = cast v44  : u32
-    v69 = inttoptr v68  : *mut i32
-    store v69, v67
-    br block2(v45)
+    v60 = const.i32 0  : i32
+    v61 = cast v40  : u32
+    v62 = inttoptr v61  : *mut i32
+    store v62, v60
+    br block2(v41)
 
 block9:
     br block8
@@ -505,117 +477,109 @@ block10:
     br block1
 
 block11:
-    v81 = cast v1  : u32
-    v82 = add v81, 28  : u32
-    v83 = inttoptr v82  : *mut i32
-    v84 = load v83  : i32
-    v85 = const.i32 2  : i32
-    v86 = shl v84, v85  : i32
-    v87 = add v0, v86  : i32
-    v88 = cast v87  : u32
-    v89 = inttoptr v88  : *mut i32
-    v90 = load v89  : i32
-    v91 = eq v90, v79  : i1
-    v92 = cast v91  : i32
-    v93 = const.i32 0  : i32
-    v94 = neq v92, v93  : i1
-    condbr v94, block13, block14
+    v72 = cast v1  : u32
+    v73 = add v72, 28  : u32
+    v74 = inttoptr v73  : *mut i32
+    v75 = load v74  : i32
+    v76 = const.i32 2  : i32
+    v77 = shl v75, v76  : i32
+    v78 = add v0, v77  : i32
+    v79 = cast v78  : u32
+    v80 = inttoptr v79  : *mut i32
+    v81 = load v80  : i32
+    v82 = eq v81, v70  : i1
+    v83 = cast v82  : i32
+    v84 = neq v83, 0  : i1
+    condbr v84, block13, block14
 
 block12:
-    v128 = cast v107  : u32
-    v129 = add v128, 24  : u32
-    v130 = inttoptr v129  : *mut i32
-    store v130, v70
-    v132 = cast v79  : u32
-    v133 = add v132, 16  : u32
-    v134 = inttoptr v133  : *mut i32
-    v135 = load v134  : i32
-    v136 = const.i32 0  : i32
-    v137 = eq v135, v136  : i1
-    v138 = cast v137  : i32
-    v139 = const.i32 0  : i32
-    v140 = neq v138, v139  : i1
-    condbr v140, block17, block18
+    v115 = cast v96  : u32
+    v116 = add v115, 24  : u32
+    v117 = inttoptr v116  : *mut i32
+    store v117, v63
+    v119 = cast v70  : u32
+    v120 = add v119, 16  : u32
+    v121 = inttoptr v120  : *mut i32
+    v122 = load v121  : i32
+    v123 = eq v122, 0  : i1
+    v124 = cast v123  : i32
+    v125 = neq v124, 0  : i1
+    condbr v125, block17, block18
 
 block13:
-    v112 = cast v87  : u32
-    v113 = inttoptr v112  : *mut i32
-    store v113, v107
-    v114 = const.i32 0  : i32
-    v115 = neq v107, v114  : i1
-    condbr v115, block12, block16
+    v100 = cast v78  : u32
+    v101 = inttoptr v100  : *mut i32
+    store v101, v96
+    v102 = neq v96, 0  : i1
+    condbr v102, block12, block16
 
 block14:
-    v95 = const.i32 16  : i32
-    v96 = const.i32 20  : i32
-    v97 = cast v70  : u32
-    v98 = add v97, 16  : u32
-    v99 = inttoptr v98  : *mut i32
-    v100 = load v99  : i32
-    v101 = eq v100, v79  : i1
-    v102 = cast v101  : i32
-    v103 = const.i32 0  : i32
-    v104 = neq v102, v103  : i1
-    v105 = select v104, v95, v96  : i32
-    v106 = add v70, v105  : i32
-    v108 = cast v106  : u32
-    v109 = inttoptr v108  : *mut i32
-    store v109, v107
-    v110 = const.i32 0  : i32
-    v111 = neq v107, v110  : i1
-    condbr v111, block12, block15
+    v85 = const.i32 16  : i32
+    v86 = const.i32 20  : i32
+    v87 = cast v63  : u32
+    v88 = add v87, 16  : u32
+    v89 = inttoptr v88  : *mut i32
+    v90 = load v89  : i32
+    v91 = eq v90, v70  : i1
+    v92 = cast v91  : i32
+    v93 = neq v92, 0  : i1
+    v94 = select v93, v85, v86  : i32
+    v95 = add v63, v94  : i32
+    v97 = cast v95  : u32
+    v98 = inttoptr v97  : *mut i32
+    store v98, v96
+    v99 = neq v96, 0  : i1
+    condbr v99, block12, block15
 
 block15:
     br block10
 
 block16:
-    v116 = cast v77  : u32
-    v117 = add v116, 412  : u32
-    v118 = inttoptr v117  : *mut i32
-    v119 = load v118  : i32
-    v120 = const.i32 -2  : i32
-    v121 = shl v120, v84  : i32
-    v122 = band v119, v121  : i32
-    v123 = cast v77  : u32
-    v124 = add v123, 412  : u32
-    v125 = inttoptr v124  : *mut i32
-    store v125, v122
+    v103 = cast v68  : u32
+    v104 = add v103, 412  : u32
+    v105 = inttoptr v104  : *mut i32
+    v106 = load v105  : i32
+    v107 = const.i32 -2  : i32
+    v108 = shl v107, v75  : i32
+    v109 = band v106, v108  : i32
+    v110 = cast v68  : u32
+    v111 = add v110, 412  : u32
+    v112 = inttoptr v111  : *mut i32
+    store v112, v109
     ret 
 
 block17:
-    v148 = const.i32 20  : i32
-    v149 = add v131, v148  : i32
-    v150 = cast v149  : u32
-    v151 = inttoptr v150  : *mut i32
-    v152 = load v151  : i32
-    v153 = const.i32 0  : i32
-    v154 = eq v152, v153  : i1
-    v155 = cast v154  : i32
-    v156 = const.i32 0  : i32
-    v157 = neq v155, v156  : i1
-    condbr v157, block10, block19
+    v133 = const.i32 20  : i32
+    v134 = add v118, v133  : i32
+    v135 = cast v134  : u32
+    v136 = inttoptr v135  : *mut i32
+    v137 = load v136  : i32
+    v138 = eq v137, 0  : i1
+    v139 = cast v138  : i32
+    v140 = neq v139, 0  : i1
+    condbr v140, block10, block19
 
 block18:
-    v141 = cast v126  : u32
-    v142 = add v141, 16  : u32
-    v143 = inttoptr v142  : *mut i32
-    store v143, v135
-    v144 = cast v135  : u32
-    v145 = add v144, 24  : u32
-    v146 = inttoptr v145  : *mut i32
-    store v146, v126
+    v126 = cast v113  : u32
+    v127 = add v126, 16  : u32
+    v128 = inttoptr v127  : *mut i32
+    store v128, v122
+    v129 = cast v122  : u32
+    v130 = add v129, 24  : u32
+    v131 = inttoptr v130  : *mut i32
+    store v131, v113
     br block17
 
 block19:
-    v159 = const.i32 20  : i32
-    v160 = add v126, v159  : i32
-    v161 = cast v160  : u32
-    v162 = inttoptr v161  : *mut i32
-    store v162, v152
-    v163 = cast v152  : u32
-    v164 = add v163, 24  : u32
-    v165 = inttoptr v164  : *mut i32
-    store v165, v158
+    v142 = const.i32 20  : i32
+    v143 = add v113, v142  : i32
+    v144 = cast v143  : u32
+    v145 = inttoptr v144  : *mut i32
+    store v145, v137
+    v146 = cast v137  : u32
+    v147 = add v146, 24  : u32
+    v148 = inttoptr v147  : *mut i32
+    store v148, v141
     ret 
 }
 
@@ -628,174 +592,168 @@ block0(v0: i32, v1: i32, v2: i32):
     v7 = cast v5  : u32
     v8 = lt v6, v7  : i1
     v9 = cast v8  : i32
-    v10 = const.i32 0  : i32
-    v11 = neq v9, v10  : i1
-    condbr v11, block2(v4), block3
+    v10 = neq v9, 0  : i1
+    condbr v10, block2(v4), block3
 
 block1:
     ret 
 
-block2(v44: i32):
-    v40 = const.i64 0  : i64
-    v41 = cast v1  : u32
-    v42 = add v41, 16  : u32
-    v43 = inttoptr v42  : *mut i64
-    store v43, v40
-    v45 = cast v39  : u32
-    v46 = add v45, 28  : u32
-    v47 = inttoptr v46  : *mut i32
-    store v47, v44
-    v49 = const.i32 2  : i32
-    v50 = shl v44, v49  : i32
-    v51 = add v0, v50  : i32
-    v52 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v39)  : i32
-    v53 = cast v48  : u32
-    v54 = add v53, 412  : u32
-    v55 = inttoptr v54  : *mut i32
-    v56 = load v55  : i32
-    v57 = const.i32 1  : i32
-    v58 = shl v57, v44  : i32
-    v59 = band v56, v58  : i32
-    v60 = const.i32 0  : i32
-    v61 = eq v59, v60  : i1
-    v62 = cast v61  : i32
-    v63 = const.i32 0  : i32
-    v64 = neq v62, v63  : i1
-    condbr v64, block6, block7
+block2(v42: i32):
+    v38 = const.i64 0  : i64
+    v39 = cast v1  : u32
+    v40 = add v39, 16  : u32
+    v41 = inttoptr v40  : *mut i64
+    store v41, v38
+    v43 = cast v37  : u32
+    v44 = add v43, 28  : u32
+    v45 = inttoptr v44  : *mut i32
+    store v45, v42
+    v47 = const.i32 2  : i32
+    v48 = shl v42, v47  : i32
+    v49 = add v0, v48  : i32
+    v50 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v37)  : i32
+    v51 = cast v46  : u32
+    v52 = add v51, 412  : u32
+    v53 = inttoptr v52  : *mut i32
+    v54 = load v53  : i32
+    v55 = const.i32 1  : i32
+    v56 = shl v55, v42  : i32
+    v57 = band v54, v56  : i32
+    v58 = eq v57, 0  : i1
+    v59 = cast v58  : i32
+    v60 = neq v59, 0  : i1
+    condbr v60, block6, block7
 
 block3:
-    v12 = const.i32 31  : i32
-    v13 = const.i32 16777215  : i32
-    v14 = cast v2  : u32
-    v15 = cast v13  : u32
-    v16 = gt v14, v15  : i1
-    v17 = cast v16  : i32
-    v18 = const.i32 0  : i32
-    v19 = neq v17, v18  : i1
-    condbr v19, block2(v12), block4
+    v11 = const.i32 31  : i32
+    v12 = const.i32 16777215  : i32
+    v13 = cast v2  : u32
+    v14 = cast v12  : u32
+    v15 = gt v13, v14  : i1
+    v16 = cast v15  : i32
+    v17 = neq v16, 0  : i1
+    condbr v17, block2(v11), block4
 
 block4:
-    v20 = const.i32 6  : i32
-    v21 = const.i32 8  : i32
-    v22 = cast v2  : u32
-    v23 = cast v21  : u32
-    v24 = shr v22, v23  : u32
-    v25 = cast v24  : i32
-    v26 = popcnt v25  : i32
-    v27 = sub v20, v26  : i32
-    v28 = cast v2  : u32
-    v29 = cast v27  : u32
-    v30 = shr v28, v29  : u32
-    v31 = cast v30  : i32
+    v18 = const.i32 6  : i32
+    v19 = const.i32 8  : i32
+    v20 = cast v2  : u32
+    v21 = cast v19  : u32
+    v22 = shr v20, v21  : u32
+    v23 = cast v22  : i32
+    v24 = popcnt v23  : i32
+    v25 = sub v18, v24  : i32
+    v26 = cast v2  : u32
+    v27 = cast v25  : u32
+    v28 = shr v26, v27  : u32
+    v29 = cast v28  : i32
+    v30 = const.i32 1  : i32
+    v31 = band v29, v30  : i32
     v32 = const.i32 1  : i32
-    v33 = band v31, v32  : i32
-    v34 = const.i32 1  : i32
-    v35 = shl v26, v34  : i32
-    v36 = sub v33, v35  : i32
-    v37 = const.i32 62  : i32
-    v38 = add v36, v37  : i32
-    br block2(v38)
+    v33 = shl v24, v32  : i32
+    v34 = sub v31, v33  : i32
+    v35 = const.i32 62  : i32
+    v36 = add v34, v35  : i32
+    br block2(v36)
 
-block5(v134: i32):
-    v135 = cast v134  : u32
-    v136 = add v135, 8  : u32
-    v137 = inttoptr v136  : *mut i32
-    store v137, v134
-    v138 = cast v134  : u32
-    v139 = add v138, 12  : u32
-    v140 = inttoptr v139  : *mut i32
-    store v140, v134
+block5(v128: i32):
+    v129 = cast v128  : u32
+    v130 = add v129, 8  : u32
+    v131 = inttoptr v130  : *mut i32
+    store v131, v128
+    v132 = cast v128  : u32
+    v133 = add v132, 12  : u32
+    v134 = inttoptr v133  : *mut i32
+    store v134, v128
     br block1
 
 block6:
-    v125 = bor v56, v58  : i32
-    v126 = cast v48  : u32
-    v127 = add v126, 412  : u32
-    v128 = inttoptr v127  : *mut i32
-    store v128, v125
-    v129 = cast v39  : u32
-    v130 = add v129, 24  : u32
-    v131 = inttoptr v130  : *mut i32
-    store v131, v51
-    v132 = cast v51  : u32
-    v133 = inttoptr v132  : *mut i32
-    store v133, v39
-    br block5(v52)
+    v119 = bor v54, v56  : i32
+    v120 = cast v46  : u32
+    v121 = add v120, 412  : u32
+    v122 = inttoptr v121  : *mut i32
+    store v122, v119
+    v123 = cast v37  : u32
+    v124 = add v123, 24  : u32
+    v125 = inttoptr v124  : *mut i32
+    store v125, v49
+    v126 = cast v49  : u32
+    v127 = inttoptr v126  : *mut i32
+    store v127, v37
+    br block5(v50)
 
 block7:
-    v65 = cast v51  : u32
-    v66 = inttoptr v65  : *mut i32
-    v67 = load v66  : i32
-    v69 = call noname::_ZN8dlmalloc8dlmalloc24leftshift_for_tree_index17h31d064fdd867f502E(v44)  : i32
-    v70 = shl v2, v69  : i32
-    br block8(v67, v70)
+    v61 = cast v49  : u32
+    v62 = inttoptr v61  : *mut i32
+    v63 = load v62  : i32
+    v65 = call noname::_ZN8dlmalloc8dlmalloc24leftshift_for_tree_index17h31d064fdd867f502E(v42)  : i32
+    v66 = shl v2, v65  : i32
+    br block8(v63, v66)
 
-block8(v71: i32, v102: i32):
-    v72 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v71)  : i32
-    v73 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v72)  : i32
-    v75 = neq v73, v74  : i1
-    v76 = cast v75  : i32
-    v77 = const.i32 0  : i32
-    v78 = neq v76, v77  : i1
-    condbr v78, block10, block11
+block8(v67: i32, v97: i32):
+    v68 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v67)  : i32
+    v69 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v68)  : i32
+    v71 = neq v69, v70  : i1
+    v72 = cast v71  : i32
+    v73 = neq v72, 0  : i1
+    condbr v73, block10, block11
 
 block9:
-    v120 = cast v114  : u32
-    v121 = inttoptr v120  : *mut i32
-    store v121, v97
-    v122 = cast v97  : u32
-    v123 = add v122, 24  : u32
-    v124 = inttoptr v123  : *mut i32
-    store v124, v71
-    br block5(v84)
+    v114 = cast v109  : u32
+    v115 = inttoptr v114  : *mut i32
+    store v115, v92
+    v116 = cast v92  : u32
+    v117 = add v116, 24  : u32
+    v118 = inttoptr v117  : *mut i32
+    store v118, v67
+    br block5(v79)
 
 block10:
-    v103 = const.i32 29  : i32
-    v104 = cast v102  : u32
-    v105 = cast v103  : u32
-    v106 = shr v104, v105  : u32
-    v107 = cast v106  : i32
-    v108 = const.i32 1  : i32
-    v109 = shl v102, v108  : i32
-    v110 = const.i32 4  : i32
-    v111 = band v107, v110  : i32
-    v112 = add v71, v111  : i32
-    v113 = const.i32 16  : i32
-    v114 = add v112, v113  : i32
-    v115 = cast v114  : u32
-    v116 = inttoptr v115  : *mut i32
-    v117 = load v116  : i32
-    v118 = const.i32 0  : i32
-    v119 = neq v117, v118  : i1
-    condbr v119, block8(v117, v109), block12
+    v98 = const.i32 29  : i32
+    v99 = cast v97  : u32
+    v100 = cast v98  : u32
+    v101 = shr v99, v100  : u32
+    v102 = cast v101  : i32
+    v103 = const.i32 1  : i32
+    v104 = shl v97, v103  : i32
+    v105 = const.i32 4  : i32
+    v106 = band v102, v105  : i32
+    v107 = add v67, v106  : i32
+    v108 = const.i32 16  : i32
+    v109 = add v107, v108  : i32
+    v110 = cast v109  : u32
+    v111 = inttoptr v110  : *mut i32
+    v112 = load v111  : i32
+    v113 = neq v112, 0  : i1
+    condbr v113, block8(v112, v104), block12
 
 block11:
-    v79 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v71)  : i32
-    v80 = cast v79  : u32
-    v81 = add v80, 8  : u32
+    v74 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v67)  : i32
+    v75 = cast v74  : u32
+    v76 = add v75, 8  : u32
+    v77 = inttoptr v76  : *mut i32
+    v78 = load v77  : i32
+    v80 = cast v78  : u32
+    v81 = add v80, 12  : u32
     v82 = inttoptr v81  : *mut i32
-    v83 = load v82  : i32
-    v85 = cast v83  : u32
-    v86 = add v85, 12  : u32
-    v87 = inttoptr v86  : *mut i32
-    store v87, v84
-    v88 = cast v79  : u32
-    v89 = add v88, 8  : u32
-    v90 = inttoptr v89  : *mut i32
-    store v90, v84
-    v91 = cast v84  : u32
-    v92 = add v91, 12  : u32
-    v93 = inttoptr v92  : *mut i32
-    store v93, v79
-    v94 = cast v84  : u32
-    v95 = add v94, 8  : u32
+    store v82, v79
+    v83 = cast v74  : u32
+    v84 = add v83, 8  : u32
+    v85 = inttoptr v84  : *mut i32
+    store v85, v79
+    v86 = cast v79  : u32
+    v87 = add v86, 12  : u32
+    v88 = inttoptr v87  : *mut i32
+    store v88, v74
+    v89 = cast v79  : u32
+    v90 = add v89, 8  : u32
+    v91 = inttoptr v90  : *mut i32
+    store v91, v78
+    v93 = const.i32 0  : i32
+    v94 = cast v92  : u32
+    v95 = add v94, 24  : u32
     v96 = inttoptr v95  : *mut i32
-    store v96, v83
-    v98 = const.i32 0  : i32
-    v99 = cast v97  : u32
-    v100 = add v99, 24  : u32
-    v101 = inttoptr v100  : *mut i32
-    store v101, v98
+    store v96, v93
     ret 
 
 block12:
@@ -810,179 +768,169 @@ block0(v0: i32):
     v5 = cast v4  : u32
     v6 = inttoptr v5  : *mut i32
     v7 = load v6  : i32
-    v8 = const.i32 0  : i32
-    v9 = neq v7, v8  : i1
-    condbr v9, block3, block4
+    v8 = neq v7, 0  : i1
+    condbr v8, block3, block4
 
 block1(v1: i32):
     ret v1
 
-block2(v135: i32, v136: i32, v149: i32):
-    v137 = const.i32 4095  : i32
-    v138 = const.i32 4095  : i32
-    v139 = cast v136  : u32
-    v140 = cast v138  : u32
-    v141 = gt v139, v140  : i1
-    v142 = cast v141  : i32
-    v143 = const.i32 0  : i32
-    v144 = neq v142, v143  : i1
-    v145 = select v144, v136, v137  : i32
-    v146 = cast v135  : u32
-    v147 = add v146, 448  : u32
-    v148 = inttoptr v147  : *mut i32
-    store v148, v145
-    br block1(v149)
+block2(v126: i32, v127: i32, v139: i32):
+    v128 = const.i32 4095  : i32
+    v129 = const.i32 4095  : i32
+    v130 = cast v127  : u32
+    v131 = cast v129  : u32
+    v132 = gt v130, v131  : i1
+    v133 = cast v132  : i32
+    v134 = neq v133, 0  : i1
+    v135 = select v134, v127, v128  : i32
+    v136 = cast v126  : u32
+    v137 = add v136, 448  : u32
+    v138 = inttoptr v137  : *mut i32
+    store v138, v135
+    br block1(v139)
 
 block3:
-    v12 = const.i32 128  : i32
-    v13 = add v0, v12  : i32
+    v11 = const.i32 128  : i32
+    v12 = add v0, v11  : i32
+    v13 = const.i32 0  : i32
     v14 = const.i32 0  : i32
-    v15 = const.i32 0  : i32
-    br block5(v7, v0, v13, v14, v15)
+    br block5(v7, v0, v12, v13, v14)
 
 block4:
+    v9 = const.i32 0  : i32
     v10 = const.i32 0  : i32
-    v11 = const.i32 0  : i32
-    br block2(v0, v10, v11)
+    br block2(v0, v9, v10)
 
-block5(v16: i32, v28: i32, v110: i32, v116: i32, v122: i32):
-    v17 = cast v16  : u32
-    v18 = add v17, 8  : u32
-    v19 = inttoptr v18  : *mut i32
-    v20 = load v19  : i32
-    v21 = cast v16  : u32
-    v22 = add v21, 4  : u32
-    v23 = inttoptr v22  : *mut i32
-    v24 = load v23  : i32
-    v25 = cast v16  : u32
-    v26 = inttoptr v25  : *mut i32
-    v27 = load v26  : i32
-    v29 = cast v16  : u32
-    v30 = add v29, 12  : u32
-    v31 = inttoptr v30  : *mut i32
-    v32 = load v31  : i32
-    v33 = const.i32 1  : i32
+block5(v15: i32, v27: i32, v102: i32, v108: i32, v114: i32):
+    v16 = cast v15  : u32
+    v17 = add v16, 8  : u32
+    v18 = inttoptr v17  : *mut i32
+    v19 = load v18  : i32
+    v20 = cast v15  : u32
+    v21 = add v20, 4  : u32
+    v22 = inttoptr v21  : *mut i32
+    v23 = load v22  : i32
+    v24 = cast v15  : u32
+    v25 = inttoptr v24  : *mut i32
+    v26 = load v25  : i32
+    v28 = cast v15  : u32
+    v29 = add v28, 12  : u32
+    v30 = inttoptr v29  : *mut i32
+    v31 = load v30  : i32
+    v32 = const.i32 1  : i32
+    v33 = cast v31  : u32
     v34 = cast v32  : u32
-    v35 = cast v33  : u32
-    v36 = shr v34, v35  : u32
-    v37 = cast v36  : i32
-    v38 = call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$16can_release_part17h43bfb7d8666fcc31E(v28, v37)  : i32
-    v39 = const.i32 0  : i32
-    v40 = eq v38, v39  : i1
-    v41 = cast v40  : i32
-    v42 = const.i32 0  : i32
-    v43 = neq v41, v42  : i1
-    condbr v43, block8(v122, v20, v28, v116), block9
+    v35 = shr v33, v34  : u32
+    v36 = cast v35  : i32
+    v37 = call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$16can_release_part17h43bfb7d8666fcc31E(v27, v36)  : i32
+    v38 = eq v37, 0  : i1
+    v39 = cast v38  : i32
+    v40 = neq v39, 0  : i1
+    condbr v40, block8(v114, v19, v27, v108), block9
 
 block6:
-    br block2(v130, v125, v133)
+    br block2(v121, v117, v124)
 
-block7(v120: i32, v126: i32, v130: i32, v132: i32, v133: i32):
-    v124 = const.i32 1  : i32
-    v125 = add v120, v124  : i32
-    v128 = const.i32 0  : i32
-    v129 = neq v126, v128  : i1
-    condbr v129, block5(v126, v130, v132, v133, v125), block18
+block7(v112: i32, v118: i32, v121: i32, v123: i32, v124: i32):
+    v116 = const.i32 1  : i32
+    v117 = add v112, v116  : i32
+    v120 = neq v118, 0  : i1
+    condbr v120, block5(v118, v121, v123, v124, v117), block18
 
-block8(v123: i32, v127: i32, v131: i32, v134: i32):
-    br block7(v123, v127, v131, v16, v134)
+block8(v115: i32, v119: i32, v122: i32, v125: i32):
+    br block7(v115, v119, v122, v15, v125)
 
 block9:
-    v44 = call noname::_ZN8dlmalloc8dlmalloc7Segment9is_extern17h6f6db2c70b891fd9E(v16)  : i32
-    v45 = const.i32 0  : i32
-    v46 = neq v44, v45  : i1
-    condbr v46, block8(v122, v20, v28, v116), block10
+    v41 = call noname::_ZN8dlmalloc8dlmalloc7Segment9is_extern17h6f6db2c70b891fd9E(v15)  : i32
+    v42 = neq v41, 0  : i1
+    condbr v42, block8(v114, v19, v27, v108), block10
 
 block10:
-    v47 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v27)  : i32
-    v48 = const.i32 8  : i32
-    v49 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v47, v48)  : i32
-    v50 = sub v49, v47  : i32
-    v51 = add v27, v50  : i32
-    v52 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v51)  : i32
-    v53 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
-    v54 = const.i32 8  : i32
-    v55 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v53, v54)  : i32
-    v56 = const.i32 20  : i32
-    v57 = const.i32 8  : i32
-    v58 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v56, v57)  : i32
-    v59 = const.i32 16  : i32
-    v60 = const.i32 8  : i32
-    v61 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v59, v60)  : i32
-    v62 = call noname::_ZN8dlmalloc8dlmalloc5Chunk5inuse17h2d327e4c36b84dfeE(v51)  : i32
-    v63 = const.i32 0  : i32
-    v64 = neq v62, v63  : i1
-    condbr v64, block8(v122, v20, v28, v116), block11
+    v43 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v26)  : i32
+    v44 = const.i32 8  : i32
+    v45 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v43, v44)  : i32
+    v46 = sub v45, v43  : i32
+    v47 = add v26, v46  : i32
+    v48 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v47)  : i32
+    v49 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v50 = const.i32 8  : i32
+    v51 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v49, v50)  : i32
+    v52 = const.i32 20  : i32
+    v53 = const.i32 8  : i32
+    v54 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v52, v53)  : i32
+    v55 = const.i32 16  : i32
+    v56 = const.i32 8  : i32
+    v57 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v55, v56)  : i32
+    v58 = call noname::_ZN8dlmalloc8dlmalloc5Chunk5inuse17h2d327e4c36b84dfeE(v47)  : i32
+    v59 = neq v58, 0  : i1
+    condbr v59, block8(v114, v19, v27, v108), block11
 
 block11:
-    v65 = add v51, v52  : i32
-    v66 = add v53, v24  : i32
-    v67 = add v55, v58  : i32
-    v68 = add v67, v61  : i32
-    v69 = sub v66, v68  : i32
-    v70 = add v27, v69  : i32
-    v71 = cast v65  : u32
-    v72 = cast v70  : u32
-    v73 = lt v71, v72  : i1
-    v74 = cast v73  : i32
-    v75 = const.i32 0  : i32
-    v76 = neq v74, v75  : i1
-    condbr v76, block8(v122, v20, v28, v116), block12
+    v60 = add v47, v48  : i32
+    v61 = add v49, v23  : i32
+    v62 = add v51, v54  : i32
+    v63 = add v62, v57  : i32
+    v64 = sub v61, v63  : i32
+    v65 = add v26, v64  : i32
+    v66 = cast v60  : u32
+    v67 = cast v65  : u32
+    v68 = lt v66, v67  : i1
+    v69 = cast v68  : i32
+    v70 = neq v69, 0  : i1
+    condbr v70, block8(v114, v19, v27, v108), block12
 
 block12:
-    v77 = cast v28  : u32
-    v78 = add v77, 424  : u32
-    v79 = inttoptr v78  : *mut i32
-    v80 = load v79  : i32
-    v81 = eq v51, v80  : i1
-    v82 = cast v81  : i32
-    v83 = const.i32 0  : i32
-    v84 = neq v82, v83  : i1
-    condbr v84, block14, block15
+    v71 = cast v27  : u32
+    v72 = add v71, 424  : u32
+    v73 = inttoptr v72  : *mut i32
+    v74 = load v73  : i32
+    v75 = eq v47, v74  : i1
+    v76 = cast v75  : i32
+    v77 = neq v76, 0  : i1
+    condbr v77, block14, block15
 
 block13:
-    v96 = call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$4free17h993c5f05ba1214bcE(v28, v27, v24)  : i32
-    v97 = const.i32 0  : i32
-    v98 = neq v96, v97  : i1
-    condbr v98, block16, block17
+    v89 = call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$4free17h993c5f05ba1214bcE(v27, v26, v23)  : i32
+    v90 = neq v89, 0  : i1
+    condbr v90, block16, block17
 
 block14:
-    v85 = const.i32 0  : i32
-    v86 = cast v28  : u32
-    v87 = add v86, 416  : u32
-    v88 = inttoptr v87  : *mut i32
-    store v88, v85
-    v89 = const.i32 0  : i32
-    v90 = cast v28  : u32
-    v91 = add v90, 424  : u32
-    v92 = inttoptr v91  : *mut i32
-    store v92, v89
+    v78 = const.i32 0  : i32
+    v79 = cast v27  : u32
+    v80 = add v79, 416  : u32
+    v81 = inttoptr v80  : *mut i32
+    store v81, v78
+    v82 = const.i32 0  : i32
+    v83 = cast v27  : u32
+    v84 = add v83, 424  : u32
+    v85 = inttoptr v84  : *mut i32
+    store v85, v82
     br block13
 
 block15:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v28, v51)
+    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v27, v47)
     br block13
 
 block16:
-    v101 = cast v93  : u32
-    v102 = add v101, 432  : u32
-    v103 = inttoptr v102  : *mut i32
-    v104 = load v103  : i32
-    v105 = sub v104, v95  : i32
-    v106 = cast v93  : u32
-    v107 = add v106, 432  : u32
-    v108 = inttoptr v107  : *mut i32
-    store v108, v105
-    v112 = cast v110  : u32
-    v113 = add v112, 8  : u32
-    v114 = inttoptr v113  : *mut i32
-    store v114, v20
-    v117 = add v95, v116  : i32
-    br block7(v122, v111, v93, v109, v117)
+    v93 = cast v86  : u32
+    v94 = add v93, 432  : u32
+    v95 = inttoptr v94  : *mut i32
+    v96 = load v95  : i32
+    v97 = sub v96, v88  : i32
+    v98 = cast v86  : u32
+    v99 = add v98, 432  : u32
+    v100 = inttoptr v99  : *mut i32
+    store v100, v97
+    v104 = cast v102  : u32
+    v105 = add v104, 8  : u32
+    v106 = inttoptr v105  : *mut i32
+    store v106, v19
+    v109 = add v88, v108  : i32
+    br block7(v114, v103, v86, v101, v109)
 
 block17:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E(v93, v51, v52)
-    br block8(v121, v111, v93, v115)
+    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E(v86, v47, v48)
+    br block8(v113, v103, v86, v107)
 
 block18:
     br block6
@@ -995,9 +943,8 @@ block0(v0: i32, v1: i32):
     v4 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v3)  : i32
     v5 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v3, v4)  : i32
     v6 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6pinuse17h92d5107047b03ba7E(v3)  : i32
-    v7 = const.i32 0  : i32
-    v8 = neq v6, v7  : i1
-    condbr v8, block3(v3, v4), block4
+    v7 = neq v6, 0  : i1
+    condbr v7, block3(v3, v4), block4
 
 block1:
     ret 
@@ -1005,476 +952,448 @@ block1:
 block2:
     br block1
 
-block3(v104: i32, v105: i32):
-    v98 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6cinuse17h58499de57c2d37e2E(v5)  : i32
-    v99 = const.i32 0  : i32
-    v100 = eq v98, v99  : i1
-    v101 = cast v100  : i32
-    v102 = const.i32 0  : i32
-    v103 = neq v101, v102  : i1
-    condbr v103, block16, block17
+block3(v94: i32, v95: i32):
+    v90 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6cinuse17h58499de57c2d37e2E(v5)  : i32
+    v91 = eq v90, 0  : i1
+    v92 = cast v91  : i32
+    v93 = neq v92, 0  : i1
+    condbr v93, block16, block17
 
 block4:
-    v9 = cast v3  : u32
-    v10 = inttoptr v9  : *mut i32
-    v11 = load v10  : i32
-    v12 = call noname::_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(v3)  : i32
-    v13 = const.i32 0  : i32
-    v14 = neq v12, v13  : i1
-    condbr v14, block5, block6
+    v8 = cast v3  : u32
+    v9 = inttoptr v8  : *mut i32
+    v10 = load v9  : i32
+    v11 = call noname::_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(v3)  : i32
+    v12 = neq v11, 0  : i1
+    condbr v12, block5, block6
 
 block5:
-    v79 = sub v3, v11  : i32
-    v80 = add v4, v11  : i32
-    v81 = const.i32 16  : i32
-    v82 = add v80, v81  : i32
-    v83 = call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$4free17h993c5f05ba1214bcE(v0, v79, v82)  : i32
-    v84 = const.i32 0  : i32
-    v85 = eq v83, v84  : i1
-    v86 = cast v85  : i32
-    v87 = const.i32 0  : i32
-    v88 = neq v86, v87  : i1
-    condbr v88, block2, block14
+    v73 = sub v3, v10  : i32
+    v74 = add v4, v10  : i32
+    v75 = const.i32 16  : i32
+    v76 = add v74, v75  : i32
+    v77 = call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$4free17h993c5f05ba1214bcE(v0, v73, v76)  : i32
+    v78 = eq v77, 0  : i1
+    v79 = cast v78  : i32
+    v80 = neq v79, 0  : i1
+    condbr v80, block2, block14
 
 block6:
-    v15 = add v11, v4  : i32
-    v16 = call noname::_ZN8dlmalloc8dlmalloc5Chunk12minus_offset17h7c3eec81761249d9E(v3, v11)  : i32
-    v17 = cast v0  : u32
-    v18 = add v17, 424  : u32
-    v19 = inttoptr v18  : *mut i32
-    v20 = load v19  : i32
-    v21 = neq v16, v20  : i1
-    v22 = cast v21  : i32
-    v23 = const.i32 0  : i32
-    v24 = neq v22, v23  : i1
-    condbr v24, block7, block8
+    v13 = add v10, v4  : i32
+    v14 = call noname::_ZN8dlmalloc8dlmalloc5Chunk12minus_offset17h7c3eec81761249d9E(v3, v10)  : i32
+    v15 = cast v0  : u32
+    v16 = add v15, 424  : u32
+    v17 = inttoptr v16  : *mut i32
+    v18 = load v17  : i32
+    v19 = neq v14, v18  : i1
+    v20 = cast v19  : i32
+    v21 = neq v20, 0  : i1
+    condbr v21, block7, block8
 
 block7:
-    v39 = const.i32 256  : i32
-    v40 = cast v11  : u32
-    v41 = cast v39  : u32
-    v42 = lt v40, v41  : i1
-    v43 = cast v42  : i32
-    v44 = const.i32 0  : i32
-    v45 = neq v43, v44  : i1
-    condbr v45, block10, block11
+    v35 = const.i32 256  : i32
+    v36 = cast v10  : u32
+    v37 = cast v35  : u32
+    v38 = lt v36, v37  : i1
+    v39 = cast v38  : i32
+    v40 = neq v39, 0  : i1
+    condbr v40, block10, block11
 
 block8:
-    v25 = cast v5  : u32
-    v26 = add v25, 4  : u32
-    v27 = inttoptr v26  : *mut i32
-    v28 = load v27  : i32
-    v29 = const.i32 3  : i32
-    v30 = band v28, v29  : i32
-    v31 = const.i32 3  : i32
-    v32 = neq v30, v31  : i1
-    v33 = cast v32  : i32
-    v34 = const.i32 0  : i32
-    v35 = neq v33, v34  : i1
-    condbr v35, block3(v16, v15), block9
+    v22 = cast v5  : u32
+    v23 = add v22, 4  : u32
+    v24 = inttoptr v23  : *mut i32
+    v25 = load v24  : i32
+    v26 = const.i32 3  : i32
+    v27 = band v25, v26  : i32
+    v28 = const.i32 3  : i32
+    v29 = neq v27, v28  : i1
+    v30 = cast v29  : i32
+    v31 = neq v30, 0  : i1
+    condbr v31, block3(v14, v13), block9
 
 block9:
-    v36 = cast v0  : u32
-    v37 = add v36, 416  : u32
-    v38 = inttoptr v37  : *mut i32
-    store v38, v15
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E(v16, v15, v5)
+    v32 = cast v0  : u32
+    v33 = add v32, 416  : u32
+    v34 = inttoptr v33  : *mut i32
+    store v34, v13
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E(v14, v13, v5)
     ret 
 
 block10:
-    v46 = cast v16  : u32
-    v47 = add v46, 12  : u32
-    v48 = inttoptr v47  : *mut i32
-    v49 = load v48  : i32
-    v50 = cast v16  : u32
-    v51 = add v50, 8  : u32
-    v52 = inttoptr v51  : *mut i32
-    v53 = load v52  : i32
-    v54 = eq v49, v53  : i1
-    v55 = cast v54  : i32
-    v56 = const.i32 0  : i32
-    v57 = neq v55, v56  : i1
-    condbr v57, block12, block13
+    v41 = cast v14  : u32
+    v42 = add v41, 12  : u32
+    v43 = inttoptr v42  : *mut i32
+    v44 = load v43  : i32
+    v45 = cast v14  : u32
+    v46 = add v45, 8  : u32
+    v47 = inttoptr v46  : *mut i32
+    v48 = load v47  : i32
+    v49 = eq v44, v48  : i1
+    v50 = cast v49  : i32
+    v51 = neq v50, 0  : i1
+    condbr v51, block12, block13
 
 block11:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v0, v16)
-    br block3(v16, v15)
+    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v0, v14)
+    br block3(v14, v13)
 
 block12:
-    v64 = cast v0  : u32
-    v65 = add v64, 408  : u32
-    v66 = inttoptr v65  : *mut i32
-    v67 = load v66  : i32
-    v68 = const.i32 -2  : i32
-    v69 = const.i32 3  : i32
-    v70 = cast v11  : u32
-    v71 = cast v69  : u32
-    v72 = shr v70, v71  : u32
-    v73 = cast v72  : i32
-    v74 = shl v68, v73  : i32
-    v75 = band v67, v74  : i32
-    v76 = cast v0  : u32
-    v77 = add v76, 408  : u32
-    v78 = inttoptr v77  : *mut i32
-    store v78, v75
-    br block3(v16, v15)
+    v58 = cast v0  : u32
+    v59 = add v58, 408  : u32
+    v60 = inttoptr v59  : *mut i32
+    v61 = load v60  : i32
+    v62 = const.i32 -2  : i32
+    v63 = const.i32 3  : i32
+    v64 = cast v10  : u32
+    v65 = cast v63  : u32
+    v66 = shr v64, v65  : u32
+    v67 = cast v66  : i32
+    v68 = shl v62, v67  : i32
+    v69 = band v61, v68  : i32
+    v70 = cast v0  : u32
+    v71 = add v70, 408  : u32
+    v72 = inttoptr v71  : *mut i32
+    store v72, v69
+    br block3(v14, v13)
 
 block13:
-    v58 = cast v53  : u32
-    v59 = add v58, 12  : u32
-    v60 = inttoptr v59  : *mut i32
-    store v60, v49
-    v61 = cast v49  : u32
-    v62 = add v61, 8  : u32
-    v63 = inttoptr v62  : *mut i32
-    store v63, v53
-    br block3(v16, v15)
+    v52 = cast v48  : u32
+    v53 = add v52, 12  : u32
+    v54 = inttoptr v53  : *mut i32
+    store v54, v44
+    v55 = cast v44  : u32
+    v56 = add v55, 8  : u32
+    v57 = inttoptr v56  : *mut i32
+    store v57, v48
+    br block3(v14, v13)
 
 block14:
-    v89 = cast v0  : u32
-    v90 = add v89, 432  : u32
-    v91 = inttoptr v90  : *mut i32
-    v92 = load v91  : i32
-    v93 = sub v92, v82  : i32
-    v94 = cast v0  : u32
-    v95 = add v94, 432  : u32
-    v96 = inttoptr v95  : *mut i32
-    store v96, v93
+    v81 = cast v0  : u32
+    v82 = add v81, 432  : u32
+    v83 = inttoptr v82  : *mut i32
+    v84 = load v83  : i32
+    v85 = sub v84, v76  : i32
+    v86 = cast v0  : u32
+    v87 = add v86, 432  : u32
+    v88 = inttoptr v87  : *mut i32
+    store v88, v85
     ret 
 
-block15(v513: i32, v521: i32, v522: i32):
-    v514 = const.i32 256  : i32
-    v515 = cast v513  : u32
-    v516 = cast v514  : u32
-    v517 = lt v515, v516  : i1
-    v518 = cast v517  : i32
-    v519 = const.i32 0  : i32
-    v520 = neq v518, v519  : i1
-    condbr v520, block55, block56
+block15(v474: i32, v481: i32, v482: i32):
+    v475 = const.i32 256  : i32
+    v476 = cast v474  : u32
+    v477 = cast v475  : u32
+    v478 = lt v476, v477  : i1
+    v479 = cast v478  : i32
+    v480 = neq v479, 0  : i1
+    condbr v480, block55, block56
 
 block16:
-    v107 = cast v0  : u32
-    v108 = add v107, 428  : u32
-    v109 = inttoptr v108  : *mut i32
-    v110 = load v109  : i32
-    v111 = eq v97, v110  : i1
-    v112 = cast v111  : i32
-    v113 = const.i32 0  : i32
-    v114 = neq v112, v113  : i1
-    condbr v114, block21, block22
+    v97 = cast v0  : u32
+    v98 = add v97, 428  : u32
+    v99 = inttoptr v98  : *mut i32
+    v100 = load v99  : i32
+    v101 = eq v89, v100  : i1
+    v102 = cast v101  : i32
+    v103 = neq v102, 0  : i1
+    condbr v103, block21, block22
 
 block17:
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E(v104, v105, v97)
-    br block15(v105, v106, v104)
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E(v94, v95, v89)
+    br block15(v95, v96, v94)
 
 block18:
-    v224 = cast v106  : u32
-    v225 = add v224, 440  : u32
-    v226 = inttoptr v225  : *mut i32
-    v227 = load v226  : i32
-    v228 = cast v186  : u32
-    v229 = cast v227  : u32
-    v230 = lte v228, v229  : i1
-    v231 = cast v230  : i32
-    v232 = const.i32 0  : i32
-    v233 = neq v231, v232  : i1
-    condbr v233, block2, block31
+    v208 = cast v96  : u32
+    v209 = add v208, 440  : u32
+    v210 = inttoptr v209  : *mut i32
+    v211 = load v210  : i32
+    v212 = cast v171  : u32
+    v213 = cast v211  : u32
+    v214 = lte v212, v213  : i1
+    v215 = cast v214  : i32
+    v216 = neq v215, 0  : i1
+    condbr v216, block2, block31
 
 block19:
-    v214 = const.i32 0  : i32
-    v215 = cast v106  : u32
-    v216 = add v215, 416  : u32
-    v217 = inttoptr v216  : *mut i32
-    store v217, v214
-    v218 = const.i32 0  : i32
-    v219 = cast v106  : u32
-    v220 = add v219, 424  : u32
-    v221 = inttoptr v220  : *mut i32
-    store v221, v218
+    v198 = const.i32 0  : i32
+    v199 = cast v96  : u32
+    v200 = add v199, 416  : u32
+    v201 = inttoptr v200  : *mut i32
+    store v201, v198
+    v202 = const.i32 0  : i32
+    v203 = cast v96  : u32
+    v204 = add v203, 424  : u32
+    v205 = inttoptr v204  : *mut i32
+    store v205, v202
     br block18
 
 block20:
-    v203 = cast v106  : u32
-    v204 = add v203, 424  : u32
-    v205 = inttoptr v204  : *mut i32
-    store v205, v104
-    v206 = cast v106  : u32
-    v207 = add v206, 416  : u32
-    v208 = inttoptr v207  : *mut i32
-    v209 = load v208  : i32
-    v210 = add v209, v105  : i32
-    v211 = cast v106  : u32
-    v212 = add v211, 416  : u32
-    v213 = inttoptr v212  : *mut i32
-    store v213, v210
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v104, v210)
+    v187 = cast v96  : u32
+    v188 = add v187, 424  : u32
+    v189 = inttoptr v188  : *mut i32
+    store v189, v94
+    v190 = cast v96  : u32
+    v191 = add v190, 416  : u32
+    v192 = inttoptr v191  : *mut i32
+    v193 = load v192  : i32
+    v194 = add v193, v95  : i32
+    v195 = cast v96  : u32
+    v196 = add v195, 416  : u32
+    v197 = inttoptr v196  : *mut i32
+    store v197, v194
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v94, v194)
     ret 
 
 block21:
-    v179 = cast v106  : u32
-    v180 = add v179, 428  : u32
-    v181 = inttoptr v180  : *mut i32
-    store v181, v104
-    v182 = cast v106  : u32
-    v183 = add v182, 420  : u32
-    v184 = inttoptr v183  : *mut i32
-    v185 = load v184  : i32
-    v186 = add v185, v105  : i32
-    v187 = cast v106  : u32
-    v188 = add v187, 420  : u32
-    v189 = inttoptr v188  : *mut i32
-    store v189, v186
-    v190 = const.i32 1  : i32
-    v191 = bor v186, v190  : i32
-    v192 = cast v104  : u32
-    v193 = add v192, 4  : u32
-    v194 = inttoptr v193  : *mut i32
-    store v194, v191
-    v195 = cast v106  : u32
-    v196 = add v195, 424  : u32
-    v197 = inttoptr v196  : *mut i32
-    v198 = load v197  : i32
-    v199 = eq v104, v198  : i1
-    v200 = cast v199  : i32
-    v201 = const.i32 0  : i32
-    v202 = neq v200, v201  : i1
-    condbr v202, block19, block30
+    v164 = cast v96  : u32
+    v165 = add v164, 428  : u32
+    v166 = inttoptr v165  : *mut i32
+    store v166, v94
+    v167 = cast v96  : u32
+    v168 = add v167, 420  : u32
+    v169 = inttoptr v168  : *mut i32
+    v170 = load v169  : i32
+    v171 = add v170, v95  : i32
+    v172 = cast v96  : u32
+    v173 = add v172, 420  : u32
+    v174 = inttoptr v173  : *mut i32
+    store v174, v171
+    v175 = const.i32 1  : i32
+    v176 = bor v171, v175  : i32
+    v177 = cast v94  : u32
+    v178 = add v177, 4  : u32
+    v179 = inttoptr v178  : *mut i32
+    store v179, v176
+    v180 = cast v96  : u32
+    v181 = add v180, 424  : u32
+    v182 = inttoptr v181  : *mut i32
+    v183 = load v182  : i32
+    v184 = eq v94, v183  : i1
+    v185 = cast v184  : i32
+    v186 = neq v185, 0  : i1
+    condbr v186, block19, block30
 
 block22:
-    v115 = cast v106  : u32
-    v116 = add v115, 424  : u32
-    v117 = inttoptr v116  : *mut i32
-    v118 = load v117  : i32
-    v119 = eq v97, v118  : i1
-    v120 = cast v119  : i32
-    v121 = const.i32 0  : i32
-    v122 = neq v120, v121  : i1
-    condbr v122, block20, block23
+    v104 = cast v96  : u32
+    v105 = add v104, 424  : u32
+    v106 = inttoptr v105  : *mut i32
+    v107 = load v106  : i32
+    v108 = eq v89, v107  : i1
+    v109 = cast v108  : i32
+    v110 = neq v109, 0  : i1
+    condbr v110, block20, block23
 
 block23:
-    v123 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v97)  : i32
-    v124 = add v123, v105  : i32
-    v125 = const.i32 256  : i32
-    v126 = cast v123  : u32
-    v127 = cast v125  : u32
-    v128 = lt v126, v127  : i1
-    v129 = cast v128  : i32
-    v130 = const.i32 0  : i32
-    v131 = neq v129, v130  : i1
-    condbr v131, block25, block26
+    v111 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v89)  : i32
+    v112 = add v111, v95  : i32
+    v113 = const.i32 256  : i32
+    v114 = cast v111  : u32
+    v115 = cast v113  : u32
+    v116 = lt v114, v115  : i1
+    v117 = cast v116  : i32
+    v118 = neq v117, 0  : i1
+    condbr v118, block25, block26
 
 block24:
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v104, v124)
-    v168 = cast v106  : u32
-    v169 = add v168, 424  : u32
-    v170 = inttoptr v169  : *mut i32
-    v171 = load v170  : i32
-    v172 = neq v165, v171  : i1
-    v173 = cast v172  : i32
-    v174 = const.i32 0  : i32
-    v175 = neq v173, v174  : i1
-    condbr v175, block15(v166, v167, v165), block29
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v94, v112)
+    v154 = cast v96  : u32
+    v155 = add v154, 424  : u32
+    v156 = inttoptr v155  : *mut i32
+    v157 = load v156  : i32
+    v158 = neq v151, v157  : i1
+    v159 = cast v158  : i32
+    v160 = neq v159, 0  : i1
+    condbr v160, block15(v152, v153, v151), block29
 
 block25:
-    v132 = cast v97  : u32
-    v133 = add v132, 12  : u32
-    v134 = inttoptr v133  : *mut i32
-    v135 = load v134  : i32
-    v136 = cast v97  : u32
-    v137 = add v136, 8  : u32
-    v138 = inttoptr v137  : *mut i32
-    v139 = load v138  : i32
-    v140 = eq v135, v139  : i1
-    v141 = cast v140  : i32
-    v142 = const.i32 0  : i32
-    v143 = neq v141, v142  : i1
-    condbr v143, block27, block28
+    v119 = cast v89  : u32
+    v120 = add v119, 12  : u32
+    v121 = inttoptr v120  : *mut i32
+    v122 = load v121  : i32
+    v123 = cast v89  : u32
+    v124 = add v123, 8  : u32
+    v125 = inttoptr v124  : *mut i32
+    v126 = load v125  : i32
+    v127 = eq v122, v126  : i1
+    v128 = cast v127  : i32
+    v129 = neq v128, 0  : i1
+    condbr v129, block27, block28
 
 block26:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v106, v97)
+    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v96, v89)
     br block24
 
 block27:
-    v150 = cast v106  : u32
-    v151 = add v150, 408  : u32
-    v152 = inttoptr v151  : *mut i32
-    v153 = load v152  : i32
-    v154 = const.i32 -2  : i32
-    v155 = const.i32 3  : i32
-    v156 = cast v123  : u32
-    v157 = cast v155  : u32
-    v158 = shr v156, v157  : u32
-    v159 = cast v158  : i32
-    v160 = shl v154, v159  : i32
-    v161 = band v153, v160  : i32
-    v162 = cast v106  : u32
-    v163 = add v162, 408  : u32
-    v164 = inttoptr v163  : *mut i32
-    store v164, v161
+    v136 = cast v96  : u32
+    v137 = add v136, 408  : u32
+    v138 = inttoptr v137  : *mut i32
+    v139 = load v138  : i32
+    v140 = const.i32 -2  : i32
+    v141 = const.i32 3  : i32
+    v142 = cast v111  : u32
+    v143 = cast v141  : u32
+    v144 = shr v142, v143  : u32
+    v145 = cast v144  : i32
+    v146 = shl v140, v145  : i32
+    v147 = band v139, v146  : i32
+    v148 = cast v96  : u32
+    v149 = add v148, 408  : u32
+    v150 = inttoptr v149  : *mut i32
+    store v150, v147
     br block24
 
 block28:
-    v144 = cast v139  : u32
-    v145 = add v144, 12  : u32
-    v146 = inttoptr v145  : *mut i32
-    store v146, v135
-    v147 = cast v135  : u32
-    v148 = add v147, 8  : u32
-    v149 = inttoptr v148  : *mut i32
-    store v149, v139
+    v130 = cast v126  : u32
+    v131 = add v130, 12  : u32
+    v132 = inttoptr v131  : *mut i32
+    store v132, v122
+    v133 = cast v122  : u32
+    v134 = add v133, 8  : u32
+    v135 = inttoptr v134  : *mut i32
+    store v135, v126
     br block24
 
 block29:
-    v176 = cast v167  : u32
-    v177 = add v176, 416  : u32
-    v178 = inttoptr v177  : *mut i32
-    store v178, v166
+    v161 = cast v153  : u32
+    v162 = add v161, 416  : u32
+    v163 = inttoptr v162  : *mut i32
+    store v163, v152
     ret 
 
 block30:
     br block18
 
 block31:
-    v234 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
-    v235 = const.i32 8  : i32
-    v236 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v234, v235)  : i32
-    v237 = const.i32 20  : i32
-    v238 = const.i32 8  : i32
-    v239 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v237, v238)  : i32
-    v240 = const.i32 16  : i32
-    v241 = const.i32 8  : i32
-    v242 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v240, v241)  : i32
-    v243 = const.i32 0  : i32
-    v244 = const.i32 16  : i32
-    v245 = const.i32 8  : i32
-    v246 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v244, v245)  : i32
-    v247 = const.i32 2  : i32
-    v248 = shl v246, v247  : i32
-    v249 = sub v243, v248  : i32
-    v250 = add v236, v239  : i32
-    v251 = add v242, v250  : i32
-    v252 = sub v234, v251  : i32
-    v253 = const.i32 -65544  : i32
-    v254 = add v252, v253  : i32
-    v255 = const.i32 -9  : i32
-    v256 = band v254, v255  : i32
-    v257 = const.i32 -3  : i32
-    v258 = add v256, v257  : i32
-    v259 = cast v249  : u32
-    v260 = cast v258  : u32
-    v261 = lt v259, v260  : i1
-    v262 = cast v261  : i32
-    v263 = const.i32 0  : i32
-    v264 = neq v262, v263  : i1
-    v265 = select v264, v249, v258  : i32
-    v266 = const.i32 0  : i32
-    v267 = eq v265, v266  : i1
-    v268 = cast v267  : i32
-    v269 = const.i32 0  : i32
-    v270 = neq v268, v269  : i1
-    condbr v270, block2, block32
+    v217 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v218 = const.i32 8  : i32
+    v219 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v217, v218)  : i32
+    v220 = const.i32 20  : i32
+    v221 = const.i32 8  : i32
+    v222 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v220, v221)  : i32
+    v223 = const.i32 16  : i32
+    v224 = const.i32 8  : i32
+    v225 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v223, v224)  : i32
+    v226 = const.i32 0  : i32
+    v227 = const.i32 16  : i32
+    v228 = const.i32 8  : i32
+    v229 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v227, v228)  : i32
+    v230 = const.i32 2  : i32
+    v231 = shl v229, v230  : i32
+    v232 = sub v226, v231  : i32
+    v233 = add v219, v222  : i32
+    v234 = add v225, v233  : i32
+    v235 = sub v217, v234  : i32
+    v236 = const.i32 -65544  : i32
+    v237 = add v235, v236  : i32
+    v238 = const.i32 -9  : i32
+    v239 = band v237, v238  : i32
+    v240 = const.i32 -3  : i32
+    v241 = add v239, v240  : i32
+    v242 = cast v232  : u32
+    v243 = cast v241  : u32
+    v244 = lt v242, v243  : i1
+    v245 = cast v244  : i32
+    v246 = neq v245, 0  : i1
+    v247 = select v246, v232, v241  : i32
+    v248 = eq v247, 0  : i1
+    v249 = cast v248  : i32
+    v250 = neq v249, 0  : i1
+    condbr v250, block2, block32
 
 block32:
-    v271 = cast v223  : u32
-    v272 = add v271, 428  : u32
-    v273 = inttoptr v272  : *mut i32
-    v274 = load v273  : i32
-    v275 = const.i32 0  : i32
-    v276 = eq v274, v275  : i1
-    v277 = cast v276  : i32
-    v278 = const.i32 0  : i32
-    v279 = neq v277, v278  : i1
-    condbr v279, block2, block33
+    v251 = cast v207  : u32
+    v252 = add v251, 428  : u32
+    v253 = inttoptr v252  : *mut i32
+    v254 = load v253  : i32
+    v255 = eq v254, 0  : i1
+    v256 = cast v255  : i32
+    v257 = neq v256, 0  : i1
+    condbr v257, block2, block33
 
 block33:
-    v280 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
-    v281 = const.i32 8  : i32
-    v282 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v280, v281)  : i32
-    v283 = const.i32 20  : i32
-    v284 = const.i32 8  : i32
-    v285 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v283, v284)  : i32
-    v286 = const.i32 16  : i32
-    v287 = const.i32 8  : i32
-    v288 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v286, v287)  : i32
-    v289 = const.i32 0  : i32
-    v290 = cast v223  : u32
-    v291 = add v290, 420  : u32
-    v292 = inttoptr v291  : *mut i32
-    v293 = load v292  : i32
-    v294 = sub v282, v280  : i32
-    v295 = add v285, v294  : i32
-    v296 = add v288, v295  : i32
-    v297 = cast v293  : u32
-    v298 = cast v296  : u32
-    v299 = lte v297, v298  : i1
-    v300 = cast v299  : i32
-    v301 = const.i32 0  : i32
-    v302 = neq v300, v301  : i1
-    condbr v302, block34(v223, v289), block35
+    v258 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v259 = const.i32 8  : i32
+    v260 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v258, v259)  : i32
+    v261 = const.i32 20  : i32
+    v262 = const.i32 8  : i32
+    v263 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v261, v262)  : i32
+    v264 = const.i32 16  : i32
+    v265 = const.i32 8  : i32
+    v266 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v264, v265)  : i32
+    v267 = const.i32 0  : i32
+    v268 = cast v207  : u32
+    v269 = add v268, 420  : u32
+    v270 = inttoptr v269  : *mut i32
+    v271 = load v270  : i32
+    v272 = sub v260, v258  : i32
+    v273 = add v263, v272  : i32
+    v274 = add v266, v273  : i32
+    v275 = cast v271  : u32
+    v276 = cast v274  : u32
+    v277 = lte v275, v276  : i1
+    v278 = cast v277  : i32
+    v279 = neq v278, 0  : i1
+    condbr v279, block34(v207, v267), block35
 
-block34(v486: i32, v489: i32):
-    v487 = call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$23release_unused_segments17h25622465f0742468E(v486)  : i32
-    v488 = const.i32 0  : i32
-    v490 = sub v488, v489  : i32
-    v491 = neq v487, v490  : i1
-    v492 = cast v491  : i32
-    v493 = const.i32 0  : i32
-    v494 = neq v492, v493  : i1
-    condbr v494, block2, block53
+block34(v449: i32, v452: i32):
+    v450 = call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$23release_unused_segments17h25622465f0742468E(v449)  : i32
+    v451 = const.i32 0  : i32
+    v453 = sub v451, v452  : i32
+    v454 = neq v450, v453  : i1
+    v455 = cast v454  : i32
+    v456 = neq v455, 0  : i1
+    condbr v456, block2, block53
 
 block35:
-    v303 = sub v293, v296  : i32
-    v304 = const.i32 65535  : i32
-    v305 = add v303, v304  : i32
-    v306 = const.i32 -65536  : i32
-    v307 = band v305, v306  : i32
-    v308 = const.i32 -65536  : i32
-    v309 = add v307, v308  : i32
-    v310 = const.i32 128  : i32
-    v311 = add v223, v310  : i32
-    br block37(v311)
+    v280 = sub v271, v274  : i32
+    v281 = const.i32 65535  : i32
+    v282 = add v280, v281  : i32
+    v283 = const.i32 -65536  : i32
+    v284 = band v282, v283  : i32
+    v285 = const.i32 -65536  : i32
+    v286 = add v284, v285  : i32
+    v287 = const.i32 128  : i32
+    v288 = add v207, v287  : i32
+    br block37(v288)
 
-block36(v340: i32, v345: i32, v368: i32, v392: i32, v451: i32):
-    v339 = const.i32 0  : i32
-    v341 = call noname::_ZN8dlmalloc8dlmalloc7Segment9is_extern17h6f6db2c70b891fd9E(v340)  : i32
-    v342 = const.i32 0  : i32
-    v343 = neq v341, v342  : i1
-    condbr v343, block34(v345, v339), block43
+block36(v314: i32, v318: i32, v339: i32, v359: i32, v414: i32):
+    v313 = const.i32 0  : i32
+    v315 = call noname::_ZN8dlmalloc8dlmalloc7Segment9is_extern17h6f6db2c70b891fd9E(v314)  : i32
+    v316 = neq v315, 0  : i1
+    condbr v316, block34(v318, v313), block43
 
-block37(v312: i32):
-    v313 = cast v312  : u32
-    v314 = inttoptr v313  : *mut i32
-    v315 = load v314  : i32
-    v317 = cast v315  : u32
-    v318 = cast v316  : u32
-    v319 = gt v317, v318  : i1
-    v320 = cast v319  : i32
-    v321 = const.i32 0  : i32
-    v322 = neq v320, v321  : i1
-    condbr v322, block39, block40
+block37(v289: i32):
+    v290 = cast v289  : u32
+    v291 = inttoptr v290  : *mut i32
+    v292 = load v291  : i32
+    v294 = cast v292  : u32
+    v295 = cast v293  : u32
+    v296 = gt v294, v295  : i1
+    v297 = cast v296  : i32
+    v298 = neq v297, 0  : i1
+    condbr v298, block39, block40
 
 block38:
-    v338 = const.i32 0  : i32
-    br block36(v338, v347, v370, v394, v453)
+    v312 = const.i32 0  : i32
+    br block36(v312, v320, v341, v361, v416)
 
 block39:
-    v331 = cast v312  : u32
-    v332 = add v331, 8  : u32
-    v333 = inttoptr v332  : *mut i32
-    v334 = load v333  : i32
-    v335 = const.i32 0  : i32
-    v336 = neq v334, v335  : i1
-    condbr v336, block37(v334), block42
+    v306 = cast v289  : u32
+    v307 = add v306, 8  : u32
+    v308 = inttoptr v307  : *mut i32
+    v309 = load v308  : i32
+    v310 = neq v309, 0  : i1
+    condbr v310, block37(v309), block42
 
 block40:
-    v323 = call noname::_ZN8dlmalloc8dlmalloc7Segment3top17he7e9e2493151d036E(v312)  : i32
-    v324 = cast v323  : u32
-    v325 = cast v316  : u32
-    v326 = gt v324, v325  : i1
-    v327 = cast v326  : i32
-    v328 = const.i32 0  : i32
-    v329 = neq v327, v328  : i1
-    condbr v329, block36(v312, v223, v309, v311, v307), block41
+    v299 = call noname::_ZN8dlmalloc8dlmalloc7Segment3top17he7e9e2493151d036E(v289)  : i32
+    v300 = cast v299  : u32
+    v301 = cast v293  : u32
+    v302 = gt v300, v301  : i1
+    v303 = cast v302  : i32
+    v304 = neq v303, 0  : i1
+    condbr v304, block36(v289, v207, v286, v288, v284), block41
 
 block41:
     br block39
@@ -1483,270 +1402,256 @@ block42:
     br block38
 
 block43:
-    v344 = const.i32 0  : i32
-    v348 = cast v340  : u32
-    v349 = add v348, 12  : u32
-    v350 = inttoptr v349  : *mut i32
-    v351 = load v350  : i32
-    v352 = const.i32 1  : i32
-    v353 = cast v351  : u32
-    v354 = cast v352  : u32
-    v355 = shr v353, v354  : u32
-    v356 = cast v355  : i32
-    v357 = call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$16can_release_part17h43bfb7d8666fcc31E(v345, v356)  : i32
-    v358 = const.i32 0  : i32
-    v359 = eq v357, v358  : i1
-    v360 = cast v359  : i32
-    v361 = const.i32 0  : i32
-    v362 = neq v360, v361  : i1
-    condbr v362, block34(v345, v344), block44
+    v317 = const.i32 0  : i32
+    v321 = cast v314  : u32
+    v322 = add v321, 12  : u32
+    v323 = inttoptr v322  : *mut i32
+    v324 = load v323  : i32
+    v325 = const.i32 1  : i32
+    v326 = cast v324  : u32
+    v327 = cast v325  : u32
+    v328 = shr v326, v327  : u32
+    v329 = cast v328  : i32
+    v330 = call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$16can_release_part17h43bfb7d8666fcc31E(v318, v329)  : i32
+    v331 = eq v330, 0  : i1
+    v332 = cast v331  : i32
+    v333 = neq v332, 0  : i1
+    condbr v333, block34(v318, v317), block44
 
 block44:
-    v363 = const.i32 0  : i32
-    v364 = cast v340  : u32
-    v365 = add v364, 4  : u32
-    v366 = inttoptr v365  : *mut i32
-    v367 = load v366  : i32
-    v371 = cast v367  : u32
-    v372 = cast v368  : u32
-    v373 = lt v371, v372  : i1
-    v374 = cast v373  : i32
-    v375 = const.i32 0  : i32
-    v376 = neq v374, v375  : i1
-    condbr v376, block34(v345, v363), block45
+    v334 = const.i32 0  : i32
+    v335 = cast v314  : u32
+    v336 = add v335, 4  : u32
+    v337 = inttoptr v336  : *mut i32
+    v338 = load v337  : i32
+    v342 = cast v338  : u32
+    v343 = cast v339  : u32
+    v344 = lt v342, v343  : i1
+    v345 = cast v344  : i32
+    v346 = neq v345, 0  : i1
+    condbr v346, block34(v318, v334), block45
 
 block45:
-    br block46(v392)
+    br block46(v359)
 
-block46(v378: i32):
-    v379 = call noname::_ZN8dlmalloc8dlmalloc7Segment5holds17h8f6de4ee6718009bE(v377, v378)  : i32
-    v380 = const.i32 0  : i32
-    v381 = eq v379, v380  : i1
-    v382 = cast v381  : i32
-    v383 = const.i32 0  : i32
-    v384 = neq v382, v383  : i1
-    condbr v384, block48, block49
+block46(v348: i32):
+    v349 = call noname::_ZN8dlmalloc8dlmalloc7Segment5holds17h8f6de4ee6718009bE(v347, v348)  : i32
+    v350 = eq v349, 0  : i1
+    v351 = cast v350  : i32
+    v352 = neq v351, 0  : i1
+    condbr v352, block48, block49
 
 block47:
-    v396 = cast v377  : u32
-    v397 = inttoptr v396  : *mut i32
-    v398 = load v397  : i32
-    v399 = cast v377  : u32
-    v400 = add v399, 4  : u32
-    v401 = inttoptr v400  : *mut i32
-    v402 = load v401  : i32
-    v404 = sub v402, v368  : i32
-    v405 = call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$9free_part17h74489c9e7a3aa967E(v345, v398, v402, v404)  : i32
-    v406 = const.i32 0  : i32
-    v407 = const.i32 0  : i32
-    v408 = eq v403, v407  : i1
-    v409 = cast v408  : i32
-    v410 = const.i32 0  : i32
-    v411 = neq v409, v410  : i1
-    condbr v411, block34(v395, v406), block51
+    v363 = cast v347  : u32
+    v364 = inttoptr v363  : *mut i32
+    v365 = load v364  : i32
+    v366 = cast v347  : u32
+    v367 = add v366, 4  : u32
+    v368 = inttoptr v367  : *mut i32
+    v369 = load v368  : i32
+    v371 = sub v369, v339  : i32
+    v372 = call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$9free_part17h74489c9e7a3aa967E(v318, v365, v369, v371)  : i32
+    v373 = const.i32 0  : i32
+    v374 = eq v370, 0  : i1
+    v375 = cast v374  : i32
+    v376 = neq v375, 0  : i1
+    condbr v376, block34(v362, v373), block51
 
 block48:
-    v386 = cast v378  : u32
-    v387 = add v386, 8  : u32
-    v388 = inttoptr v387  : *mut i32
-    v389 = load v388  : i32
-    v390 = const.i32 0  : i32
-    v391 = neq v389, v390  : i1
-    condbr v391, block46(v389), block50
+    v354 = cast v348  : u32
+    v355 = add v354, 8  : u32
+    v356 = inttoptr v355  : *mut i32
+    v357 = load v356  : i32
+    v358 = neq v357, 0  : i1
+    condbr v358, block46(v357), block50
 
 block49:
-    v385 = const.i32 0  : i32
-    br block34(v395, v385)
+    v353 = const.i32 0  : i32
+    br block34(v362, v353)
 
 block50:
     br block47
 
 block51:
-    v412 = const.i32 0  : i32
-    v413 = const.i32 0  : i32
-    v414 = eq v405, v413  : i1
-    v415 = cast v414  : i32
-    v416 = const.i32 0  : i32
-    v417 = neq v415, v416  : i1
-    condbr v417, block34(v395, v412), block52
+    v377 = const.i32 0  : i32
+    v378 = eq v372, 0  : i1
+    v379 = cast v378  : i32
+    v380 = neq v379, 0  : i1
+    condbr v380, block34(v362, v377), block52
 
 block52:
-    v418 = cast v377  : u32
-    v419 = add v418, 4  : u32
-    v420 = inttoptr v419  : *mut i32
-    v421 = load v420  : i32
-    v422 = sub v421, v403  : i32
-    v423 = cast v377  : u32
-    v424 = add v423, 4  : u32
-    v425 = inttoptr v424  : *mut i32
-    store v425, v422
-    v426 = cast v395  : u32
-    v427 = add v426, 432  : u32
+    v381 = cast v347  : u32
+    v382 = add v381, 4  : u32
+    v383 = inttoptr v382  : *mut i32
+    v384 = load v383  : i32
+    v385 = sub v384, v370  : i32
+    v386 = cast v347  : u32
+    v387 = add v386, 4  : u32
+    v388 = inttoptr v387  : *mut i32
+    store v388, v385
+    v389 = cast v362  : u32
+    v390 = add v389, 432  : u32
+    v391 = inttoptr v390  : *mut i32
+    v392 = load v391  : i32
+    v393 = sub v392, v370  : i32
+    v394 = cast v362  : u32
+    v395 = add v394, 432  : u32
+    v396 = inttoptr v395  : *mut i32
+    store v396, v393
+    v397 = cast v362  : u32
+    v398 = add v397, 420  : u32
+    v399 = inttoptr v398  : *mut i32
+    v400 = load v399  : i32
+    v401 = cast v362  : u32
+    v402 = add v401, 428  : u32
+    v403 = inttoptr v402  : *mut i32
+    v404 = load v403  : i32
+    v405 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v404)  : i32
+    v406 = const.i32 8  : i32
+    v407 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v405, v406)  : i32
+    v408 = sub v407, v405  : i32
+    v409 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v404, v408)  : i32
+    v410 = cast v362  : u32
+    v411 = add v410, 428  : u32
+    v412 = inttoptr v411  : *mut i32
+    store v412, v409
+    v417 = add v414, v408  : i32
+    v418 = sub v400, v417  : i32
+    v419 = const.i32 65536  : i32
+    v420 = add v418, v419  : i32
+    v421 = cast v362  : u32
+    v422 = add v421, 420  : u32
+    v423 = inttoptr v422  : *mut i32
+    store v423, v420
+    v424 = const.i32 1  : i32
+    v425 = bor v420, v424  : i32
+    v426 = cast v409  : u32
+    v427 = add v426, 4  : u32
     v428 = inttoptr v427  : *mut i32
-    v429 = load v428  : i32
-    v430 = sub v429, v403  : i32
-    v431 = cast v395  : u32
-    v432 = add v431, 432  : u32
-    v433 = inttoptr v432  : *mut i32
-    store v433, v430
-    v434 = cast v395  : u32
-    v435 = add v434, 420  : u32
-    v436 = inttoptr v435  : *mut i32
-    v437 = load v436  : i32
-    v438 = cast v395  : u32
-    v439 = add v438, 428  : u32
-    v440 = inttoptr v439  : *mut i32
-    v441 = load v440  : i32
-    v442 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v441)  : i32
-    v443 = const.i32 8  : i32
-    v444 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v442, v443)  : i32
-    v445 = sub v444, v442  : i32
-    v446 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v441, v445)  : i32
-    v447 = cast v395  : u32
-    v448 = add v447, 428  : u32
-    v449 = inttoptr v448  : *mut i32
-    store v449, v446
-    v454 = add v451, v445  : i32
-    v455 = sub v437, v454  : i32
-    v456 = const.i32 65536  : i32
-    v457 = add v455, v456  : i32
-    v458 = cast v395  : u32
-    v459 = add v458, 420  : u32
-    v460 = inttoptr v459  : *mut i32
-    store v460, v457
-    v461 = const.i32 1  : i32
-    v462 = bor v457, v461  : i32
-    v463 = cast v446  : u32
-    v464 = add v463, 4  : u32
-    v465 = inttoptr v464  : *mut i32
-    store v465, v462
-    v466 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
-    v467 = const.i32 8  : i32
-    v468 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v466, v467)  : i32
-    v469 = const.i32 20  : i32
-    v470 = const.i32 8  : i32
-    v471 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v469, v470)  : i32
-    v472 = const.i32 16  : i32
-    v473 = const.i32 8  : i32
-    v474 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v472, v473)  : i32
-    v475 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v446, v457)  : i32
-    v476 = const.i32 2097152  : i32
-    v477 = cast v395  : u32
-    v478 = add v477, 440  : u32
-    v479 = inttoptr v478  : *mut i32
-    store v479, v476
-    v480 = sub v468, v466  : i32
-    v481 = add v471, v480  : i32
-    v482 = add v474, v481  : i32
-    v483 = cast v475  : u32
-    v484 = add v483, 4  : u32
-    v485 = inttoptr v484  : *mut i32
-    store v485, v482
-    br block34(v395, v403)
+    store v428, v425
+    v429 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v430 = const.i32 8  : i32
+    v431 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v429, v430)  : i32
+    v432 = const.i32 20  : i32
+    v433 = const.i32 8  : i32
+    v434 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v432, v433)  : i32
+    v435 = const.i32 16  : i32
+    v436 = const.i32 8  : i32
+    v437 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v435, v436)  : i32
+    v438 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v409, v420)  : i32
+    v439 = const.i32 2097152  : i32
+    v440 = cast v362  : u32
+    v441 = add v440, 440  : u32
+    v442 = inttoptr v441  : *mut i32
+    store v442, v439
+    v443 = sub v431, v429  : i32
+    v444 = add v434, v443  : i32
+    v445 = add v437, v444  : i32
+    v446 = cast v438  : u32
+    v447 = add v446, 4  : u32
+    v448 = inttoptr v447  : *mut i32
+    store v448, v445
+    br block34(v362, v370)
 
 block53:
-    v495 = cast v486  : u32
-    v496 = add v495, 420  : u32
-    v497 = inttoptr v496  : *mut i32
-    v498 = load v497  : i32
-    v499 = cast v486  : u32
-    v500 = add v499, 440  : u32
-    v501 = inttoptr v500  : *mut i32
-    v502 = load v501  : i32
-    v503 = cast v498  : u32
-    v504 = cast v502  : u32
-    v505 = lte v503, v504  : i1
-    v506 = cast v505  : i32
-    v507 = const.i32 0  : i32
-    v508 = neq v506, v507  : i1
-    condbr v508, block2, block54
+    v457 = cast v449  : u32
+    v458 = add v457, 420  : u32
+    v459 = inttoptr v458  : *mut i32
+    v460 = load v459  : i32
+    v461 = cast v449  : u32
+    v462 = add v461, 440  : u32
+    v463 = inttoptr v462  : *mut i32
+    v464 = load v463  : i32
+    v465 = cast v460  : u32
+    v466 = cast v464  : u32
+    v467 = lte v465, v466  : i1
+    v468 = cast v467  : i32
+    v469 = neq v468, 0  : i1
+    condbr v469, block2, block54
 
 block54:
-    v509 = const.i32 -1  : i32
-    v510 = cast v486  : u32
-    v511 = add v510, 440  : u32
-    v512 = inttoptr v511  : *mut i32
-    store v512, v509
+    v470 = const.i32 -1  : i32
+    v471 = cast v449  : u32
+    v472 = add v471, 440  : u32
+    v473 = inttoptr v472  : *mut i32
+    store v473, v470
     ret 
 
 block55:
-    v535 = const.i32 -8  : i32
-    v536 = band v513, v535  : i32
-    v537 = add v521, v536  : i32
-    v538 = const.i32 144  : i32
-    v539 = add v537, v538  : i32
-    v540 = cast v521  : u32
-    v541 = add v540, 408  : u32
-    v542 = inttoptr v541  : *mut i32
-    v543 = load v542  : i32
-    v544 = const.i32 1  : i32
-    v545 = const.i32 3  : i32
-    v546 = cast v513  : u32
-    v547 = cast v545  : u32
-    v548 = shr v546, v547  : u32
-    v549 = cast v548  : i32
-    v550 = shl v544, v549  : i32
-    v551 = band v543, v550  : i32
-    v552 = const.i32 0  : i32
-    v553 = eq v551, v552  : i1
-    v554 = cast v553  : i32
-    v555 = const.i32 0  : i32
-    v556 = neq v554, v555  : i1
-    condbr v556, block59, block60
+    v494 = const.i32 -8  : i32
+    v495 = band v474, v494  : i32
+    v496 = add v481, v495  : i32
+    v497 = const.i32 144  : i32
+    v498 = add v496, v497  : i32
+    v499 = cast v481  : u32
+    v500 = add v499, 408  : u32
+    v501 = inttoptr v500  : *mut i32
+    v502 = load v501  : i32
+    v503 = const.i32 1  : i32
+    v504 = const.i32 3  : i32
+    v505 = cast v474  : u32
+    v506 = cast v504  : u32
+    v507 = shr v505, v506  : u32
+    v508 = cast v507  : i32
+    v509 = shl v503, v508  : i32
+    v510 = band v502, v509  : i32
+    v511 = eq v510, 0  : i1
+    v512 = cast v511  : i32
+    v513 = neq v512, 0  : i1
+    condbr v513, block59, block60
 
 block56:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E(v521, v522, v513)
-    v523 = cast v521  : u32
-    v524 = add v523, 448  : u32
-    v525 = inttoptr v524  : *mut i32
-    v526 = load v525  : i32
-    v527 = const.i32 -1  : i32
-    v528 = add v526, v527  : i32
-    v529 = cast v521  : u32
-    v530 = add v529, 448  : u32
-    v531 = inttoptr v530  : *mut i32
-    store v531, v528
-    v532 = const.i32 0  : i32
-    v533 = neq v528, v532  : i1
-    condbr v533, block2, block57
+    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E(v481, v482, v474)
+    v483 = cast v481  : u32
+    v484 = add v483, 448  : u32
+    v485 = inttoptr v484  : *mut i32
+    v486 = load v485  : i32
+    v487 = const.i32 -1  : i32
+    v488 = add v486, v487  : i32
+    v489 = cast v481  : u32
+    v490 = add v489, 448  : u32
+    v491 = inttoptr v490  : *mut i32
+    store v491, v488
+    v492 = neq v488, 0  : i1
+    condbr v492, block2, block57
 
 block57:
-    v534 = call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$23release_unused_segments17h25622465f0742468E(v521)  : i32
+    v493 = call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$23release_unused_segments17h25622465f0742468E(v481)  : i32
     ret 
 
-block58(v570: i32):
-    v567 = cast v539  : u32
-    v568 = add v567, 8  : u32
-    v569 = inttoptr v568  : *mut i32
-    store v569, v522
-    v571 = cast v570  : u32
-    v572 = add v571, 12  : u32
-    v573 = inttoptr v572  : *mut i32
-    store v573, v566
-    v574 = cast v566  : u32
-    v575 = add v574, 12  : u32
-    v576 = inttoptr v575  : *mut i32
-    store v576, v565
-    v577 = cast v566  : u32
-    v578 = add v577, 8  : u32
-    v579 = inttoptr v578  : *mut i32
-    store v579, v570
+block58(v527: i32):
+    v524 = cast v498  : u32
+    v525 = add v524, 8  : u32
+    v526 = inttoptr v525  : *mut i32
+    store v526, v482
+    v528 = cast v527  : u32
+    v529 = add v528, 12  : u32
+    v530 = inttoptr v529  : *mut i32
+    store v530, v523
+    v531 = cast v523  : u32
+    v532 = add v531, 12  : u32
+    v533 = inttoptr v532  : *mut i32
+    store v533, v522
+    v534 = cast v523  : u32
+    v535 = add v534, 8  : u32
+    v536 = inttoptr v535  : *mut i32
+    store v536, v527
     br block2
 
 block59:
-    v561 = bor v543, v550  : i32
-    v562 = cast v521  : u32
-    v563 = add v562, 408  : u32
-    v564 = inttoptr v563  : *mut i32
-    store v564, v561
-    br block58(v539)
+    v518 = bor v502, v509  : i32
+    v519 = cast v481  : u32
+    v520 = add v519, 408  : u32
+    v521 = inttoptr v520  : *mut i32
+    store v521, v518
+    br block58(v498)
 
 block60:
-    v557 = cast v539  : u32
-    v558 = add v557, 8  : u32
-    v559 = inttoptr v558  : *mut i32
-    v560 = load v559  : i32
-    br block58(v560)
+    v514 = cast v498  : u32
+    v515 = add v514, 8  : u32
+    v516 = inttoptr v515  : *mut i32
+    v517 = load v516  : i32
+    br block58(v517)
 }
 
 pub fn _ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$6malloc17h1ae2390053e3628cE(i32, i32) -> i32 {
@@ -1763,1461 +1668,1379 @@ block0(v0: i32, v1: i32):
     v11 = cast v9  : u32
     v12 = lt v10, v11  : i1
     v13 = cast v12  : i32
-    v14 = const.i32 0  : i32
-    v15 = neq v13, v14  : i1
-    condbr v15, block7, block8
+    v14 = neq v13, 0  : i1
+    condbr v14, block7, block8
 
 block1(v2: i32):
     ret v2
 
-block2(v1571: i32, v1595: i32):
-    v1592 = const.i32 16  : i32
-    v1593 = add v1571, v1592  : i32
-    v1594 = global.symbol @__stack_pointer  : *mut i32
-    store v1594, v1593
-    br block1(v1595)
+block2(v1477: i32, v1501: i32):
+    v1498 = const.i32 16  : i32
+    v1499 = add v1477, v1498  : i32
+    v1500 = global.symbol @__stack_pointer  : *mut i32
+    store v1500, v1499
+    br block1(v1501)
 
-block3(v709: i32, v717: i32, v739: i32):
-    v713 = cast v709  : u32
-    v714 = add v713, 416  : u32
-    v715 = inttoptr v714  : *mut i32
-    v716 = load v715  : i32
-    v723 = cast v716  : u32
-    v724 = cast v717  : u32
-    v725 = gte v723, v724  : i1
-    v726 = cast v725  : i32
-    v727 = const.i32 0  : i32
-    v728 = neq v726, v727  : i1
-    condbr v728, block83, block84
+block3(v654: i32, v662: i32, v682: i32):
+    v658 = cast v654  : u32
+    v659 = add v658, 416  : u32
+    v660 = inttoptr v659  : *mut i32
+    v661 = load v660  : i32
+    v668 = cast v661  : u32
+    v669 = cast v662  : u32
+    v670 = gte v668, v669  : i1
+    v671 = cast v670  : i32
+    v672 = neq v671, 0  : i1
+    condbr v672, block83, block84
 
-block4(v607: i32, v613: i32, v621: i32, v628: i32, v749: i32):
-    v608 = const.i32 0  : i32
-    v609 = eq v607, v608  : i1
-    v610 = cast v609  : i32
-    v611 = const.i32 0  : i32
-    v612 = neq v610, v611  : i1
-    condbr v612, block3(v613, v621, v749), block63
+block4(v561: i32, v565: i32, v573: i32, v579: i32, v692: i32):
+    v562 = eq v561, 0  : i1
+    v563 = cast v562  : i32
+    v564 = neq v563, 0  : i1
+    condbr v564, block3(v565, v573, v692), block63
 
-block5(v598: i32, v599: i32, v601: i32, v604: i32, v616: i32, v752: i32):
-    br block60(v598, v599, v604)
+block5(v552: i32, v553: i32, v555: i32, v558: i32, v568: i32, v695: i32):
+    br block60(v552, v553, v558)
 
-block6(v531: i32, v533: i32, v540: i32, v545: i32, v555: i32, v603: i32, v606: i32, v745: i32):
-    v536 = bor v531, v533  : i32
-    v537 = const.i32 0  : i32
-    v538 = neq v536, v537  : i1
-    condbr v538, block56(v531, v533), block57
+block6(v493: i32, v495: i32, v501: i32, v506: i32, v514: i32, v557: i32, v560: i32, v688: i32):
+    v498 = bor v493, v495  : i32
+    v499 = neq v498, 0  : i1
+    condbr v499, block56(v493, v495), block57
 
 block7:
-    v183 = const.i32 16  : i32
-    v184 = const.i32 4  : i32
-    v185 = add v1, v184  : i32
-    v186 = const.i32 16  : i32
-    v187 = const.i32 8  : i32
-    v188 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v186, v187)  : i32
-    v189 = const.i32 -5  : i32
-    v190 = add v188, v189  : i32
-    v191 = cast v190  : u32
-    v192 = cast v1  : u32
-    v193 = gt v191, v192  : i1
-    v194 = cast v193  : i32
-    v195 = const.i32 0  : i32
-    v196 = neq v194, v195  : i1
-    v197 = select v196, v183, v185  : i32
-    v198 = const.i32 8  : i32
-    v199 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v197, v198)  : i32
-    v200 = cast v0  : u32
-    v201 = add v200, 408  : u32
-    v202 = inttoptr v201  : *mut i32
-    v203 = load v202  : i32
-    v204 = const.i32 3  : i32
-    v205 = cast v199  : u32
-    v206 = cast v204  : u32
-    v207 = shr v205, v206  : u32
-    v208 = cast v207  : i32
-    v209 = cast v203  : u32
-    v210 = cast v208  : u32
-    v211 = shr v209, v210  : u32
-    v212 = cast v211  : i32
-    v213 = const.i32 3  : i32
-    v214 = band v212, v213  : i32
-    v215 = const.i32 0  : i32
-    v216 = eq v214, v215  : i1
-    v217 = cast v216  : i32
-    v218 = const.i32 0  : i32
-    v219 = neq v217, v218  : i1
-    condbr v219, block23, block24
+    v168 = const.i32 16  : i32
+    v169 = const.i32 4  : i32
+    v170 = add v1, v169  : i32
+    v171 = const.i32 16  : i32
+    v172 = const.i32 8  : i32
+    v173 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v171, v172)  : i32
+    v174 = const.i32 -5  : i32
+    v175 = add v173, v174  : i32
+    v176 = cast v175  : u32
+    v177 = cast v1  : u32
+    v178 = gt v176, v177  : i1
+    v179 = cast v178  : i32
+    v180 = neq v179, 0  : i1
+    v181 = select v180, v168, v170  : i32
+    v182 = const.i32 8  : i32
+    v183 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v181, v182)  : i32
+    v184 = cast v0  : u32
+    v185 = add v184, 408  : u32
+    v186 = inttoptr v185  : *mut i32
+    v187 = load v186  : i32
+    v188 = const.i32 3  : i32
+    v189 = cast v183  : u32
+    v190 = cast v188  : u32
+    v191 = shr v189, v190  : u32
+    v192 = cast v191  : i32
+    v193 = cast v187  : u32
+    v194 = cast v192  : u32
+    v195 = shr v193, v194  : u32
+    v196 = cast v195  : i32
+    v197 = const.i32 3  : i32
+    v198 = band v196, v197  : i32
+    v199 = eq v198, 0  : i1
+    v200 = cast v199  : i32
+    v201 = neq v200, 0  : i1
+    condbr v201, block23, block24
 
 block8:
-    v16 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
-    v17 = const.i32 8  : i32
-    v18 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v16, v17)  : i32
-    v19 = const.i32 20  : i32
-    v20 = const.i32 8  : i32
-    v21 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v19, v20)  : i32
-    v22 = const.i32 16  : i32
-    v23 = const.i32 8  : i32
-    v24 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v22, v23)  : i32
+    v15 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v16 = const.i32 8  : i32
+    v17 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v15, v16)  : i32
+    v18 = const.i32 20  : i32
+    v19 = const.i32 8  : i32
+    v20 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v18, v19)  : i32
+    v21 = const.i32 16  : i32
+    v22 = const.i32 8  : i32
+    v23 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v21, v22)  : i32
+    v24 = const.i32 0  : i32
     v25 = const.i32 0  : i32
-    v26 = const.i32 0  : i32
-    v27 = const.i32 16  : i32
-    v28 = const.i32 8  : i32
-    v29 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v27, v28)  : i32
-    v30 = const.i32 2  : i32
-    v31 = shl v29, v30  : i32
-    v32 = sub v26, v31  : i32
-    v33 = add v18, v21  : i32
-    v34 = add v24, v33  : i32
-    v35 = sub v16, v34  : i32
-    v36 = const.i32 -65544  : i32
-    v37 = add v35, v36  : i32
-    v38 = const.i32 -9  : i32
-    v39 = band v37, v38  : i32
-    v40 = const.i32 -3  : i32
-    v41 = add v39, v40  : i32
-    v42 = cast v32  : u32
-    v43 = cast v41  : u32
-    v44 = lt v42, v43  : i1
-    v45 = cast v44  : i32
-    v46 = const.i32 0  : i32
-    v47 = neq v45, v46  : i1
-    v48 = select v47, v32, v41  : i32
-    v49 = cast v48  : u32
-    v50 = cast v1  : u32
-    v51 = lte v49, v50  : i1
-    v52 = cast v51  : i32
-    v53 = const.i32 0  : i32
-    v54 = neq v52, v53  : i1
-    condbr v54, block2(v7, v25), block9
+    v26 = const.i32 16  : i32
+    v27 = const.i32 8  : i32
+    v28 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v26, v27)  : i32
+    v29 = const.i32 2  : i32
+    v30 = shl v28, v29  : i32
+    v31 = sub v25, v30  : i32
+    v32 = add v17, v20  : i32
+    v33 = add v23, v32  : i32
+    v34 = sub v15, v33  : i32
+    v35 = const.i32 -65544  : i32
+    v36 = add v34, v35  : i32
+    v37 = const.i32 -9  : i32
+    v38 = band v36, v37  : i32
+    v39 = const.i32 -3  : i32
+    v40 = add v38, v39  : i32
+    v41 = cast v31  : u32
+    v42 = cast v40  : u32
+    v43 = lt v41, v42  : i1
+    v44 = cast v43  : i32
+    v45 = neq v44, 0  : i1
+    v46 = select v45, v31, v40  : i32
+    v47 = cast v46  : u32
+    v48 = cast v1  : u32
+    v49 = lte v47, v48  : i1
+    v50 = cast v49  : i32
+    v51 = neq v50, 0  : i1
+    condbr v51, block2(v7, v24), block9
 
 block9:
-    v55 = const.i32 4  : i32
-    v56 = add v1, v55  : i32
-    v57 = const.i32 8  : i32
-    v58 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v56, v57)  : i32
-    v59 = cast v0  : u32
-    v60 = add v59, 412  : u32
-    v61 = inttoptr v60  : *mut i32
-    v62 = load v61  : i32
-    v63 = const.i32 0  : i32
-    v64 = eq v62, v63  : i1
-    v65 = cast v64  : i32
-    v66 = const.i32 0  : i32
-    v67 = neq v65, v66  : i1
-    condbr v67, block3(v0, v58, v7), block10
+    v52 = const.i32 4  : i32
+    v53 = add v1, v52  : i32
+    v54 = const.i32 8  : i32
+    v55 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v53, v54)  : i32
+    v56 = cast v0  : u32
+    v57 = add v56, 412  : u32
+    v58 = inttoptr v57  : *mut i32
+    v59 = load v58  : i32
+    v60 = eq v59, 0  : i1
+    v61 = cast v60  : i32
+    v62 = neq v61, 0  : i1
+    condbr v62, block3(v0, v55, v7), block10
 
 block10:
-    v68 = const.i32 0  : i32
-    v69 = const.i32 0  : i32
-    v70 = const.i32 256  : i32
-    v71 = cast v58  : u32
-    v72 = cast v70  : u32
-    v73 = lt v71, v72  : i1
-    v74 = cast v73  : i32
-    v75 = const.i32 0  : i32
-    v76 = neq v74, v75  : i1
-    condbr v76, block11(v69), block12
+    v63 = const.i32 0  : i32
+    v64 = const.i32 0  : i32
+    v65 = const.i32 256  : i32
+    v66 = cast v55  : u32
+    v67 = cast v65  : u32
+    v68 = lt v66, v67  : i1
+    v69 = cast v68  : i32
+    v70 = neq v69, 0  : i1
+    condbr v70, block11(v64), block12
 
-block11(v108: i32):
-    v104 = const.i32 0  : i32
-    v106 = sub v104, v58  : i32
-    v109 = const.i32 2  : i32
-    v110 = shl v108, v109  : i32
-    v111 = add v0, v110  : i32
-    v112 = cast v111  : u32
-    v113 = inttoptr v112  : *mut i32
-    v114 = load v113  : i32
-    v115 = const.i32 0  : i32
-    v116 = neq v114, v115  : i1
-    condbr v116, block14, block15
+block11(v101: i32):
+    v97 = const.i32 0  : i32
+    v99 = sub v97, v55  : i32
+    v102 = const.i32 2  : i32
+    v103 = shl v101, v102  : i32
+    v104 = add v0, v103  : i32
+    v105 = cast v104  : u32
+    v106 = inttoptr v105  : *mut i32
+    v107 = load v106  : i32
+    v108 = neq v107, 0  : i1
+    condbr v108, block14, block15
 
 block12:
-    v77 = const.i32 31  : i32
-    v78 = const.i32 16777215  : i32
-    v79 = cast v58  : u32
-    v80 = cast v78  : u32
-    v81 = gt v79, v80  : i1
-    v82 = cast v81  : i32
-    v83 = const.i32 0  : i32
-    v84 = neq v82, v83  : i1
-    condbr v84, block11(v77), block13
+    v71 = const.i32 31  : i32
+    v72 = const.i32 16777215  : i32
+    v73 = cast v55  : u32
+    v74 = cast v72  : u32
+    v75 = gt v73, v74  : i1
+    v76 = cast v75  : i32
+    v77 = neq v76, 0  : i1
+    condbr v77, block11(v71), block13
 
 block13:
-    v85 = const.i32 6  : i32
-    v86 = const.i32 8  : i32
-    v87 = cast v58  : u32
-    v88 = cast v86  : u32
-    v89 = shr v87, v88  : u32
-    v90 = cast v89  : i32
-    v91 = popcnt v90  : i32
-    v92 = sub v85, v91  : i32
-    v93 = cast v58  : u32
-    v94 = cast v92  : u32
-    v95 = shr v93, v94  : u32
-    v96 = cast v95  : i32
-    v97 = const.i32 1  : i32
-    v98 = band v96, v97  : i32
-    v99 = const.i32 1  : i32
-    v100 = shl v91, v99  : i32
-    v101 = sub v98, v100  : i32
-    v102 = const.i32 62  : i32
-    v103 = add v101, v102  : i32
-    br block11(v103)
+    v78 = const.i32 6  : i32
+    v79 = const.i32 8  : i32
+    v80 = cast v55  : u32
+    v81 = cast v79  : u32
+    v82 = shr v80, v81  : u32
+    v83 = cast v82  : i32
+    v84 = popcnt v83  : i32
+    v85 = sub v78, v84  : i32
+    v86 = cast v55  : u32
+    v87 = cast v85  : u32
+    v88 = shr v86, v87  : u32
+    v89 = cast v88  : i32
+    v90 = const.i32 1  : i32
+    v91 = band v89, v90  : i32
+    v92 = const.i32 1  : i32
+    v93 = shl v84, v92  : i32
+    v94 = sub v91, v93  : i32
+    v95 = const.i32 62  : i32
+    v96 = add v94, v95  : i32
+    br block11(v96)
 
 block14:
-    v118 = call noname::_ZN8dlmalloc8dlmalloc24leftshift_for_tree_index17h31d064fdd867f502E(v108)  : i32
-    v119 = shl v105, v118  : i32
-    v120 = const.i32 0  : i32
-    v121 = const.i32 0  : i32
-    br block16(v114, v106, v120, v119, v121, v108, v546, v107, v746)
+    v110 = call noname::_ZN8dlmalloc8dlmalloc24leftshift_for_tree_index17h31d064fdd867f502E(v101)  : i32
+    v111 = shl v98, v110  : i32
+    v112 = const.i32 0  : i32
+    v113 = const.i32 0  : i32
+    br block16(v107, v99, v112, v111, v113, v101, v507, v100, v689)
 
 block15:
-    v117 = const.i32 0  : i32
-    br block6(v68, v117, v108, v62, v107, v105, v106, v7)
+    v109 = const.i32 0  : i32
+    br block6(v63, v109, v101, v59, v100, v98, v99, v7)
 
-block16(v122: i32, v133: i32, v150: i32, v152: i32, v535: i32, v542: i32, v548: i32, v557: i32, v748: i32):
-    v123 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v122)  : i32
-    v124 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v123)  : i32
-    v126 = cast v124  : u32
-    v127 = cast v125  : u32
-    v128 = lt v126, v127  : i1
-    v129 = cast v128  : i32
-    v130 = const.i32 0  : i32
-    v131 = neq v129, v130  : i1
-    condbr v131, block18(v133, v535), block19
+block16(v114: i32, v124: i32, v139: i32, v141: i32, v497: i32, v503: i32, v509: i32, v516: i32, v691: i32):
+    v115 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v114)  : i32
+    v116 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v115)  : i32
+    v118 = cast v116  : u32
+    v119 = cast v117  : u32
+    v120 = lt v118, v119  : i1
+    v121 = cast v120  : i32
+    v122 = neq v121, 0  : i1
+    condbr v122, block18(v124, v497), block19
 
 block17:
 
-block18(v182: i32, v534: i32):
-    v144 = const.i32 20  : i32
-    v145 = add v122, v144  : i32
-    v146 = cast v145  : u32
-    v147 = inttoptr v146  : *mut i32
-    v148 = load v147  : i32
-    v153 = const.i32 29  : i32
-    v154 = cast v152  : u32
-    v155 = cast v153  : u32
-    v156 = shr v154, v155  : u32
-    v157 = cast v156  : i32
-    v158 = const.i32 4  : i32
-    v159 = band v157, v158  : i32
-    v160 = add v143, v159  : i32
-    v161 = const.i32 16  : i32
-    v162 = add v160, v161  : i32
-    v163 = cast v162  : u32
-    v164 = inttoptr v163  : *mut i32
-    v165 = load v164  : i32
-    v166 = neq v148, v165  : i1
-    v167 = cast v166  : i32
-    v168 = const.i32 0  : i32
-    v169 = neq v167, v168  : i1
-    v170 = select v169, v148, v150  : i32
-    v171 = const.i32 0  : i32
-    v172 = neq v148, v171  : i1
-    v173 = select v172, v170, v149  : i32
-    v174 = const.i32 1  : i32
-    v175 = shl v151, v174  : i32
-    v176 = const.i32 0  : i32
-    v177 = eq v165, v176  : i1
-    v178 = cast v177  : i32
-    v179 = const.i32 0  : i32
-    v180 = neq v178, v179  : i1
-    condbr v180, block6(v173, v534, v542, v548, v557, v181, v182, v748), block22
+block18(v167: i32, v496: i32):
+    v133 = const.i32 20  : i32
+    v134 = add v114, v133  : i32
+    v135 = cast v134  : u32
+    v136 = inttoptr v135  : *mut i32
+    v137 = load v136  : i32
+    v142 = const.i32 29  : i32
+    v143 = cast v141  : u32
+    v144 = cast v142  : u32
+    v145 = shr v143, v144  : u32
+    v146 = cast v145  : i32
+    v147 = const.i32 4  : i32
+    v148 = band v146, v147  : i32
+    v149 = add v132, v148  : i32
+    v150 = const.i32 16  : i32
+    v151 = add v149, v150  : i32
+    v152 = cast v151  : u32
+    v153 = inttoptr v152  : *mut i32
+    v154 = load v153  : i32
+    v155 = neq v137, v154  : i1
+    v156 = cast v155  : i32
+    v157 = neq v156, 0  : i1
+    v158 = select v157, v137, v139  : i32
+    v159 = neq v137, 0  : i1
+    v160 = select v159, v158, v138  : i32
+    v161 = const.i32 1  : i32
+    v162 = shl v140, v161  : i32
+    v163 = eq v154, 0  : i1
+    v164 = cast v163  : i32
+    v165 = neq v164, 0  : i1
+    condbr v165, block6(v160, v496, v503, v509, v516, v166, v167, v691), block22
 
 block19:
-    v132 = sub v124, v125  : i32
-    v134 = cast v132  : u32
-    v135 = cast v133  : u32
-    v136 = gte v134, v135  : i1
-    v137 = cast v136  : i32
-    v138 = const.i32 0  : i32
-    v139 = neq v137, v138  : i1
-    condbr v139, block18(v133, v535), block20
+    v123 = sub v116, v117  : i32
+    v125 = cast v123  : u32
+    v126 = cast v124  : u32
+    v127 = gte v125, v126  : i1
+    v128 = cast v127  : i32
+    v129 = neq v128, 0  : i1
+    condbr v129, block18(v124, v497), block20
 
 block20:
-    v140 = const.i32 0  : i32
-    v141 = neq v132, v140  : i1
-    condbr v141, block18(v132, v122), block21
+    v130 = neq v123, 0  : i1
+    condbr v130, block18(v123, v114), block21
 
 block21:
-    v142 = const.i32 0  : i32
-    br block5(v122, v122, v125, v142, v557, v748)
+    v131 = const.i32 0  : i32
+    br block5(v114, v114, v117, v131, v516, v691)
 
 block22:
-    br block16(v165, v182, v173, v175, v534, v541, v547, v556, v747)
+    br block16(v154, v167, v160, v162, v496, v502, v508, v515, v690)
 
 block23:
-    v260 = cast v0  : u32
-    v261 = add v260, 416  : u32
-    v262 = inttoptr v261  : *mut i32
-    v263 = load v262  : i32
-    v264 = cast v199  : u32
-    v265 = cast v263  : u32
-    v266 = lte v264, v265  : i1
-    v267 = cast v266  : i32
-    v268 = const.i32 0  : i32
-    v269 = neq v267, v268  : i1
-    condbr v269, block3(v0, v199, v7), block28
+    v241 = cast v0  : u32
+    v242 = add v241, 416  : u32
+    v243 = inttoptr v242  : *mut i32
+    v244 = load v243  : i32
+    v245 = cast v183  : u32
+    v246 = cast v244  : u32
+    v247 = lte v245, v246  : i1
+    v248 = cast v247  : i32
+    v249 = neq v248, 0  : i1
+    condbr v249, block3(v0, v183, v7), block28
 
 block24:
-    v220 = const.i32 -1  : i32
-    v221 = bxor v212, v220  : i32
-    v222 = const.i32 1  : i32
-    v223 = band v221, v222  : i32
-    v224 = add v223, v208  : i32
-    v225 = const.i32 3  : i32
-    v226 = shl v224, v225  : i32
-    v227 = add v0, v226  : i32
-    v228 = const.i32 152  : i32
-    v229 = add v227, v228  : i32
-    v230 = cast v229  : u32
-    v231 = inttoptr v230  : *mut i32
-    v232 = load v231  : i32
-    v233 = cast v232  : u32
-    v234 = add v233, 8  : u32
-    v235 = inttoptr v234  : *mut i32
-    v236 = load v235  : i32
-    v237 = const.i32 144  : i32
-    v238 = add v227, v237  : i32
-    v239 = eq v236, v238  : i1
-    v240 = cast v239  : i32
-    v241 = const.i32 0  : i32
-    v242 = neq v240, v241  : i1
-    condbr v242, block26, block27
+    v202 = const.i32 -1  : i32
+    v203 = bxor v196, v202  : i32
+    v204 = const.i32 1  : i32
+    v205 = band v203, v204  : i32
+    v206 = add v205, v192  : i32
+    v207 = const.i32 3  : i32
+    v208 = shl v206, v207  : i32
+    v209 = add v0, v208  : i32
+    v210 = const.i32 152  : i32
+    v211 = add v209, v210  : i32
+    v212 = cast v211  : u32
+    v213 = inttoptr v212  : *mut i32
+    v214 = load v213  : i32
+    v215 = cast v214  : u32
+    v216 = add v215, 8  : u32
+    v217 = inttoptr v216  : *mut i32
+    v218 = load v217  : i32
+    v219 = const.i32 144  : i32
+    v220 = add v209, v219  : i32
+    v221 = eq v218, v220  : i1
+    v222 = cast v221  : i32
+    v223 = neq v222, 0  : i1
+    condbr v223, block26, block27
 
 block25:
-    v257 = const.i32 3  : i32
-    v258 = shl v224, v257  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_inuse_and_pinuse17h515e5a69a6d1edc6E(v232, v258)
-    v259 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v255)  : i32
-    br block2(v7, v259)
+    v238 = const.i32 3  : i32
+    v239 = shl v206, v238  : i32
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_inuse_and_pinuse17h515e5a69a6d1edc6E(v214, v239)
+    v240 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v236)  : i32
+    br block2(v7, v240)
 
 block26:
-    v249 = const.i32 -2  : i32
-    v250 = shl v249, v224  : i32
-    v251 = band v203, v250  : i32
-    v252 = cast v0  : u32
-    v253 = add v252, 408  : u32
-    v254 = inttoptr v253  : *mut i32
-    store v254, v251
+    v230 = const.i32 -2  : i32
+    v231 = shl v230, v206  : i32
+    v232 = band v187, v231  : i32
+    v233 = cast v0  : u32
+    v234 = add v233, 408  : u32
+    v235 = inttoptr v234  : *mut i32
+    store v235, v232
     br block25
 
 block27:
-    v243 = cast v236  : u32
-    v244 = add v243, 12  : u32
-    v245 = inttoptr v244  : *mut i32
-    store v245, v238
-    v246 = cast v238  : u32
-    v247 = add v246, 8  : u32
-    v248 = inttoptr v247  : *mut i32
-    store v248, v236
+    v224 = cast v218  : u32
+    v225 = add v224, 12  : u32
+    v226 = inttoptr v225  : *mut i32
+    store v226, v220
+    v227 = cast v220  : u32
+    v228 = add v227, 8  : u32
+    v229 = inttoptr v228  : *mut i32
+    store v229, v218
     br block25
 
 block28:
-    v270 = const.i32 0  : i32
-    v271 = neq v212, v270  : i1
-    condbr v271, block35, block36
+    v250 = neq v196, 0  : i1
+    condbr v250, block35, block36
 
-block29(v710: i32, v740: i32):
-    v525 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v319)  : i32
-    v526 = const.i32 0  : i32
-    v527 = eq v525, v526  : i1
-    v528 = cast v527  : i32
-    v529 = const.i32 0  : i32
-    v530 = neq v528, v529  : i1
-    condbr v530, block3(v710, v320, v740), block55
+block29(v655: i32, v683: i32):
+    v489 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v291)  : i32
+    v490 = eq v489, 0  : i1
+    v491 = cast v490  : i32
+    v492 = neq v491, 0  : i1
+    condbr v492, block3(v655, v292, v683), block55
 
 block30:
-    v514 = cast v322  : u32
-    v515 = add v514, 424  : u32
-    v516 = inttoptr v515  : *mut i32
-    store v516, v334
-    v519 = cast v510  : u32
-    v520 = add v519, 416  : u32
-    v521 = inttoptr v520  : *mut i32
-    store v521, v324
-    br block29(v510, v741)
+    v478 = cast v294  : u32
+    v479 = add v478, 424  : u32
+    v480 = inttoptr v479  : *mut i32
+    store v480, v305
+    v483 = cast v474  : u32
+    v484 = add v483, 416  : u32
+    v485 = inttoptr v484  : *mut i32
+    store v485, v296
+    br block29(v474, v684)
 
-block31(v1573: i32):
-    v499 = cast v390  : u32
-    v500 = add v499, 424  : u32
-    v501 = inttoptr v500  : *mut i32
-    store v501, v385
-    v504 = cast v495  : u32
-    v505 = add v504, 416  : u32
-    v506 = inttoptr v505  : *mut i32
-    store v506, v389
-    v509 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v383)  : i32
-    br block2(v1573, v509)
+block31(v1479: i32):
+    v463 = cast v359  : u32
+    v464 = add v463, 424  : u32
+    v465 = inttoptr v464  : *mut i32
+    store v465, v354
+    v468 = cast v459  : u32
+    v469 = add v468, 416  : u32
+    v470 = inttoptr v469  : *mut i32
+    store v470, v358
+    v473 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v352)  : i32
+    br block2(v1479, v473)
 
 block32:
-    v448 = const.i32 -8  : i32
-    v449 = band v394, v448  : i32
-    v450 = add v342, v449  : i32
-    v451 = cast v390  : u32
-    v452 = add v451, 424  : u32
-    v453 = inttoptr v452  : *mut i32
-    v454 = load v453  : i32
-    v455 = cast v390  : u32
-    v456 = add v455, 408  : u32
-    v457 = inttoptr v456  : *mut i32
-    v458 = load v457  : i32
-    v459 = const.i32 1  : i32
-    v460 = const.i32 3  : i32
-    v461 = cast v394  : u32
-    v462 = cast v460  : u32
-    v463 = shr v461, v462  : u32
-    v464 = cast v463  : i32
-    v465 = shl v459, v464  : i32
-    v466 = band v458, v465  : i32
-    v467 = const.i32 0  : i32
-    v468 = eq v466, v467  : i1
-    v469 = cast v468  : i32
-    v470 = const.i32 0  : i32
-    v471 = neq v469, v470  : i1
-    condbr v471, block53, block54
+    v414 = const.i32 -8  : i32
+    v415 = band v363, v414  : i32
+    v416 = add v312, v415  : i32
+    v417 = cast v359  : u32
+    v418 = add v417, 424  : u32
+    v419 = inttoptr v418  : *mut i32
+    v420 = load v419  : i32
+    v421 = cast v359  : u32
+    v422 = add v421, 408  : u32
+    v423 = inttoptr v422  : *mut i32
+    v424 = load v423  : i32
+    v425 = const.i32 1  : i32
+    v426 = const.i32 3  : i32
+    v427 = cast v363  : u32
+    v428 = cast v426  : u32
+    v429 = shr v427, v428  : u32
+    v430 = cast v429  : i32
+    v431 = shl v425, v430  : i32
+    v432 = band v424, v431  : i32
+    v433 = eq v432, 0  : i1
+    v434 = cast v433  : i32
+    v435 = neq v434, 0  : i1
+    condbr v435, block53, block54
 
 block33:
-    v446 = add v324, v320  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_inuse_and_pinuse17h515e5a69a6d1edc6E(v319, v446)
-    br block29(v322, v7)
+    v412 = add v296, v292  : i32
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_inuse_and_pinuse17h515e5a69a6d1edc6E(v291, v412)
+    br block29(v294, v7)
 
 block34:
-    v397 = const.i32 -8  : i32
-    v398 = band v338, v397  : i32
-    v399 = add v322, v398  : i32
-    v400 = const.i32 144  : i32
-    v401 = add v399, v400  : i32
-    v402 = cast v322  : u32
-    v403 = add v402, 424  : u32
-    v404 = inttoptr v403  : *mut i32
-    v405 = load v404  : i32
-    v406 = cast v322  : u32
-    v407 = add v406, 408  : u32
-    v408 = inttoptr v407  : *mut i32
-    v409 = load v408  : i32
-    v410 = const.i32 1  : i32
-    v411 = const.i32 3  : i32
-    v412 = cast v338  : u32
-    v413 = cast v411  : u32
-    v414 = shr v412, v413  : u32
-    v415 = cast v414  : i32
-    v416 = shl v410, v415  : i32
-    v417 = band v409, v416  : i32
-    v418 = const.i32 0  : i32
-    v419 = eq v417, v418  : i1
-    v420 = cast v419  : i32
-    v421 = const.i32 0  : i32
-    v422 = neq v420, v421  : i1
-    condbr v422, block50, block51
+    v365 = const.i32 -8  : i32
+    v366 = band v309, v365  : i32
+    v367 = add v294, v366  : i32
+    v368 = const.i32 144  : i32
+    v369 = add v367, v368  : i32
+    v370 = cast v294  : u32
+    v371 = add v370, 424  : u32
+    v372 = inttoptr v371  : *mut i32
+    v373 = load v372  : i32
+    v374 = cast v294  : u32
+    v375 = add v374, 408  : u32
+    v376 = inttoptr v375  : *mut i32
+    v377 = load v376  : i32
+    v378 = const.i32 1  : i32
+    v379 = const.i32 3  : i32
+    v380 = cast v309  : u32
+    v381 = cast v379  : u32
+    v382 = shr v380, v381  : u32
+    v383 = cast v382  : i32
+    v384 = shl v378, v383  : i32
+    v385 = band v377, v384  : i32
+    v386 = eq v385, 0  : i1
+    v387 = cast v386  : i32
+    v388 = neq v387, 0  : i1
+    condbr v388, block50, block51
 
 block35:
-    v341 = const.i32 144  : i32
-    v342 = add v0, v341  : i32
-    v343 = const.i32 1  : i32
-    v344 = const.i32 31  : i32
-    v345 = band v208, v344  : i32
-    v346 = shl v343, v345  : i32
-    v347 = call noname::_ZN8dlmalloc8dlmalloc9left_bits17hb6cbe146b8019d98E(v346)  : i32
-    v348 = shl v212, v345  : i32
-    v349 = band v347, v348  : i32
-    v350 = call noname::_ZN8dlmalloc8dlmalloc9least_bit17h4bca52ead665dc5aE(v349)  : i32
-    v351 = popcnt v350  : i32
-    v352 = const.i32 3  : i32
-    v353 = shl v351, v352  : i32
-    v354 = add v342, v353  : i32
-    v355 = cast v354  : u32
-    v356 = add v355, 8  : u32
-    v357 = inttoptr v356  : *mut i32
-    v358 = load v357  : i32
-    v359 = cast v358  : u32
-    v360 = add v359, 8  : u32
-    v361 = inttoptr v360  : *mut i32
-    v362 = load v361  : i32
-    v363 = eq v362, v354  : i1
-    v364 = cast v363  : i32
-    v365 = const.i32 0  : i32
-    v366 = neq v364, v365  : i1
-    condbr v366, block46, block47
+    v311 = const.i32 144  : i32
+    v312 = add v0, v311  : i32
+    v313 = const.i32 1  : i32
+    v314 = const.i32 31  : i32
+    v315 = band v192, v314  : i32
+    v316 = shl v313, v315  : i32
+    v317 = call noname::_ZN8dlmalloc8dlmalloc9left_bits17hb6cbe146b8019d98E(v316)  : i32
+    v318 = shl v196, v315  : i32
+    v319 = band v317, v318  : i32
+    v320 = call noname::_ZN8dlmalloc8dlmalloc9least_bit17h4bca52ead665dc5aE(v319)  : i32
+    v321 = popcnt v320  : i32
+    v322 = const.i32 3  : i32
+    v323 = shl v321, v322  : i32
+    v324 = add v312, v323  : i32
+    v325 = cast v324  : u32
+    v326 = add v325, 8  : u32
+    v327 = inttoptr v326  : *mut i32
+    v328 = load v327  : i32
+    v329 = cast v328  : u32
+    v330 = add v329, 8  : u32
+    v331 = inttoptr v330  : *mut i32
+    v332 = load v331  : i32
+    v333 = eq v332, v324  : i1
+    v334 = cast v333  : i32
+    v335 = neq v334, 0  : i1
+    condbr v335, block46, block47
 
 block36:
-    v272 = cast v0  : u32
-    v273 = add v272, 412  : u32
-    v274 = inttoptr v273  : *mut i32
-    v275 = load v274  : i32
-    v276 = const.i32 0  : i32
-    v277 = eq v275, v276  : i1
-    v278 = cast v277  : i32
-    v279 = const.i32 0  : i32
-    v280 = neq v278, v279  : i1
-    condbr v280, block3(v0, v199, v7), block37
+    v251 = cast v0  : u32
+    v252 = add v251, 412  : u32
+    v253 = inttoptr v252  : *mut i32
+    v254 = load v253  : i32
+    v255 = eq v254, 0  : i1
+    v256 = cast v255  : i32
+    v257 = neq v256, 0  : i1
+    condbr v257, block3(v0, v183, v7), block37
 
 block37:
-    v281 = call noname::_ZN8dlmalloc8dlmalloc9least_bit17h4bca52ead665dc5aE(v275)  : i32
-    v282 = popcnt v281  : i32
-    v283 = const.i32 2  : i32
-    v284 = shl v282, v283  : i32
-    v285 = add v0, v284  : i32
-    v286 = cast v285  : u32
-    v287 = inttoptr v286  : *mut i32
-    v288 = load v287  : i32
-    v289 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v288)  : i32
-    v290 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v289)  : i32
-    v291 = sub v290, v199  : i32
-    v292 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk14leftmost_child17h20605933c801b44bE(v288)  : i32
-    v293 = const.i32 0  : i32
-    v294 = eq v292, v293  : i1
-    v295 = cast v294  : i32
-    v296 = const.i32 0  : i32
-    v297 = neq v295, v296  : i1
-    condbr v297, block38(v288, v199, v291), block39
+    v258 = call noname::_ZN8dlmalloc8dlmalloc9least_bit17h4bca52ead665dc5aE(v254)  : i32
+    v259 = popcnt v258  : i32
+    v260 = const.i32 2  : i32
+    v261 = shl v259, v260  : i32
+    v262 = add v0, v261  : i32
+    v263 = cast v262  : u32
+    v264 = inttoptr v263  : *mut i32
+    v265 = load v264  : i32
+    v266 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v265)  : i32
+    v267 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v266)  : i32
+    v268 = sub v267, v183  : i32
+    v269 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk14leftmost_child17h20605933c801b44bE(v265)  : i32
+    v270 = eq v269, 0  : i1
+    v271 = cast v270  : i32
+    v272 = neq v271, 0  : i1
+    condbr v272, block38(v265, v183, v268), block39
 
-block38(v318: i32, v320: i32, v324: i32):
-    v319 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v318)  : i32
-    v321 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v319, v320)  : i32
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v0, v318)
-    v325 = const.i32 16  : i32
-    v326 = const.i32 8  : i32
-    v327 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v325, v326)  : i32
-    v328 = cast v324  : u32
-    v329 = cast v327  : u32
-    v330 = lt v328, v329  : i1
-    v331 = cast v330  : i32
-    v332 = const.i32 0  : i32
-    v333 = neq v331, v332  : i1
-    condbr v333, block33, block43
+block38(v290: i32, v292: i32, v296: i32):
+    v291 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v290)  : i32
+    v293 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v291, v292)  : i32
+    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v0, v290)
+    v297 = const.i32 16  : i32
+    v298 = const.i32 8  : i32
+    v299 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v297, v298)  : i32
+    v300 = cast v296  : u32
+    v301 = cast v299  : u32
+    v302 = lt v300, v301  : i1
+    v303 = cast v302  : i32
+    v304 = neq v303, 0  : i1
+    condbr v304, block33, block43
 
 block39:
-    br block40(v292, v291, v288)
+    br block40(v269, v268, v265)
 
-block40(v298: i32, v303: i32, v311: i32):
-    v299 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v298)  : i32
-    v300 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v299)  : i32
-    v302 = sub v300, v301  : i32
-    v304 = cast v302  : u32
-    v305 = cast v303  : u32
-    v306 = lt v304, v305  : i1
-    v307 = cast v306  : i32
-    v308 = const.i32 0  : i32
-    v309 = neq v307, v308  : i1
-    v310 = select v309, v302, v303  : i32
-    v312 = const.i32 0  : i32
-    v313 = neq v307, v312  : i1
-    v314 = select v313, v298, v311  : i32
-    v315 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk14leftmost_child17h20605933c801b44bE(v298)  : i32
-    v316 = const.i32 0  : i32
-    v317 = neq v315, v316  : i1
-    condbr v317, block40(v315, v310, v314), block42
+block40(v273: i32, v278: i32, v285: i32):
+    v274 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v273)  : i32
+    v275 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v274)  : i32
+    v277 = sub v275, v276  : i32
+    v279 = cast v277  : u32
+    v280 = cast v278  : u32
+    v281 = lt v279, v280  : i1
+    v282 = cast v281  : i32
+    v283 = neq v282, 0  : i1
+    v284 = select v283, v277, v278  : i32
+    v286 = neq v282, 0  : i1
+    v287 = select v286, v273, v285  : i32
+    v288 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk14leftmost_child17h20605933c801b44bE(v273)  : i32
+    v289 = neq v288, 0  : i1
+    condbr v289, block40(v288, v284, v287), block42
 
 block41:
-    br block38(v314, v301, v310)
+    br block38(v287, v276, v284)
 
 block42:
     br block41
 
 block43:
-    v334 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v321)  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(v319, v320)
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v334, v324)
-    v335 = cast v322  : u32
-    v336 = add v335, 416  : u32
-    v337 = inttoptr v336  : *mut i32
-    v338 = load v337  : i32
-    v339 = const.i32 0  : i32
-    v340 = neq v338, v339  : i1
-    condbr v340, block34, block44
+    v305 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v293)  : i32
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(v291, v292)
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v305, v296)
+    v306 = cast v294  : u32
+    v307 = add v306, 416  : u32
+    v308 = inttoptr v307  : *mut i32
+    v309 = load v308  : i32
+    v310 = neq v309, 0  : i1
+    condbr v310, block34, block44
 
 block44:
     br block30
 
 block45:
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(v358, v199)
-    v385 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v383, v384)  : i32
-    v387 = const.i32 3  : i32
-    v388 = shl v351, v387  : i32
-    v389 = sub v388, v384  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v385, v389)
-    v391 = cast v0  : u32
-    v392 = add v391, 416  : u32
-    v393 = inttoptr v392  : *mut i32
-    v394 = load v393  : i32
-    v395 = const.i32 0  : i32
-    v396 = neq v394, v395  : i1
-    condbr v396, block32, block48
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(v328, v183)
+    v354 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v352, v353)  : i32
+    v356 = const.i32 3  : i32
+    v357 = shl v321, v356  : i32
+    v358 = sub v357, v353  : i32
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v354, v358)
+    v360 = cast v0  : u32
+    v361 = add v360, 416  : u32
+    v362 = inttoptr v361  : *mut i32
+    v363 = load v362  : i32
+    v364 = neq v363, 0  : i1
+    condbr v364, block32, block48
 
 block46:
-    v373 = cast v0  : u32
-    v374 = add v373, 408  : u32
-    v375 = inttoptr v374  : *mut i32
-    v376 = load v375  : i32
-    v377 = const.i32 -2  : i32
-    v378 = shl v377, v351  : i32
-    v379 = band v376, v378  : i32
-    v380 = cast v0  : u32
-    v381 = add v380, 408  : u32
-    v382 = inttoptr v381  : *mut i32
-    store v382, v379
+    v342 = cast v0  : u32
+    v343 = add v342, 408  : u32
+    v344 = inttoptr v343  : *mut i32
+    v345 = load v344  : i32
+    v346 = const.i32 -2  : i32
+    v347 = shl v346, v321  : i32
+    v348 = band v345, v347  : i32
+    v349 = cast v0  : u32
+    v350 = add v349, 408  : u32
+    v351 = inttoptr v350  : *mut i32
+    store v351, v348
     br block45
 
 block47:
-    v367 = cast v362  : u32
-    v368 = add v367, 12  : u32
-    v369 = inttoptr v368  : *mut i32
-    store v369, v354
-    v370 = cast v354  : u32
-    v371 = add v370, 8  : u32
-    v372 = inttoptr v371  : *mut i32
-    store v372, v362
+    v336 = cast v332  : u32
+    v337 = add v336, 12  : u32
+    v338 = inttoptr v337  : *mut i32
+    store v338, v324
+    v339 = cast v324  : u32
+    v340 = add v339, 8  : u32
+    v341 = inttoptr v340  : *mut i32
+    store v341, v332
     br block45
 
 block48:
     br block31(v7)
 
-block49(v436: i32):
-    v433 = cast v401  : u32
-    v434 = add v433, 8  : u32
-    v435 = inttoptr v434  : *mut i32
-    store v435, v405
-    v437 = cast v436  : u32
-    v438 = add v437, 12  : u32
-    v439 = inttoptr v438  : *mut i32
-    store v439, v432
-    v440 = cast v432  : u32
-    v441 = add v440, 12  : u32
-    v442 = inttoptr v441  : *mut i32
-    store v442, v431
-    v443 = cast v432  : u32
-    v444 = add v443, 8  : u32
-    v445 = inttoptr v444  : *mut i32
-    store v445, v436
+block49(v402: i32):
+    v399 = cast v369  : u32
+    v400 = add v399, 8  : u32
+    v401 = inttoptr v400  : *mut i32
+    store v401, v373
+    v403 = cast v402  : u32
+    v404 = add v403, 12  : u32
+    v405 = inttoptr v404  : *mut i32
+    store v405, v398
+    v406 = cast v398  : u32
+    v407 = add v406, 12  : u32
+    v408 = inttoptr v407  : *mut i32
+    store v408, v397
+    v409 = cast v398  : u32
+    v410 = add v409, 8  : u32
+    v411 = inttoptr v410  : *mut i32
+    store v411, v402
     br block30
 
 block50:
-    v427 = bor v409, v416  : i32
-    v428 = cast v322  : u32
-    v429 = add v428, 408  : u32
-    v430 = inttoptr v429  : *mut i32
-    store v430, v427
-    br block49(v401)
+    v393 = bor v377, v384  : i32
+    v394 = cast v294  : u32
+    v395 = add v394, 408  : u32
+    v396 = inttoptr v395  : *mut i32
+    store v396, v393
+    br block49(v369)
 
 block51:
-    v423 = cast v401  : u32
-    v424 = add v423, 8  : u32
-    v425 = inttoptr v424  : *mut i32
-    v426 = load v425  : i32
-    br block49(v426)
+    v389 = cast v369  : u32
+    v390 = add v389, 8  : u32
+    v391 = inttoptr v390  : *mut i32
+    v392 = load v391  : i32
+    br block49(v392)
 
-block52(v485: i32):
-    v482 = cast v450  : u32
-    v483 = add v482, 8  : u32
-    v484 = inttoptr v483  : *mut i32
-    store v484, v454
-    v486 = cast v485  : u32
-    v487 = add v486, 12  : u32
-    v488 = inttoptr v487  : *mut i32
-    store v488, v481
-    v489 = cast v481  : u32
-    v490 = add v489, 12  : u32
-    v491 = inttoptr v490  : *mut i32
-    store v491, v480
-    v492 = cast v481  : u32
-    v493 = add v492, 8  : u32
-    v494 = inttoptr v493  : *mut i32
-    store v494, v485
-    br block31(v1574)
+block52(v449: i32):
+    v446 = cast v416  : u32
+    v447 = add v446, 8  : u32
+    v448 = inttoptr v447  : *mut i32
+    store v448, v420
+    v450 = cast v449  : u32
+    v451 = add v450, 12  : u32
+    v452 = inttoptr v451  : *mut i32
+    store v452, v445
+    v453 = cast v445  : u32
+    v454 = add v453, 12  : u32
+    v455 = inttoptr v454  : *mut i32
+    store v455, v444
+    v456 = cast v445  : u32
+    v457 = add v456, 8  : u32
+    v458 = inttoptr v457  : *mut i32
+    store v458, v449
+    br block31(v1480)
 
 block53:
-    v476 = bor v458, v465  : i32
-    v477 = cast v390  : u32
-    v478 = add v477, 408  : u32
-    v479 = inttoptr v478  : *mut i32
-    store v479, v476
-    br block52(v450)
+    v440 = bor v424, v431  : i32
+    v441 = cast v359  : u32
+    v442 = add v441, 408  : u32
+    v443 = inttoptr v442  : *mut i32
+    store v443, v440
+    br block52(v416)
 
 block54:
-    v472 = cast v450  : u32
-    v473 = add v472, 8  : u32
-    v474 = inttoptr v473  : *mut i32
-    v475 = load v474  : i32
-    br block52(v475)
+    v436 = cast v416  : u32
+    v437 = add v436, 8  : u32
+    v438 = inttoptr v437  : *mut i32
+    v439 = load v438  : i32
+    br block52(v439)
 
 block55:
-    br block2(v740, v525)
+    br block2(v683, v489)
 
-block56(v567: i32, v600: i32):
-    v568 = const.i32 0  : i32
-    v569 = eq v567, v568  : i1
-    v570 = cast v569  : i32
-    v571 = const.i32 0  : i32
-    v572 = neq v570, v571  : i1
-    condbr v572, block4(v600, v555, v602, v605, v745), block59
+block56(v526: i32, v554: i32):
+    v527 = eq v526, 0  : i1
+    v528 = cast v527  : i32
+    v529 = neq v528, 0  : i1
+    condbr v529, block4(v554, v514, v556, v559, v688), block59
 
 block57:
-    v539 = const.i32 1  : i32
-    v543 = shl v539, v540  : i32
-    v544 = call noname::_ZN8dlmalloc8dlmalloc9left_bits17hb6cbe146b8019d98E(v543)  : i32
-    v549 = band v544, v545  : i32
-    v550 = const.i32 0  : i32
-    v551 = eq v549, v550  : i1
-    v552 = cast v551  : i32
-    v553 = const.i32 0  : i32
-    v554 = neq v552, v553  : i1
-    condbr v554, block3(v555, v603, v745), block58
+    v500 = const.i32 1  : i32
+    v504 = shl v500, v501  : i32
+    v505 = call noname::_ZN8dlmalloc8dlmalloc9left_bits17hb6cbe146b8019d98E(v504)  : i32
+    v510 = band v505, v506  : i32
+    v511 = eq v510, 0  : i1
+    v512 = cast v511  : i32
+    v513 = neq v512, 0  : i1
+    condbr v513, block3(v514, v557, v688), block58
 
 block58:
-    v558 = call noname::_ZN8dlmalloc8dlmalloc9least_bit17h4bca52ead665dc5aE(v549)  : i32
-    v559 = popcnt v558  : i32
-    v560 = const.i32 2  : i32
-    v561 = shl v559, v560  : i32
-    v562 = add v555, v561  : i32
-    v563 = cast v562  : u32
-    v564 = inttoptr v563  : *mut i32
-    v565 = load v564  : i32
-    v566 = const.i32 0  : i32
-    br block56(v565, v566)
+    v517 = call noname::_ZN8dlmalloc8dlmalloc9least_bit17h4bca52ead665dc5aE(v510)  : i32
+    v518 = popcnt v517  : i32
+    v519 = const.i32 2  : i32
+    v520 = shl v518, v519  : i32
+    v521 = add v514, v520  : i32
+    v522 = cast v521  : u32
+    v523 = inttoptr v522  : *mut i32
+    v524 = load v523  : i32
+    v525 = const.i32 0  : i32
+    br block56(v524, v525)
 
 block59:
-    br block5(v567, v600, v603, v606, v614, v750)
+    br block5(v526, v554, v557, v560, v566, v693)
 
-block60(v573: i32, v574: i32, v583: i32):
-    v575 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v573)  : i32
-    v576 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v575)  : i32
-    v578 = cast v576  : u32
-    v579 = cast v577  : u32
-    v580 = gte v578, v579  : i1
-    v581 = cast v580  : i32
-    v582 = sub v576, v577  : i32
-    v584 = cast v582  : u32
-    v585 = cast v583  : u32
-    v586 = lt v584, v585  : i1
-    v587 = cast v586  : i32
-    v588 = band v581, v587  : i32
-    v589 = const.i32 0  : i32
-    v590 = neq v588, v589  : i1
-    v591 = select v590, v573, v574  : i32
-    v592 = const.i32 0  : i32
-    v593 = neq v588, v592  : i1
-    v594 = select v593, v582, v583  : i32
-    v595 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk14leftmost_child17h20605933c801b44bE(v573)  : i32
-    v596 = const.i32 0  : i32
-    v597 = neq v595, v596  : i1
-    condbr v597, block60(v595, v591, v594), block62
+block60(v530: i32, v531: i32, v540: i32):
+    v532 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v530)  : i32
+    v533 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v532)  : i32
+    v535 = cast v533  : u32
+    v536 = cast v534  : u32
+    v537 = gte v535, v536  : i1
+    v538 = cast v537  : i32
+    v539 = sub v533, v534  : i32
+    v541 = cast v539  : u32
+    v542 = cast v540  : u32
+    v543 = lt v541, v542  : i1
+    v544 = cast v543  : i32
+    v545 = band v538, v544  : i32
+    v546 = neq v545, 0  : i1
+    v547 = select v546, v530, v531  : i32
+    v548 = neq v545, 0  : i1
+    v549 = select v548, v539, v540  : i32
+    v550 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk14leftmost_child17h20605933c801b44bE(v530)  : i32
+    v551 = neq v550, 0  : i1
+    condbr v551, block60(v550, v547, v549), block62
 
 block61:
-    br block4(v591, v616, v577, v594, v752)
+    br block4(v547, v568, v534, v549, v695)
 
 block62:
     br block61
 
 block63:
-    v617 = cast v613  : u32
-    v618 = add v617, 416  : u32
-    v619 = inttoptr v618  : *mut i32
-    v620 = load v619  : i32
-    v622 = cast v620  : u32
-    v623 = cast v621  : u32
-    v624 = lt v622, v623  : i1
-    v625 = cast v624  : i32
-    v626 = const.i32 0  : i32
-    v627 = neq v625, v626  : i1
-    condbr v627, block64, block65
+    v569 = cast v565  : u32
+    v570 = add v569, 416  : u32
+    v571 = inttoptr v570  : *mut i32
+    v572 = load v571  : i32
+    v574 = cast v572  : u32
+    v575 = cast v573  : u32
+    v576 = lt v574, v575  : i1
+    v577 = cast v576  : i32
+    v578 = neq v577, 0  : i1
+    condbr v578, block64, block65
 
 block64:
-    v637 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v607)  : i32
-    v639 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v637, v621)  : i32
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v613, v636)
-    v642 = const.i32 16  : i32
-    v643 = const.i32 8  : i32
-    v644 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v642, v643)  : i32
-    v645 = cast v628  : u32
-    v646 = cast v644  : u32
-    v647 = lt v645, v646  : i1
-    v648 = cast v647  : i32
-    v649 = const.i32 0  : i32
-    v650 = neq v648, v649  : i1
-    condbr v650, block68, block69
+    v587 = call noname::_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(v561)  : i32
+    v589 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v587, v573)  : i32
+    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v565, v586)
+    v592 = const.i32 16  : i32
+    v593 = const.i32 8  : i32
+    v594 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v592, v593)  : i32
+    v595 = cast v579  : u32
+    v596 = cast v594  : u32
+    v597 = lt v595, v596  : i1
+    v598 = cast v597  : i32
+    v599 = neq v598, 0  : i1
+    condbr v599, block68, block69
 
 block65:
-    v629 = sub v620, v621  : i32
-    v630 = cast v628  : u32
-    v631 = cast v629  : u32
-    v632 = gte v630, v631  : i1
-    v633 = cast v632  : i32
-    v634 = const.i32 0  : i32
-    v635 = neq v633, v634  : i1
-    condbr v635, block3(v613, v621, v749), block66
+    v580 = sub v572, v573  : i32
+    v581 = cast v579  : u32
+    v582 = cast v580  : u32
+    v583 = gte v581, v582  : i1
+    v584 = cast v583  : i32
+    v585 = neq v584, 0  : i1
+    condbr v585, block3(v565, v573, v692), block66
 
 block66:
     br block64
 
-block67(v753: i32):
-    v706 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v637)  : i32
-    v707 = const.i32 0  : i32
-    v708 = neq v706, v707  : i1
-    condbr v708, block2(v753, v706), block75
+block67(v696: i32):
+    v652 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v587)  : i32
+    v653 = neq v652, 0  : i1
+    condbr v653, block2(v696, v652), block75
 
 block68:
-    v703 = add v641, v638  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_inuse_and_pinuse17h515e5a69a6d1edc6E(v637, v703)
-    br block67(v754)
+    v649 = add v591, v588  : i32
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_inuse_and_pinuse17h515e5a69a6d1edc6E(v587, v649)
+    br block67(v697)
 
 block69:
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(v637, v638)
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v639, v641)
-    v651 = const.i32 256  : i32
-    v652 = cast v641  : u32
-    v653 = cast v651  : u32
-    v654 = lt v652, v653  : i1
-    v655 = cast v654  : i32
-    v656 = const.i32 0  : i32
-    v657 = neq v655, v656  : i1
-    condbr v657, block70, block71
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(v587, v588)
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v589, v591)
+    v600 = const.i32 256  : i32
+    v601 = cast v591  : u32
+    v602 = cast v600  : u32
+    v603 = lt v601, v602  : i1
+    v604 = cast v603  : i32
+    v605 = neq v604, 0  : i1
+    condbr v605, block70, block71
 
 block70:
-    v658 = const.i32 -8  : i32
-    v659 = band v641, v658  : i32
-    v660 = add v640, v659  : i32
-    v661 = const.i32 144  : i32
-    v662 = add v660, v661  : i32
-    v663 = cast v640  : u32
-    v664 = add v663, 408  : u32
-    v665 = inttoptr v664  : *mut i32
-    v666 = load v665  : i32
-    v667 = const.i32 1  : i32
-    v668 = const.i32 3  : i32
-    v669 = cast v641  : u32
-    v670 = cast v668  : u32
-    v671 = shr v669, v670  : u32
-    v672 = cast v671  : i32
-    v673 = shl v667, v672  : i32
-    v674 = band v666, v673  : i32
-    v675 = const.i32 0  : i32
-    v676 = eq v674, v675  : i1
-    v677 = cast v676  : i32
-    v678 = const.i32 0  : i32
-    v679 = neq v677, v678  : i1
-    condbr v679, block73, block74
+    v606 = const.i32 -8  : i32
+    v607 = band v591, v606  : i32
+    v608 = add v590, v607  : i32
+    v609 = const.i32 144  : i32
+    v610 = add v608, v609  : i32
+    v611 = cast v590  : u32
+    v612 = add v611, 408  : u32
+    v613 = inttoptr v612  : *mut i32
+    v614 = load v613  : i32
+    v615 = const.i32 1  : i32
+    v616 = const.i32 3  : i32
+    v617 = cast v591  : u32
+    v618 = cast v616  : u32
+    v619 = shr v617, v618  : u32
+    v620 = cast v619  : i32
+    v621 = shl v615, v620  : i32
+    v622 = band v614, v621  : i32
+    v623 = eq v622, 0  : i1
+    v624 = cast v623  : i32
+    v625 = neq v624, 0  : i1
+    condbr v625, block73, block74
 
 block71:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E(v640, v639, v641)
-    br block67(v749)
+    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E(v590, v589, v591)
+    br block67(v692)
 
-block72(v693: i32):
-    v690 = cast v662  : u32
-    v691 = add v690, 8  : u32
-    v692 = inttoptr v691  : *mut i32
-    store v692, v639
-    v694 = cast v693  : u32
-    v695 = add v694, 12  : u32
-    v696 = inttoptr v695  : *mut i32
-    store v696, v689
-    v697 = cast v689  : u32
-    v698 = add v697, 12  : u32
-    v699 = inttoptr v698  : *mut i32
-    store v699, v688
-    v700 = cast v689  : u32
-    v701 = add v700, 8  : u32
-    v702 = inttoptr v701  : *mut i32
-    store v702, v693
-    br block67(v754)
+block72(v639: i32):
+    v636 = cast v610  : u32
+    v637 = add v636, 8  : u32
+    v638 = inttoptr v637  : *mut i32
+    store v638, v589
+    v640 = cast v639  : u32
+    v641 = add v640, 12  : u32
+    v642 = inttoptr v641  : *mut i32
+    store v642, v635
+    v643 = cast v635  : u32
+    v644 = add v643, 12  : u32
+    v645 = inttoptr v644  : *mut i32
+    store v645, v634
+    v646 = cast v635  : u32
+    v647 = add v646, 8  : u32
+    v648 = inttoptr v647  : *mut i32
+    store v648, v639
+    br block67(v697)
 
 block73:
-    v684 = bor v666, v673  : i32
-    v685 = cast v640  : u32
-    v686 = add v685, 408  : u32
-    v687 = inttoptr v686  : *mut i32
-    store v687, v684
-    br block72(v662)
+    v630 = bor v614, v621  : i32
+    v631 = cast v590  : u32
+    v632 = add v631, 408  : u32
+    v633 = inttoptr v632  : *mut i32
+    store v633, v630
+    br block72(v610)
 
 block74:
-    v680 = cast v662  : u32
-    v681 = add v680, 8  : u32
-    v682 = inttoptr v681  : *mut i32
-    v683 = load v682  : i32
-    br block72(v683)
+    v626 = cast v610  : u32
+    v627 = add v626, 8  : u32
+    v628 = inttoptr v627  : *mut i32
+    v629 = load v628  : i32
+    br block72(v629)
 
 block75:
-    br block3(v640, v638, v753)
+    br block3(v590, v588, v696)
 
-block76(v1531: i32, v1537: i32, v1582: i32, v1596: i32):
-    v1533 = cast v1531  : u32
-    v1534 = add v1533, 420  : u32
-    v1535 = inttoptr v1534  : *mut i32
-    v1536 = load v1535  : i32
-    v1547 = cast v1536  : u32
-    v1548 = cast v1537  : u32
-    v1549 = lte v1547, v1548  : i1
-    v1550 = cast v1549  : i32
-    v1551 = const.i32 0  : i32
-    v1552 = neq v1550, v1551  : i1
-    condbr v1552, block2(v1582, v1596), block144
+block76(v1438: i32, v1444: i32, v1488: i32, v1502: i32):
+    v1440 = cast v1438  : u32
+    v1441 = add v1440, 420  : u32
+    v1442 = inttoptr v1441  : *mut i32
+    v1443 = load v1442  : i32
+    v1454 = cast v1443  : u32
+    v1455 = cast v1444  : u32
+    v1456 = lte v1454, v1455  : i1
+    v1457 = cast v1456  : i32
+    v1458 = neq v1457, 0  : i1
+    condbr v1458, block2(v1488, v1502), block144
 
-block77(v1413: i32, v1418: i32):
-    v1414 = const.i32 4095  : i32
-    v1415 = cast v1413  : u32
-    v1416 = add v1415, 448  : u32
-    v1417 = inttoptr v1416  : *mut i32
-    store v1417, v1414
-    v1419 = cast v1413  : u32
-    v1420 = add v1419, 128  : u32
-    v1421 = inttoptr v1420  : *mut i32
-    store v1421, v1418
-    v1422 = const.i32 140  : i32
-    v1423 = add v1413, v1422  : i32
-    v1426 = cast v1423  : u32
-    v1427 = inttoptr v1426  : *mut i32
-    store v1427, v788
-    v1428 = const.i32 132  : i32
-    v1429 = add v1413, v1428  : i32
-    v1432 = cast v1429  : u32
-    v1433 = inttoptr v1432  : *mut i32
-    store v1433, v796
-    v1434 = const.i32 0  : i32
-    br block141(v1434)
+block77(v1321: i32, v1326: i32):
+    v1322 = const.i32 4095  : i32
+    v1323 = cast v1321  : u32
+    v1324 = add v1323, 448  : u32
+    v1325 = inttoptr v1324  : *mut i32
+    store v1325, v1322
+    v1327 = cast v1321  : u32
+    v1328 = add v1327, 128  : u32
+    v1329 = inttoptr v1328  : *mut i32
+    store v1329, v1326
+    v1330 = const.i32 140  : i32
+    v1331 = add v1321, v1330  : i32
+    v1334 = cast v1331  : u32
+    v1335 = inttoptr v1334  : *mut i32
+    store v1335, v729
+    v1336 = const.i32 132  : i32
+    v1337 = add v1321, v1336  : i32
+    v1340 = cast v1337  : u32
+    v1341 = inttoptr v1340  : *mut i32
+    store v1341, v737
+    v1342 = const.i32 0  : i32
+    br block141(v1342)
 
-block78(v1352: i32, v1353: i32):
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E(v1176, v1352, v1353)
-    v1354 = const.i32 256  : i32
-    v1355 = cast v1352  : u32
-    v1356 = cast v1354  : u32
-    v1357 = lt v1355, v1356  : i1
-    v1358 = cast v1357  : i32
-    v1359 = const.i32 0  : i32
-    v1360 = neq v1358, v1359  : i1
-    condbr v1360, block136, block137
+block78(v1263: i32, v1264: i32):
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E(v1093, v1263, v1264)
+    v1265 = const.i32 256  : i32
+    v1266 = cast v1263  : u32
+    v1267 = cast v1265  : u32
+    v1268 = lt v1266, v1267  : i1
+    v1269 = cast v1268  : i32
+    v1270 = neq v1269, 0  : i1
+    condbr v1270, block136, block137
 
 block79:
-    v1337 = const.i32 0  : i32
-    v1338 = cast v709  : u32
-    v1339 = add v1338, 424  : u32
-    v1340 = inttoptr v1339  : *mut i32
-    store v1340, v1337
-    v1341 = cast v709  : u32
-    v1342 = add v1341, 416  : u32
-    v1343 = inttoptr v1342  : *mut i32
-    v1344 = load v1343  : i32
-    v1345 = const.i32 0  : i32
-    v1346 = cast v709  : u32
-    v1347 = add v1346, 416  : u32
-    v1348 = inttoptr v1347  : *mut i32
-    store v1348, v1345
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_inuse_and_pinuse17h515e5a69a6d1edc6E(v1284, v1344)
-    v1349 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1284)  : i32
-    br block2(v739, v1349)
+    v1248 = const.i32 0  : i32
+    v1249 = cast v654  : u32
+    v1250 = add v1249, 424  : u32
+    v1251 = inttoptr v1250  : *mut i32
+    store v1251, v1248
+    v1252 = cast v654  : u32
+    v1253 = add v1252, 416  : u32
+    v1254 = inttoptr v1253  : *mut i32
+    v1255 = load v1254  : i32
+    v1256 = const.i32 0  : i32
+    v1257 = cast v654  : u32
+    v1258 = add v1257, 416  : u32
+    v1259 = inttoptr v1258  : *mut i32
+    store v1259, v1256
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_inuse_and_pinuse17h515e5a69a6d1edc6E(v1196, v1255)
+    v1260 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1196)  : i32
+    br block2(v682, v1260)
 
 block80:
-    v1325 = cast v915  : u32
-    v1326 = add v1325, 424  : u32
-    v1327 = inttoptr v1326  : *mut i32
-    store v1327, v1176
-    v1328 = cast v915  : u32
-    v1329 = add v1328, 416  : u32
-    v1330 = inttoptr v1329  : *mut i32
-    v1331 = load v1330  : i32
-    v1332 = add v1331, v1180  : i32
-    v1333 = cast v915  : u32
-    v1334 = add v1333, 416  : u32
-    v1335 = inttoptr v1334  : *mut i32
-    store v1335, v1332
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v1176, v1332)
-    v1336 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1172)  : i32
-    br block2(v1576, v1336)
+    v1236 = cast v841  : u32
+    v1237 = add v1236, 424  : u32
+    v1238 = inttoptr v1237  : *mut i32
+    store v1238, v1093
+    v1239 = cast v841  : u32
+    v1240 = add v1239, 416  : u32
+    v1241 = inttoptr v1240  : *mut i32
+    v1242 = load v1241  : i32
+    v1243 = add v1242, v1097  : i32
+    v1244 = cast v841  : u32
+    v1245 = add v1244, 416  : u32
+    v1246 = inttoptr v1245  : *mut i32
+    store v1246, v1243
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v1093, v1243)
+    v1247 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1089)  : i32
+    br block2(v1482, v1247)
 
 block81:
-    v1308 = cast v839  : u32
-    v1309 = add v1308, 4  : u32
-    v1310 = inttoptr v1309  : *mut i32
-    v1311 = load v1310  : i32
-    v1312 = add v1311, v885  : i32
-    v1313 = cast v839  : u32
-    v1314 = add v1313, 4  : u32
-    v1315 = inttoptr v1314  : *mut i32
-    store v1315, v1312
-    v1316 = cast v860  : u32
-    v1317 = add v1316, 428  : u32
-    v1318 = inttoptr v1317  : *mut i32
-    v1319 = load v1318  : i32
-    v1320 = cast v860  : u32
-    v1321 = add v1320, 420  : u32
-    v1322 = inttoptr v1321  : *mut i32
-    v1323 = load v1322  : i32
-    v1324 = add v1323, v885  : i32
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$8init_top17he4cefe3b36a3bd87E(v860, v1319, v1324)
-    br block76(v860, v1175, v1578, v1603)
+    v1219 = cast v775  : u32
+    v1220 = add v1219, 4  : u32
+    v1221 = inttoptr v1220  : *mut i32
+    v1222 = load v1221  : i32
+    v1223 = add v1222, v815  : i32
+    v1224 = cast v775  : u32
+    v1225 = add v1224, 4  : u32
+    v1226 = inttoptr v1225  : *mut i32
+    store v1226, v1223
+    v1227 = cast v792  : u32
+    v1228 = add v1227, 428  : u32
+    v1229 = inttoptr v1228  : *mut i32
+    v1230 = load v1229  : i32
+    v1231 = cast v792  : u32
+    v1232 = add v1231, 420  : u32
+    v1233 = inttoptr v1232  : *mut i32
+    v1234 = load v1233  : i32
+    v1235 = add v1234, v815  : i32
+    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$8init_top17he4cefe3b36a3bd87E(v792, v1230, v1235)
+    br block76(v792, v1092, v1484, v1509)
 
 block82:
-    v1305 = cast v709  : u32
-    v1306 = add v1305, 444  : u32
-    v1307 = inttoptr v1306  : *mut i32
-    store v1307, v779
-    br block77(v1303, v1304)
+    v1216 = cast v654  : u32
+    v1217 = add v1216, 444  : u32
+    v1218 = inttoptr v1217  : *mut i32
+    store v1218, v722
+    br block77(v1214, v1215)
 
 block83:
-    v1281 = cast v709  : u32
-    v1282 = add v1281, 424  : u32
-    v1283 = inttoptr v1282  : *mut i32
-    v1284 = load v1283  : i32
-    v1285 = sub v716, v717  : i32
-    v1286 = const.i32 16  : i32
-    v1287 = const.i32 8  : i32
-    v1288 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1286, v1287)  : i32
-    v1289 = cast v1285  : u32
-    v1290 = cast v1288  : u32
-    v1291 = lt v1289, v1290  : i1
-    v1292 = cast v1291  : i32
-    v1293 = const.i32 0  : i32
-    v1294 = neq v1292, v1293  : i1
-    condbr v1294, block79, block135
+    v1193 = cast v654  : u32
+    v1194 = add v1193, 424  : u32
+    v1195 = inttoptr v1194  : *mut i32
+    v1196 = load v1195  : i32
+    v1197 = sub v661, v662  : i32
+    v1198 = const.i32 16  : i32
+    v1199 = const.i32 8  : i32
+    v1200 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1198, v1199)  : i32
+    v1201 = cast v1197  : u32
+    v1202 = cast v1200  : u32
+    v1203 = lt v1201, v1202  : i1
+    v1204 = cast v1203  : i32
+    v1205 = neq v1204, 0  : i1
+    condbr v1205, block79, block135
 
 block84:
-    v729 = cast v709  : u32
-    v730 = add v729, 420  : u32
-    v731 = inttoptr v730  : *mut i32
-    v732 = load v731  : i32
-    v733 = cast v732  : u32
-    v734 = cast v717  : u32
-    v735 = gt v733, v734  : i1
-    v736 = cast v735  : i32
-    v737 = const.i32 0  : i32
-    v738 = neq v736, v737  : i1
-    condbr v738, block85, block86
+    v673 = cast v654  : u32
+    v674 = add v673, 420  : u32
+    v675 = inttoptr v674  : *mut i32
+    v676 = load v675  : i32
+    v677 = cast v676  : u32
+    v678 = cast v662  : u32
+    v679 = gt v677, v678  : i1
+    v680 = cast v679  : i32
+    v681 = neq v680, 0  : i1
+    condbr v681, block85, block86
 
 block85:
-    v1263 = sub v732, v717  : i32
-    v1264 = cast v709  : u32
-    v1265 = add v1264, 420  : u32
-    v1266 = inttoptr v1265  : *mut i32
-    store v1266, v1263
-    v1267 = cast v709  : u32
-    v1268 = add v1267, 428  : u32
-    v1269 = inttoptr v1268  : *mut i32
-    v1270 = load v1269  : i32
-    v1271 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1270, v717)  : i32
-    v1272 = cast v709  : u32
-    v1273 = add v1272, 428  : u32
-    v1274 = inttoptr v1273  : *mut i32
-    store v1274, v1271
-    v1275 = const.i32 1  : i32
-    v1276 = bor v1263, v1275  : i32
-    v1277 = cast v1271  : u32
-    v1278 = add v1277, 4  : u32
-    v1279 = inttoptr v1278  : *mut i32
-    store v1279, v1276
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(v1270, v717)
-    v1280 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1270)  : i32
-    br block2(v739, v1280)
+    v1175 = sub v676, v662  : i32
+    v1176 = cast v654  : u32
+    v1177 = add v1176, 420  : u32
+    v1178 = inttoptr v1177  : *mut i32
+    store v1178, v1175
+    v1179 = cast v654  : u32
+    v1180 = add v1179, 428  : u32
+    v1181 = inttoptr v1180  : *mut i32
+    v1182 = load v1181  : i32
+    v1183 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1182, v662)  : i32
+    v1184 = cast v654  : u32
+    v1185 = add v1184, 428  : u32
+    v1186 = inttoptr v1185  : *mut i32
+    store v1186, v1183
+    v1187 = const.i32 1  : i32
+    v1188 = bor v1175, v1187  : i32
+    v1189 = cast v1183  : u32
+    v1190 = add v1189, 4  : u32
+    v1191 = inttoptr v1190  : *mut i32
+    store v1191, v1188
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(v1182, v662)
+    v1192 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1182)  : i32
+    br block2(v682, v1192)
 
 block86:
-    v756 = const.i32 4  : i32
-    v757 = add v739, v756  : i32
-    v758 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
-    v759 = sub v717, v758  : i32
-    v760 = const.i32 8  : i32
-    v761 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v758, v760)  : i32
-    v762 = add v759, v761  : i32
-    v763 = const.i32 20  : i32
-    v764 = const.i32 8  : i32
-    v765 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v763, v764)  : i32
-    v766 = add v762, v765  : i32
-    v767 = const.i32 16  : i32
-    v768 = const.i32 8  : i32
-    v769 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v767, v768)  : i32
-    v770 = add v766, v769  : i32
-    v771 = const.i32 8  : i32
-    v772 = add v770, v771  : i32
-    v773 = const.i32 65536  : i32
-    v774 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v772, v773)  : i32
-    call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$5alloc17hdbf1e2bcc01bc909E(v757, v709, v774)
-    v775 = const.i32 0  : i32
-    v776 = cast v739  : u32
-    v777 = add v776, 4  : u32
-    v778 = inttoptr v777  : *mut i32
-    v779 = load v778  : i32
-    v780 = const.i32 0  : i32
-    v781 = eq v779, v780  : i1
-    v782 = cast v781  : i32
-    v783 = const.i32 0  : i32
-    v784 = neq v782, v783  : i1
-    condbr v784, block2(v739, v775), block87
+    v699 = const.i32 4  : i32
+    v700 = add v682, v699  : i32
+    v701 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v702 = sub v662, v701  : i32
+    v703 = const.i32 8  : i32
+    v704 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v701, v703)  : i32
+    v705 = add v702, v704  : i32
+    v706 = const.i32 20  : i32
+    v707 = const.i32 8  : i32
+    v708 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v706, v707)  : i32
+    v709 = add v705, v708  : i32
+    v710 = const.i32 16  : i32
+    v711 = const.i32 8  : i32
+    v712 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v710, v711)  : i32
+    v713 = add v709, v712  : i32
+    v714 = const.i32 8  : i32
+    v715 = add v713, v714  : i32
+    v716 = const.i32 65536  : i32
+    v717 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v715, v716)  : i32
+    call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$5alloc17hdbf1e2bcc01bc909E(v700, v654, v717)
+    v718 = const.i32 0  : i32
+    v719 = cast v682  : u32
+    v720 = add v719, 4  : u32
+    v721 = inttoptr v720  : *mut i32
+    v722 = load v721  : i32
+    v723 = eq v722, 0  : i1
+    v724 = cast v723  : i32
+    v725 = neq v724, 0  : i1
+    condbr v725, block2(v682, v718), block87
 
 block87:
-    v785 = cast v739  : u32
-    v786 = add v785, 12  : u32
-    v787 = inttoptr v786  : *mut i32
-    v788 = load v787  : i32
-    v789 = cast v709  : u32
-    v790 = add v789, 432  : u32
-    v791 = inttoptr v790  : *mut i32
-    v792 = load v791  : i32
-    v793 = cast v739  : u32
-    v794 = add v793, 8  : u32
-    v795 = inttoptr v794  : *mut i32
-    v796 = load v795  : i32
-    v797 = add v792, v796  : i32
-    v798 = cast v709  : u32
-    v799 = add v798, 432  : u32
-    v800 = inttoptr v799  : *mut i32
-    store v800, v797
-    v801 = cast v709  : u32
-    v802 = add v801, 436  : u32
-    v803 = inttoptr v802  : *mut i32
-    v804 = load v803  : i32
-    v805 = cast v804  : u32
-    v806 = cast v797  : u32
-    v807 = gt v805, v806  : i1
-    v808 = cast v807  : i32
-    v809 = const.i32 0  : i32
-    v810 = neq v808, v809  : i1
-    v811 = select v810, v804, v797  : i32
-    v812 = cast v709  : u32
-    v813 = add v812, 436  : u32
-    v814 = inttoptr v813  : *mut i32
-    store v814, v811
-    v815 = cast v709  : u32
-    v816 = add v815, 428  : u32
-    v817 = inttoptr v816  : *mut i32
-    v818 = load v817  : i32
-    v819 = const.i32 0  : i32
-    v820 = neq v818, v819  : i1
-    condbr v820, block88, block89
+    v726 = cast v682  : u32
+    v727 = add v726, 12  : u32
+    v728 = inttoptr v727  : *mut i32
+    v729 = load v728  : i32
+    v730 = cast v654  : u32
+    v731 = add v730, 432  : u32
+    v732 = inttoptr v731  : *mut i32
+    v733 = load v732  : i32
+    v734 = cast v682  : u32
+    v735 = add v734, 8  : u32
+    v736 = inttoptr v735  : *mut i32
+    v737 = load v736  : i32
+    v738 = add v733, v737  : i32
+    v739 = cast v654  : u32
+    v740 = add v739, 432  : u32
+    v741 = inttoptr v740  : *mut i32
+    store v741, v738
+    v742 = cast v654  : u32
+    v743 = add v742, 436  : u32
+    v744 = inttoptr v743  : *mut i32
+    v745 = load v744  : i32
+    v746 = cast v745  : u32
+    v747 = cast v738  : u32
+    v748 = gt v746, v747  : i1
+    v749 = cast v748  : i32
+    v750 = neq v749, 0  : i1
+    v751 = select v750, v745, v738  : i32
+    v752 = cast v654  : u32
+    v753 = add v752, 436  : u32
+    v754 = inttoptr v753  : *mut i32
+    store v754, v751
+    v755 = cast v654  : u32
+    v756 = add v755, 428  : u32
+    v757 = inttoptr v756  : *mut i32
+    v758 = load v757  : i32
+    v759 = neq v758, 0  : i1
+    condbr v759, block88, block89
 
 block88:
-    v836 = const.i32 128  : i32
-    v837 = add v709, v836  : i32
-    br block94(v837)
+    v772 = const.i32 128  : i32
+    v773 = add v654, v772  : i32
+    br block94(v773)
 
 block89:
-    v821 = cast v709  : u32
-    v822 = add v821, 444  : u32
-    v823 = inttoptr v822  : *mut i32
-    v824 = load v823  : i32
-    v825 = const.i32 0  : i32
-    v826 = eq v824, v825  : i1
-    v827 = cast v826  : i32
-    v828 = const.i32 0  : i32
-    v829 = neq v827, v828  : i1
-    condbr v829, block82, block90
+    v760 = cast v654  : u32
+    v761 = add v760, 444  : u32
+    v762 = inttoptr v761  : *mut i32
+    v763 = load v762  : i32
+    v764 = eq v763, 0  : i1
+    v765 = cast v764  : i32
+    v766 = neq v765, 0  : i1
+    condbr v766, block82, block90
 
 block90:
-    v830 = cast v779  : u32
-    v831 = cast v824  : u32
-    v832 = lt v830, v831  : i1
-    v833 = cast v832  : i32
-    v834 = const.i32 0  : i32
-    v835 = neq v833, v834  : i1
-    condbr v835, block82, block91
+    v767 = cast v722  : u32
+    v768 = cast v763  : u32
+    v769 = lt v767, v768  : i1
+    v770 = cast v769  : i32
+    v771 = neq v770, 0  : i1
+    condbr v771, block82, block91
 
 block91:
-    br block77(v709, v779)
+    br block77(v654, v722)
 
-block92(v884: i32, v887: i32, v1174: i32, v1577: i32, v1602: i32):
-    v869 = cast v868  : u32
-    v870 = add v869, 444  : u32
-    v871 = inttoptr v870  : *mut i32
-    v872 = load v871  : i32
-    v874 = cast v873  : u32
-    v875 = cast v872  : u32
-    v876 = gt v874, v875  : i1
-    v877 = cast v876  : i32
-    v878 = const.i32 0  : i32
-    v879 = neq v877, v878  : i1
-    v880 = select v879, v872, v838  : i32
-    v881 = cast v860  : u32
-    v882 = add v881, 444  : u32
-    v883 = inttoptr v882  : *mut i32
-    store v883, v880
-    v886 = add v873, v884  : i32
-    br block104(v887)
+block92(v814: i32, v817: i32, v1091: i32, v1483: i32, v1508: i32):
+    v800 = cast v799  : u32
+    v801 = add v800, 444  : u32
+    v802 = inttoptr v801  : *mut i32
+    v803 = load v802  : i32
+    v805 = cast v804  : u32
+    v806 = cast v803  : u32
+    v807 = gt v805, v806  : i1
+    v808 = cast v807  : i32
+    v809 = neq v808, 0  : i1
+    v810 = select v809, v803, v774  : i32
+    v811 = cast v792  : u32
+    v812 = add v811, 444  : u32
+    v813 = inttoptr v812  : *mut i32
+    store v813, v810
+    v816 = add v804, v814  : i32
+    br block104(v817)
 
 block93:
-    v851 = call noname::_ZN8dlmalloc8dlmalloc7Segment9is_extern17h6f6db2c70b891fd9E(v839)  : i32
-    v852 = const.i32 0  : i32
-    v853 = neq v851, v852  : i1
-    condbr v853, block92(v885, v888, v1175, v1578, v1603), block98
+    v785 = call noname::_ZN8dlmalloc8dlmalloc7Segment9is_extern17h6f6db2c70b891fd9E(v775)  : i32
+    v786 = neq v785, 0  : i1
+    condbr v786, block92(v815, v818, v1092, v1484, v1509), block98
 
-block94(v839: i32):
-    v840 = call noname::_ZN8dlmalloc8dlmalloc7Segment3top17he7e9e2493151d036E(v839)  : i32
-    v841 = eq v838, v840  : i1
-    v842 = cast v841  : i32
-    v843 = const.i32 0  : i32
-    v844 = neq v842, v843  : i1
-    condbr v844, block93, block96
+block94(v775: i32):
+    v776 = call noname::_ZN8dlmalloc8dlmalloc7Segment3top17he7e9e2493151d036E(v775)  : i32
+    v777 = eq v774, v776  : i1
+    v778 = cast v777  : i32
+    v779 = neq v778, 0  : i1
+    condbr v779, block93, block96
 
 block95:
 
 block96:
-    v845 = cast v839  : u32
-    v846 = add v845, 8  : u32
-    v847 = inttoptr v846  : *mut i32
-    v848 = load v847  : i32
-    v849 = const.i32 0  : i32
-    v850 = neq v848, v849  : i1
-    condbr v850, block94(v848), block97
+    v780 = cast v775  : u32
+    v781 = add v780, 8  : u32
+    v782 = inttoptr v781  : *mut i32
+    v783 = load v782  : i32
+    v784 = neq v783, 0  : i1
+    condbr v784, block94(v783), block97
 
 block97:
-    br block92(v796, v837, v717, v739, v775)
+    br block92(v737, v773, v662, v682, v718)
 
 block98:
-    v854 = call noname::_ZN8dlmalloc8dlmalloc7Segment9sys_flags17h224550055bf7775bE(v839)  : i32
-    v856 = neq v854, v788  : i1
-    v857 = cast v856  : i32
-    v858 = const.i32 0  : i32
-    v859 = neq v857, v858  : i1
-    condbr v859, block92(v885, v888, v1175, v1578, v1603), block99
+    v787 = call noname::_ZN8dlmalloc8dlmalloc7Segment9sys_flags17h224550055bf7775bE(v775)  : i32
+    v789 = neq v787, v729  : i1
+    v790 = cast v789  : i32
+    v791 = neq v790, 0  : i1
+    condbr v791, block92(v815, v818, v1092, v1484, v1509), block99
 
 block99:
-    v861 = cast v709  : u32
-    v862 = add v861, 428  : u32
-    v863 = inttoptr v862  : *mut i32
-    v864 = load v863  : i32
-    v865 = call noname::_ZN8dlmalloc8dlmalloc7Segment5holds17h8f6de4ee6718009bE(v839, v864)  : i32
-    v866 = const.i32 0  : i32
-    v867 = neq v865, v866  : i1
-    condbr v867, block81, block100
+    v793 = cast v654  : u32
+    v794 = add v793, 428  : u32
+    v795 = inttoptr v794  : *mut i32
+    v796 = load v795  : i32
+    v797 = call noname::_ZN8dlmalloc8dlmalloc7Segment5holds17h8f6de4ee6718009bE(v775, v796)  : i32
+    v798 = neq v797, 0  : i1
+    condbr v798, block81, block100
 
 block100:
-    br block92(v885, v888, v1175, v1578, v1603)
+    br block92(v815, v818, v1092, v1484, v1509)
 
 block101:
-    v1152 = cast v889  : u32
-    v1153 = inttoptr v1152  : *mut i32
-    v1154 = load v1153  : i32
-    v1155 = cast v889  : u32
-    v1156 = inttoptr v1155  : *mut i32
-    store v1156, v991
-    v1157 = cast v889  : u32
-    v1158 = add v1157, 4  : u32
-    v1159 = inttoptr v1158  : *mut i32
-    v1160 = load v1159  : i32
-    v1161 = add v1160, v1004  : i32
-    v1162 = cast v889  : u32
-    v1163 = add v1162, 4  : u32
-    v1164 = inttoptr v1163  : *mut i32
-    store v1164, v1161
-    v1165 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v991)  : i32
-    v1166 = const.i32 8  : i32
-    v1167 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1165, v1166)  : i32
-    v1168 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1154)  : i32
-    v1169 = const.i32 8  : i32
-    v1170 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1168, v1169)  : i32
-    v1171 = sub v1167, v1165  : i32
-    v1172 = add v991, v1171  : i32
-    v1176 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1172, v1174)  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(v1172, v1173)
-    v1177 = sub v1170, v1168  : i32
-    v1178 = add v1154, v1177  : i32
-    v1179 = add v1173, v1172  : i32
-    v1180 = sub v1178, v1179  : i32
-    v1181 = cast v915  : u32
-    v1182 = add v1181, 428  : u32
-    v1183 = inttoptr v1182  : *mut i32
-    v1184 = load v1183  : i32
-    v1185 = eq v1178, v1184  : i1
-    v1186 = cast v1185  : i32
-    v1187 = const.i32 0  : i32
-    v1188 = neq v1186, v1187  : i1
-    condbr v1188, block126, block127
+    v1069 = cast v819  : u32
+    v1070 = inttoptr v1069  : *mut i32
+    v1071 = load v1070  : i32
+    v1072 = cast v819  : u32
+    v1073 = inttoptr v1072  : *mut i32
+    store v1073, v913
+    v1074 = cast v819  : u32
+    v1075 = add v1074, 4  : u32
+    v1076 = inttoptr v1075  : *mut i32
+    v1077 = load v1076  : i32
+    v1078 = add v1077, v926  : i32
+    v1079 = cast v819  : u32
+    v1080 = add v1079, 4  : u32
+    v1081 = inttoptr v1080  : *mut i32
+    store v1081, v1078
+    v1082 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v913)  : i32
+    v1083 = const.i32 8  : i32
+    v1084 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1082, v1083)  : i32
+    v1085 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1071)  : i32
+    v1086 = const.i32 8  : i32
+    v1087 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1085, v1086)  : i32
+    v1088 = sub v1084, v1082  : i32
+    v1089 = add v913, v1088  : i32
+    v1093 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1089, v1091)  : i32
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(v1089, v1090)
+    v1094 = sub v1087, v1085  : i32
+    v1095 = add v1071, v1094  : i32
+    v1096 = add v1090, v1089  : i32
+    v1097 = sub v1095, v1096  : i32
+    v1098 = cast v841  : u32
+    v1099 = add v1098, 428  : u32
+    v1100 = inttoptr v1099  : *mut i32
+    v1101 = load v1100  : i32
+    v1102 = eq v1095, v1101  : i1
+    v1103 = cast v1102  : i32
+    v1104 = neq v1103, 0  : i1
+    condbr v1104, block126, block127
 
-block102(v914: i32, v920: i32, v990: i32, v1003: i32, v1600: i32):
-    v916 = cast v914  : u32
-    v917 = add v916, 428  : u32
-    v918 = inttoptr v917  : *mut i32
-    v919 = load v918  : i32
-    br block111(v920)
+block102(v840: i32, v846: i32, v912: i32, v925: i32, v1506: i32):
+    v842 = cast v840  : u32
+    v843 = add v842, 428  : u32
+    v844 = inttoptr v843  : *mut i32
+    v845 = load v844  : i32
+    br block111(v846)
 
 block103:
-    v904 = call noname::_ZN8dlmalloc8dlmalloc7Segment9is_extern17h6f6db2c70b891fd9E(v889)  : i32
-    v905 = const.i32 0  : i32
-    v906 = neq v904, v905  : i1
-    condbr v906, block102(v915, v921, v991, v1004, v1601), block108
+    v832 = call noname::_ZN8dlmalloc8dlmalloc7Segment9is_extern17h6f6db2c70b891fd9E(v819)  : i32
+    v833 = neq v832, 0  : i1
+    condbr v833, block102(v841, v847, v913, v926, v1507), block108
 
-block104(v889: i32):
-    v890 = cast v889  : u32
-    v891 = inttoptr v890  : *mut i32
-    v892 = load v891  : i32
-    v894 = eq v892, v893  : i1
-    v895 = cast v894  : i32
-    v896 = const.i32 0  : i32
-    v897 = neq v895, v896  : i1
-    condbr v897, block103, block106
+block104(v819: i32):
+    v820 = cast v819  : u32
+    v821 = inttoptr v820  : *mut i32
+    v822 = load v821  : i32
+    v824 = eq v822, v823  : i1
+    v825 = cast v824  : i32
+    v826 = neq v825, 0  : i1
+    condbr v826, block103, block106
 
 block105:
 
 block106:
-    v898 = cast v889  : u32
-    v899 = add v898, 8  : u32
-    v900 = inttoptr v899  : *mut i32
-    v901 = load v900  : i32
-    v902 = const.i32 0  : i32
-    v903 = neq v901, v902  : i1
-    condbr v903, block104(v901), block107
+    v827 = cast v819  : u32
+    v828 = add v827, 8  : u32
+    v829 = inttoptr v828  : *mut i32
+    v830 = load v829  : i32
+    v831 = neq v830, 0  : i1
+    condbr v831, block104(v830), block107
 
 block107:
-    br block102(v868, v887, v873, v884, v1602)
+    br block102(v799, v817, v804, v814, v1508)
 
 block108:
-    v907 = call noname::_ZN8dlmalloc8dlmalloc7Segment9sys_flags17h224550055bf7775bE(v889)  : i32
-    v910 = eq v907, v855  : i1
-    v911 = cast v910  : i32
-    v912 = const.i32 0  : i32
-    v913 = neq v911, v912  : i1
-    condbr v913, block101, block109
+    v834 = call noname::_ZN8dlmalloc8dlmalloc7Segment9sys_flags17h224550055bf7775bE(v819)  : i32
+    v837 = eq v834, v788  : i1
+    v838 = cast v837  : i32
+    v839 = neq v838, 0  : i1
+    condbr v839, block101, block109
 
 block109:
-    br block102(v915, v921, v991, v1004, v1601)
+    br block102(v841, v847, v913, v926, v1507)
 
-block110(v949: i32, v957: i32, v985: i32, v988: i32, v1001: i32, v1039: i32, v1058: i32, v1539: i32, v1584: i32, v1598: i32):
-    v950 = call noname::_ZN8dlmalloc8dlmalloc7Segment3top17he7e9e2493151d036E(v949)  : i32
-    v951 = const.i32 20  : i32
-    v952 = const.i32 8  : i32
-    v953 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v951, v952)  : i32
-    v954 = sub v950, v953  : i32
-    v955 = const.i32 -23  : i32
-    v956 = add v954, v955  : i32
-    v958 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v956)  : i32
-    v959 = const.i32 8  : i32
-    v960 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v958, v959)  : i32
-    v961 = sub v960, v958  : i32
-    v962 = add v956, v961  : i32
-    v963 = const.i32 16  : i32
-    v964 = const.i32 8  : i32
-    v965 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v963, v964)  : i32
-    v966 = add v957, v965  : i32
-    v967 = cast v962  : u32
-    v968 = cast v966  : u32
-    v969 = lt v967, v968  : i1
-    v970 = cast v969  : i32
-    v971 = const.i32 0  : i32
-    v972 = neq v970, v971  : i1
-    v973 = select v972, v957, v962  : i32
-    v974 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v973)  : i32
-    v975 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v973, v953)  : i32
-    v976 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
-    v977 = const.i32 8  : i32
-    v978 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v976, v977)  : i32
-    v979 = const.i32 20  : i32
-    v980 = const.i32 8  : i32
-    v981 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v979, v980)  : i32
-    v982 = const.i32 16  : i32
-    v983 = const.i32 8  : i32
-    v984 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v982, v983)  : i32
-    v993 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v988)  : i32
-    v994 = const.i32 8  : i32
-    v995 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v993, v994)  : i32
-    v996 = sub v995, v993  : i32
-    v997 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v988, v996)  : i32
-    v998 = cast v985  : u32
-    v999 = add v998, 428  : u32
-    v1000 = inttoptr v999  : *mut i32
-    store v1000, v997
-    v1006 = add v976, v1001  : i32
-    v1007 = add v978, v981  : i32
-    v1008 = add v984, v1007  : i32
-    v1009 = add v1008, v996  : i32
-    v1010 = sub v1006, v1009  : i32
-    v1011 = cast v985  : u32
-    v1012 = add v1011, 420  : u32
-    v1013 = inttoptr v1012  : *mut i32
-    store v1013, v1010
-    v1014 = const.i32 1  : i32
-    v1015 = bor v1010, v1014  : i32
-    v1016 = cast v997  : u32
-    v1017 = add v1016, 4  : u32
-    v1018 = inttoptr v1017  : *mut i32
-    store v1018, v1015
-    v1019 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
-    v1020 = const.i32 8  : i32
-    v1021 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1019, v1020)  : i32
-    v1022 = const.i32 20  : i32
-    v1023 = const.i32 8  : i32
-    v1024 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1022, v1023)  : i32
-    v1025 = const.i32 16  : i32
-    v1026 = const.i32 8  : i32
-    v1027 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1025, v1026)  : i32
-    v1028 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v997, v1010)  : i32
-    v1029 = const.i32 2097152  : i32
-    v1030 = cast v985  : u32
-    v1031 = add v1030, 440  : u32
-    v1032 = inttoptr v1031  : *mut i32
-    store v1032, v1029
-    v1033 = sub v1021, v1019  : i32
-    v1034 = add v1024, v1033  : i32
-    v1035 = add v1027, v1034  : i32
-    v1036 = cast v1028  : u32
-    v1037 = add v1036, 4  : u32
-    v1038 = inttoptr v1037  : *mut i32
-    store v1038, v1035
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(v973, v953)
-    v1042 = cast v1039  : u32
-    v1043 = inttoptr v1042  : *mut i64
-    v1044 = load v1043  : i64
-    v1045 = const.i32 8  : i32
-    v1046 = add v974, v1045  : i32
-    v1047 = const.i32 8  : i32
-    v1048 = add v1039, v1047  : i32
-    v1049 = cast v1048  : u32
-    v1050 = inttoptr v1049  : *mut i64
-    v1051 = load v1050  : i64
-    v1052 = cast v1046  : u32
-    v1053 = inttoptr v1052  : *mut i64
-    store v1053, v1051
-    v1054 = cast v974  : u32
-    v1055 = inttoptr v1054  : *mut i64
-    store v1055, v1044
-    v1056 = const.i32 140  : i32
-    v1057 = add v985, v1056  : i32
-    v1062 = cast v1057  : u32
-    v1063 = inttoptr v1062  : *mut i32
-    store v1063, v1058
-    v1064 = const.i32 132  : i32
-    v1065 = add v985, v1064  : i32
-    v1066 = cast v1065  : u32
-    v1067 = inttoptr v1066  : *mut i32
-    store v1067, v1001
-    v1068 = cast v985  : u32
-    v1069 = add v1068, 128  : u32
-    v1070 = inttoptr v1069  : *mut i32
-    store v1070, v988
-    v1071 = const.i32 136  : i32
-    v1072 = add v985, v1071  : i32
-    v1073 = cast v1072  : u32
-    v1074 = inttoptr v1073  : *mut i32
-    store v1074, v974
-    br block117(v975)
+block110(v872: i32, v880: i32, v907: i32, v910: i32, v923: i32, v961: i32, v980: i32, v1446: i32, v1490: i32, v1504: i32):
+    v873 = call noname::_ZN8dlmalloc8dlmalloc7Segment3top17he7e9e2493151d036E(v872)  : i32
+    v874 = const.i32 20  : i32
+    v875 = const.i32 8  : i32
+    v876 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v874, v875)  : i32
+    v877 = sub v873, v876  : i32
+    v878 = const.i32 -23  : i32
+    v879 = add v877, v878  : i32
+    v881 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v879)  : i32
+    v882 = const.i32 8  : i32
+    v883 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v881, v882)  : i32
+    v884 = sub v883, v881  : i32
+    v885 = add v879, v884  : i32
+    v886 = const.i32 16  : i32
+    v887 = const.i32 8  : i32
+    v888 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v886, v887)  : i32
+    v889 = add v880, v888  : i32
+    v890 = cast v885  : u32
+    v891 = cast v889  : u32
+    v892 = lt v890, v891  : i1
+    v893 = cast v892  : i32
+    v894 = neq v893, 0  : i1
+    v895 = select v894, v880, v885  : i32
+    v896 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v895)  : i32
+    v897 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v895, v876)  : i32
+    v898 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v899 = const.i32 8  : i32
+    v900 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v898, v899)  : i32
+    v901 = const.i32 20  : i32
+    v902 = const.i32 8  : i32
+    v903 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v901, v902)  : i32
+    v904 = const.i32 16  : i32
+    v905 = const.i32 8  : i32
+    v906 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v904, v905)  : i32
+    v915 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v910)  : i32
+    v916 = const.i32 8  : i32
+    v917 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v915, v916)  : i32
+    v918 = sub v917, v915  : i32
+    v919 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v910, v918)  : i32
+    v920 = cast v907  : u32
+    v921 = add v920, 428  : u32
+    v922 = inttoptr v921  : *mut i32
+    store v922, v919
+    v928 = add v898, v923  : i32
+    v929 = add v900, v903  : i32
+    v930 = add v906, v929  : i32
+    v931 = add v930, v918  : i32
+    v932 = sub v928, v931  : i32
+    v933 = cast v907  : u32
+    v934 = add v933, 420  : u32
+    v935 = inttoptr v934  : *mut i32
+    store v935, v932
+    v936 = const.i32 1  : i32
+    v937 = bor v932, v936  : i32
+    v938 = cast v919  : u32
+    v939 = add v938, 4  : u32
+    v940 = inttoptr v939  : *mut i32
+    store v940, v937
+    v941 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v942 = const.i32 8  : i32
+    v943 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v941, v942)  : i32
+    v944 = const.i32 20  : i32
+    v945 = const.i32 8  : i32
+    v946 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v944, v945)  : i32
+    v947 = const.i32 16  : i32
+    v948 = const.i32 8  : i32
+    v949 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v947, v948)  : i32
+    v950 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v919, v932)  : i32
+    v951 = const.i32 2097152  : i32
+    v952 = cast v907  : u32
+    v953 = add v952, 440  : u32
+    v954 = inttoptr v953  : *mut i32
+    store v954, v951
+    v955 = sub v943, v941  : i32
+    v956 = add v946, v955  : i32
+    v957 = add v949, v956  : i32
+    v958 = cast v950  : u32
+    v959 = add v958, 4  : u32
+    v960 = inttoptr v959  : *mut i32
+    store v960, v957
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(v895, v876)
+    v964 = cast v961  : u32
+    v965 = inttoptr v964  : *mut i64
+    v966 = load v965  : i64
+    v967 = const.i32 8  : i32
+    v968 = add v896, v967  : i32
+    v969 = const.i32 8  : i32
+    v970 = add v961, v969  : i32
+    v971 = cast v970  : u32
+    v972 = inttoptr v971  : *mut i64
+    v973 = load v972  : i64
+    v974 = cast v968  : u32
+    v975 = inttoptr v974  : *mut i64
+    store v975, v973
+    v976 = cast v896  : u32
+    v977 = inttoptr v976  : *mut i64
+    store v977, v966
+    v978 = const.i32 140  : i32
+    v979 = add v907, v978  : i32
+    v984 = cast v979  : u32
+    v985 = inttoptr v984  : *mut i32
+    store v985, v980
+    v986 = const.i32 132  : i32
+    v987 = add v907, v986  : i32
+    v988 = cast v987  : u32
+    v989 = inttoptr v988  : *mut i32
+    store v989, v923
+    v990 = cast v907  : u32
+    v991 = add v990, 128  : u32
+    v992 = inttoptr v991  : *mut i32
+    store v992, v910
+    v993 = const.i32 136  : i32
+    v994 = add v907, v993  : i32
+    v995 = cast v994  : u32
+    v996 = inttoptr v995  : *mut i32
+    store v996, v896
+    br block117(v897)
 
-block111(v922: i32):
-    v923 = cast v922  : u32
-    v924 = inttoptr v923  : *mut i32
-    v925 = load v924  : i32
-    v927 = cast v925  : u32
-    v928 = cast v926  : u32
-    v929 = gt v927, v928  : i1
-    v930 = cast v929  : i32
-    v931 = const.i32 0  : i32
-    v932 = neq v930, v931  : i1
-    condbr v932, block113, block114
+block111(v848: i32):
+    v849 = cast v848  : u32
+    v850 = inttoptr v849  : *mut i32
+    v851 = load v850  : i32
+    v853 = cast v851  : u32
+    v854 = cast v852  : u32
+    v855 = gt v853, v854  : i1
+    v856 = cast v855  : i32
+    v857 = neq v856, 0  : i1
+    condbr v857, block113, block114
 
 block112:
-    v948 = const.i32 0  : i32
-    br block110(v948, v947, v987, v992, v1005, v1041, v1061, v1542, v1587, v1604)
+    v871 = const.i32 0  : i32
+    br block110(v871, v870, v909, v914, v927, v963, v983, v1449, v1493, v1510)
 
 block113:
-    v941 = cast v922  : u32
-    v942 = add v941, 8  : u32
-    v943 = inttoptr v942  : *mut i32
-    v944 = load v943  : i32
-    v945 = const.i32 0  : i32
-    v946 = neq v944, v945  : i1
-    condbr v946, block111(v944), block116
+    v865 = cast v848  : u32
+    v866 = add v865, 8  : u32
+    v867 = inttoptr v866  : *mut i32
+    v868 = load v867  : i32
+    v869 = neq v868, 0  : i1
+    condbr v869, block111(v868), block116
 
 block114:
-    v933 = call noname::_ZN8dlmalloc8dlmalloc7Segment3top17he7e9e2493151d036E(v922)  : i32
-    v934 = cast v933  : u32
-    v935 = cast v926  : u32
-    v936 = gt v934, v935  : i1
-    v937 = cast v936  : i32
-    v938 = const.i32 0  : i32
-    v939 = neq v937, v938  : i1
-    condbr v939, block110(v922, v926, v914, v990, v1003, v920, v908, v1173, v1576, v1600), block115
+    v858 = call noname::_ZN8dlmalloc8dlmalloc7Segment3top17he7e9e2493151d036E(v848)  : i32
+    v859 = cast v858  : u32
+    v860 = cast v852  : u32
+    v861 = gt v859, v860  : i1
+    v862 = cast v861  : i32
+    v863 = neq v862, 0  : i1
+    condbr v863, block110(v848, v852, v840, v912, v925, v846, v835, v1090, v1482, v1506), block115
 
 block115:
     br block113
@@ -3225,433 +3048,421 @@ block115:
 block116:
     br block112
 
-block117(v1075: i32):
-    v1076 = const.i32 4  : i32
-    v1077 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1075, v1076)  : i32
-    v1078 = call noname::_ZN8dlmalloc8dlmalloc5Chunk14fencepost_head17he07aaa52f3b50dfdE()  : i32
-    v1079 = cast v1075  : u32
-    v1080 = add v1079, 4  : u32
-    v1081 = inttoptr v1080  : *mut i32
-    store v1081, v1078
-    v1082 = const.i32 4  : i32
-    v1083 = add v1077, v1082  : i32
-    v1085 = cast v1083  : u32
-    v1086 = cast v1084  : u32
-    v1087 = lt v1085, v1086  : i1
-    v1088 = cast v1087  : i32
-    v1089 = const.i32 0  : i32
-    v1090 = neq v1088, v1089  : i1
-    condbr v1090, block117(v1077), block119
+block117(v997: i32):
+    v998 = const.i32 4  : i32
+    v999 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v997, v998)  : i32
+    v1000 = call noname::_ZN8dlmalloc8dlmalloc5Chunk14fencepost_head17he07aaa52f3b50dfdE()  : i32
+    v1001 = cast v997  : u32
+    v1002 = add v1001, 4  : u32
+    v1003 = inttoptr v1002  : *mut i32
+    store v1003, v1000
+    v1004 = const.i32 4  : i32
+    v1005 = add v999, v1004  : i32
+    v1007 = cast v1005  : u32
+    v1008 = cast v1006  : u32
+    v1009 = lt v1007, v1008  : i1
+    v1010 = cast v1009  : i32
+    v1011 = neq v1010, 0  : i1
+    condbr v1011, block117(v999), block119
 
 block118:
-    v1093 = eq v973, v957  : i1
-    v1094 = cast v1093  : i32
-    v1095 = const.i32 0  : i32
-    v1096 = neq v1094, v1095  : i1
-    condbr v1096, block76(v1106, v1539, v1584, v1598), block120
+    v1014 = eq v895, v880  : i1
+    v1015 = cast v1014  : i32
+    v1016 = neq v1015, 0  : i1
+    condbr v1016, block76(v1025, v1446, v1490, v1504), block120
 
 block119:
     br block118
 
 block120:
-    v1097 = sub v1091, v1092  : i32
-    v1098 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1092, v1097)  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E(v1092, v1097, v1098)
-    v1099 = const.i32 256  : i32
-    v1100 = cast v1097  : u32
-    v1101 = cast v1099  : u32
-    v1102 = lt v1100, v1101  : i1
-    v1103 = cast v1102  : i32
-    v1104 = const.i32 0  : i32
-    v1105 = neq v1103, v1104  : i1
-    condbr v1105, block121, block122
+    v1017 = sub v1012, v1013  : i32
+    v1018 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1013, v1017)  : i32
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E(v1013, v1017, v1018)
+    v1019 = const.i32 256  : i32
+    v1020 = cast v1017  : u32
+    v1021 = cast v1019  : u32
+    v1022 = lt v1020, v1021  : i1
+    v1023 = cast v1022  : i32
+    v1024 = neq v1023, 0  : i1
+    condbr v1024, block121, block122
 
 block121:
-    v1107 = const.i32 -8  : i32
-    v1108 = band v1097, v1107  : i32
-    v1109 = add v1106, v1108  : i32
-    v1110 = const.i32 144  : i32
-    v1111 = add v1109, v1110  : i32
-    v1112 = cast v1106  : u32
-    v1113 = add v1112, 408  : u32
-    v1114 = inttoptr v1113  : *mut i32
-    v1115 = load v1114  : i32
-    v1116 = const.i32 1  : i32
-    v1117 = const.i32 3  : i32
-    v1118 = cast v1097  : u32
-    v1119 = cast v1117  : u32
-    v1120 = shr v1118, v1119  : u32
-    v1121 = cast v1120  : i32
-    v1122 = shl v1116, v1121  : i32
-    v1123 = band v1115, v1122  : i32
-    v1124 = const.i32 0  : i32
-    v1125 = eq v1123, v1124  : i1
-    v1126 = cast v1125  : i32
-    v1127 = const.i32 0  : i32
-    v1128 = neq v1126, v1127  : i1
-    condbr v1128, block124, block125
+    v1026 = const.i32 -8  : i32
+    v1027 = band v1017, v1026  : i32
+    v1028 = add v1025, v1027  : i32
+    v1029 = const.i32 144  : i32
+    v1030 = add v1028, v1029  : i32
+    v1031 = cast v1025  : u32
+    v1032 = add v1031, 408  : u32
+    v1033 = inttoptr v1032  : *mut i32
+    v1034 = load v1033  : i32
+    v1035 = const.i32 1  : i32
+    v1036 = const.i32 3  : i32
+    v1037 = cast v1017  : u32
+    v1038 = cast v1036  : u32
+    v1039 = shr v1037, v1038  : u32
+    v1040 = cast v1039  : i32
+    v1041 = shl v1035, v1040  : i32
+    v1042 = band v1034, v1041  : i32
+    v1043 = eq v1042, 0  : i1
+    v1044 = cast v1043  : i32
+    v1045 = neq v1044, 0  : i1
+    condbr v1045, block124, block125
 
 block122:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E(v985, v1092, v1097)
-    br block76(v1106, v1538, v1583, v1597)
+    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E(v907, v1013, v1017)
+    br block76(v1025, v1445, v1489, v1503)
 
-block123(v1142: i32):
-    v1139 = cast v1111  : u32
-    v1140 = add v1139, 8  : u32
-    v1141 = inttoptr v1140  : *mut i32
-    store v1141, v1092
-    v1143 = cast v1142  : u32
-    v1144 = add v1143, 12  : u32
-    v1145 = inttoptr v1144  : *mut i32
-    store v1145, v1138
-    v1146 = cast v1138  : u32
-    v1147 = add v1146, 12  : u32
-    v1148 = inttoptr v1147  : *mut i32
-    store v1148, v1137
-    v1149 = cast v1138  : u32
-    v1150 = add v1149, 8  : u32
-    v1151 = inttoptr v1150  : *mut i32
-    store v1151, v1142
-    br block76(v1106, v1538, v1583, v1597)
+block123(v1059: i32):
+    v1056 = cast v1030  : u32
+    v1057 = add v1056, 8  : u32
+    v1058 = inttoptr v1057  : *mut i32
+    store v1058, v1013
+    v1060 = cast v1059  : u32
+    v1061 = add v1060, 12  : u32
+    v1062 = inttoptr v1061  : *mut i32
+    store v1062, v1055
+    v1063 = cast v1055  : u32
+    v1064 = add v1063, 12  : u32
+    v1065 = inttoptr v1064  : *mut i32
+    store v1065, v1054
+    v1066 = cast v1055  : u32
+    v1067 = add v1066, 8  : u32
+    v1068 = inttoptr v1067  : *mut i32
+    store v1068, v1059
+    br block76(v1025, v1445, v1489, v1503)
 
 block124:
-    v1133 = bor v1115, v1122  : i32
-    v1134 = cast v1106  : u32
-    v1135 = add v1134, 408  : u32
-    v1136 = inttoptr v1135  : *mut i32
-    store v1136, v1133
-    br block123(v1111)
+    v1050 = bor v1034, v1041  : i32
+    v1051 = cast v1025  : u32
+    v1052 = add v1051, 408  : u32
+    v1053 = inttoptr v1052  : *mut i32
+    store v1053, v1050
+    br block123(v1030)
 
 block125:
-    v1129 = cast v1111  : u32
-    v1130 = add v1129, 8  : u32
-    v1131 = inttoptr v1130  : *mut i32
-    v1132 = load v1131  : i32
-    br block123(v1132)
+    v1046 = cast v1030  : u32
+    v1047 = add v1046, 8  : u32
+    v1048 = inttoptr v1047  : *mut i32
+    v1049 = load v1048  : i32
+    br block123(v1049)
 
 block126:
-    v1246 = cast v915  : u32
-    v1247 = add v1246, 428  : u32
-    v1248 = inttoptr v1247  : *mut i32
-    store v1248, v1176
-    v1249 = cast v915  : u32
-    v1250 = add v1249, 420  : u32
-    v1251 = inttoptr v1250  : *mut i32
-    v1252 = load v1251  : i32
-    v1253 = add v1252, v1180  : i32
-    v1254 = cast v915  : u32
-    v1255 = add v1254, 420  : u32
-    v1256 = inttoptr v1255  : *mut i32
-    store v1256, v1253
-    v1257 = const.i32 1  : i32
-    v1258 = bor v1253, v1257  : i32
-    v1259 = cast v1176  : u32
-    v1260 = add v1259, 4  : u32
-    v1261 = inttoptr v1260  : *mut i32
-    store v1261, v1258
-    v1262 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1172)  : i32
-    br block2(v1577, v1262)
+    v1158 = cast v841  : u32
+    v1159 = add v1158, 428  : u32
+    v1160 = inttoptr v1159  : *mut i32
+    store v1160, v1093
+    v1161 = cast v841  : u32
+    v1162 = add v1161, 420  : u32
+    v1163 = inttoptr v1162  : *mut i32
+    v1164 = load v1163  : i32
+    v1165 = add v1164, v1097  : i32
+    v1166 = cast v841  : u32
+    v1167 = add v1166, 420  : u32
+    v1168 = inttoptr v1167  : *mut i32
+    store v1168, v1165
+    v1169 = const.i32 1  : i32
+    v1170 = bor v1165, v1169  : i32
+    v1171 = cast v1093  : u32
+    v1172 = add v1171, 4  : u32
+    v1173 = inttoptr v1172  : *mut i32
+    store v1173, v1170
+    v1174 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1089)  : i32
+    br block2(v1483, v1174)
 
 block127:
-    v1189 = cast v915  : u32
-    v1190 = add v1189, 424  : u32
-    v1191 = inttoptr v1190  : *mut i32
-    v1192 = load v1191  : i32
-    v1193 = eq v1178, v1192  : i1
-    v1194 = cast v1193  : i32
-    v1195 = const.i32 0  : i32
-    v1196 = neq v1194, v1195  : i1
-    condbr v1196, block80, block128
+    v1105 = cast v841  : u32
+    v1106 = add v1105, 424  : u32
+    v1107 = inttoptr v1106  : *mut i32
+    v1108 = load v1107  : i32
+    v1109 = eq v1095, v1108  : i1
+    v1110 = cast v1109  : i32
+    v1111 = neq v1110, 0  : i1
+    condbr v1111, block80, block128
 
 block128:
-    v1197 = call noname::_ZN8dlmalloc8dlmalloc5Chunk5inuse17h2d327e4c36b84dfeE(v1178)  : i32
-    v1198 = const.i32 0  : i32
-    v1199 = neq v1197, v1198  : i1
-    condbr v1199, block78(v1180, v1178), block129
+    v1112 = call noname::_ZN8dlmalloc8dlmalloc5Chunk5inuse17h2d327e4c36b84dfeE(v1095)  : i32
+    v1113 = neq v1112, 0  : i1
+    condbr v1113, block78(v1097, v1095), block129
 
 block129:
-    v1200 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v1178)  : i32
-    v1201 = const.i32 256  : i32
-    v1202 = cast v1200  : u32
-    v1203 = cast v1201  : u32
-    v1204 = lt v1202, v1203  : i1
-    v1205 = cast v1204  : i32
-    v1206 = const.i32 0  : i32
-    v1207 = neq v1205, v1206  : i1
-    condbr v1207, block131, block132
+    v1114 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v1095)  : i32
+    v1115 = const.i32 256  : i32
+    v1116 = cast v1114  : u32
+    v1117 = cast v1115  : u32
+    v1118 = lt v1116, v1117  : i1
+    v1119 = cast v1118  : i32
+    v1120 = neq v1119, 0  : i1
+    condbr v1120, block131, block132
 
 block130:
-    v1243 = add v1200, v1180  : i32
-    v1245 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1178, v1241)  : i32
-    br block78(v1243, v1245)
+    v1155 = add v1114, v1097  : i32
+    v1157 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1095, v1153)  : i32
+    br block78(v1155, v1157)
 
 block131:
-    v1208 = cast v1178  : u32
-    v1209 = add v1208, 12  : u32
-    v1210 = inttoptr v1209  : *mut i32
-    v1211 = load v1210  : i32
-    v1212 = cast v1178  : u32
-    v1213 = add v1212, 8  : u32
-    v1214 = inttoptr v1213  : *mut i32
-    v1215 = load v1214  : i32
-    v1216 = eq v1211, v1215  : i1
-    v1217 = cast v1216  : i32
-    v1218 = const.i32 0  : i32
-    v1219 = neq v1217, v1218  : i1
-    condbr v1219, block133, block134
+    v1121 = cast v1095  : u32
+    v1122 = add v1121, 12  : u32
+    v1123 = inttoptr v1122  : *mut i32
+    v1124 = load v1123  : i32
+    v1125 = cast v1095  : u32
+    v1126 = add v1125, 8  : u32
+    v1127 = inttoptr v1126  : *mut i32
+    v1128 = load v1127  : i32
+    v1129 = eq v1124, v1128  : i1
+    v1130 = cast v1129  : i32
+    v1131 = neq v1130, 0  : i1
+    condbr v1131, block133, block134
 
 block132:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v915, v1178)
+    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v841, v1095)
     br block130
 
 block133:
-    v1226 = cast v915  : u32
-    v1227 = add v1226, 408  : u32
-    v1228 = inttoptr v1227  : *mut i32
-    v1229 = load v1228  : i32
-    v1230 = const.i32 -2  : i32
-    v1231 = const.i32 3  : i32
-    v1232 = cast v1200  : u32
-    v1233 = cast v1231  : u32
-    v1234 = shr v1232, v1233  : u32
-    v1235 = cast v1234  : i32
-    v1236 = shl v1230, v1235  : i32
-    v1237 = band v1229, v1236  : i32
-    v1238 = cast v915  : u32
-    v1239 = add v1238, 408  : u32
-    v1240 = inttoptr v1239  : *mut i32
-    store v1240, v1237
+    v1138 = cast v841  : u32
+    v1139 = add v1138, 408  : u32
+    v1140 = inttoptr v1139  : *mut i32
+    v1141 = load v1140  : i32
+    v1142 = const.i32 -2  : i32
+    v1143 = const.i32 3  : i32
+    v1144 = cast v1114  : u32
+    v1145 = cast v1143  : u32
+    v1146 = shr v1144, v1145  : u32
+    v1147 = cast v1146  : i32
+    v1148 = shl v1142, v1147  : i32
+    v1149 = band v1141, v1148  : i32
+    v1150 = cast v841  : u32
+    v1151 = add v1150, 408  : u32
+    v1152 = inttoptr v1151  : *mut i32
+    store v1152, v1149
     br block130
 
 block134:
-    v1220 = cast v1215  : u32
-    v1221 = add v1220, 12  : u32
-    v1222 = inttoptr v1221  : *mut i32
-    store v1222, v1211
-    v1223 = cast v1211  : u32
-    v1224 = add v1223, 8  : u32
-    v1225 = inttoptr v1224  : *mut i32
-    store v1225, v1215
+    v1132 = cast v1128  : u32
+    v1133 = add v1132, 12  : u32
+    v1134 = inttoptr v1133  : *mut i32
+    store v1134, v1124
+    v1135 = cast v1124  : u32
+    v1136 = add v1135, 8  : u32
+    v1137 = inttoptr v1136  : *mut i32
+    store v1137, v1128
     br block130
 
 block135:
-    v1295 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1284, v717)  : i32
-    v1296 = cast v709  : u32
-    v1297 = add v1296, 416  : u32
-    v1298 = inttoptr v1297  : *mut i32
-    store v1298, v1285
-    v1299 = cast v709  : u32
-    v1300 = add v1299, 424  : u32
-    v1301 = inttoptr v1300  : *mut i32
-    store v1301, v1295
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v1295, v1285)
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(v1284, v717)
-    v1302 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1284)  : i32
-    br block2(v739, v1302)
+    v1206 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1196, v662)  : i32
+    v1207 = cast v654  : u32
+    v1208 = add v1207, 416  : u32
+    v1209 = inttoptr v1208  : *mut i32
+    store v1209, v1197
+    v1210 = cast v654  : u32
+    v1211 = add v1210, 424  : u32
+    v1212 = inttoptr v1211  : *mut i32
+    store v1212, v1206
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v1206, v1197)
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(v1196, v662)
+    v1213 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1196)  : i32
+    br block2(v682, v1213)
 
 block136:
-    v1366 = const.i32 -8  : i32
-    v1367 = band v1352, v1366  : i32
-    v1368 = add v1361, v1367  : i32
-    v1369 = const.i32 144  : i32
-    v1370 = add v1368, v1369  : i32
-    v1371 = cast v1361  : u32
-    v1372 = add v1371, 408  : u32
-    v1373 = inttoptr v1372  : *mut i32
-    v1374 = load v1373  : i32
-    v1375 = const.i32 1  : i32
-    v1376 = const.i32 3  : i32
-    v1377 = cast v1352  : u32
-    v1378 = cast v1376  : u32
-    v1379 = shr v1377, v1378  : u32
-    v1380 = cast v1379  : i32
-    v1381 = shl v1375, v1380  : i32
-    v1382 = band v1374, v1381  : i32
-    v1383 = const.i32 0  : i32
-    v1384 = eq v1382, v1383  : i1
-    v1385 = cast v1384  : i32
-    v1386 = const.i32 0  : i32
-    v1387 = neq v1385, v1386  : i1
-    condbr v1387, block139, block140
+    v1276 = const.i32 -8  : i32
+    v1277 = band v1263, v1276  : i32
+    v1278 = add v1271, v1277  : i32
+    v1279 = const.i32 144  : i32
+    v1280 = add v1278, v1279  : i32
+    v1281 = cast v1271  : u32
+    v1282 = add v1281, 408  : u32
+    v1283 = inttoptr v1282  : *mut i32
+    v1284 = load v1283  : i32
+    v1285 = const.i32 1  : i32
+    v1286 = const.i32 3  : i32
+    v1287 = cast v1263  : u32
+    v1288 = cast v1286  : u32
+    v1289 = shr v1287, v1288  : u32
+    v1290 = cast v1289  : i32
+    v1291 = shl v1285, v1290  : i32
+    v1292 = band v1284, v1291  : i32
+    v1293 = eq v1292, 0  : i1
+    v1294 = cast v1293  : i32
+    v1295 = neq v1294, 0  : i1
+    condbr v1295, block139, block140
 
 block137:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E(v915, v1350, v1352)
-    v1365 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1172)  : i32
-    br block2(v1576, v1365)
+    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E(v841, v1261, v1263)
+    v1275 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1089)  : i32
+    br block2(v1482, v1275)
 
-block138(v1401: i32):
-    v1398 = cast v1370  : u32
-    v1399 = add v1398, 8  : u32
-    v1400 = inttoptr v1399  : *mut i32
-    store v1400, v1350
-    v1402 = cast v1401  : u32
-    v1403 = add v1402, 12  : u32
-    v1404 = inttoptr v1403  : *mut i32
-    store v1404, v1397
-    v1405 = cast v1397  : u32
-    v1406 = add v1405, 12  : u32
-    v1407 = inttoptr v1406  : *mut i32
-    store v1407, v1396
-    v1408 = cast v1397  : u32
-    v1409 = add v1408, 8  : u32
-    v1410 = inttoptr v1409  : *mut i32
-    store v1410, v1401
-    v1412 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1363)  : i32
-    br block2(v1579, v1412)
+block138(v1309: i32):
+    v1306 = cast v1280  : u32
+    v1307 = add v1306, 8  : u32
+    v1308 = inttoptr v1307  : *mut i32
+    store v1308, v1261
+    v1310 = cast v1309  : u32
+    v1311 = add v1310, 12  : u32
+    v1312 = inttoptr v1311  : *mut i32
+    store v1312, v1305
+    v1313 = cast v1305  : u32
+    v1314 = add v1313, 12  : u32
+    v1315 = inttoptr v1314  : *mut i32
+    store v1315, v1304
+    v1316 = cast v1305  : u32
+    v1317 = add v1316, 8  : u32
+    v1318 = inttoptr v1317  : *mut i32
+    store v1318, v1309
+    v1320 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1273)  : i32
+    br block2(v1485, v1320)
 
 block139:
-    v1392 = bor v1374, v1381  : i32
-    v1393 = cast v1361  : u32
-    v1394 = add v1393, 408  : u32
-    v1395 = inttoptr v1394  : *mut i32
-    store v1395, v1392
-    br block138(v1370)
+    v1300 = bor v1284, v1291  : i32
+    v1301 = cast v1271  : u32
+    v1302 = add v1301, 408  : u32
+    v1303 = inttoptr v1302  : *mut i32
+    store v1303, v1300
+    br block138(v1280)
 
 block140:
-    v1388 = cast v1370  : u32
-    v1389 = add v1388, 8  : u32
-    v1390 = inttoptr v1389  : *mut i32
-    v1391 = load v1390  : i32
-    br block138(v1391)
+    v1296 = cast v1280  : u32
+    v1297 = add v1296, 8  : u32
+    v1298 = inttoptr v1297  : *mut i32
+    v1299 = load v1298  : i32
+    br block138(v1299)
 
-block141(v1436: i32):
-    v1437 = add v1435, v1436  : i32
-    v1438 = const.i32 164  : i32
-    v1439 = add v1437, v1438  : i32
-    v1440 = const.i32 152  : i32
-    v1441 = add v1437, v1440  : i32
-    v1442 = cast v1439  : u32
-    v1443 = inttoptr v1442  : *mut i32
-    store v1443, v1441
-    v1444 = const.i32 144  : i32
-    v1445 = add v1437, v1444  : i32
-    v1446 = cast v1441  : u32
-    v1447 = inttoptr v1446  : *mut i32
-    store v1447, v1445
-    v1448 = const.i32 156  : i32
-    v1449 = add v1437, v1448  : i32
-    v1450 = cast v1449  : u32
-    v1451 = inttoptr v1450  : *mut i32
-    store v1451, v1445
-    v1452 = const.i32 172  : i32
-    v1453 = add v1437, v1452  : i32
-    v1454 = const.i32 160  : i32
-    v1455 = add v1437, v1454  : i32
-    v1456 = cast v1453  : u32
-    v1457 = inttoptr v1456  : *mut i32
-    store v1457, v1455
-    v1458 = cast v1455  : u32
-    v1459 = inttoptr v1458  : *mut i32
-    store v1459, v1441
-    v1460 = const.i32 180  : i32
-    v1461 = add v1437, v1460  : i32
-    v1462 = const.i32 168  : i32
-    v1463 = add v1437, v1462  : i32
-    v1464 = cast v1461  : u32
-    v1465 = inttoptr v1464  : *mut i32
-    store v1465, v1463
-    v1466 = cast v1463  : u32
-    v1467 = inttoptr v1466  : *mut i32
-    store v1467, v1455
-    v1468 = const.i32 176  : i32
-    v1469 = add v1437, v1468  : i32
-    v1470 = cast v1469  : u32
-    v1471 = inttoptr v1470  : *mut i32
-    store v1471, v1463
-    v1472 = const.i32 32  : i32
-    v1473 = add v1436, v1472  : i32
-    v1474 = const.i32 256  : i32
-    v1475 = neq v1473, v1474  : i1
-    v1476 = cast v1475  : i32
-    v1477 = const.i32 0  : i32
-    v1478 = neq v1476, v1477  : i1
-    condbr v1478, block141(v1473), block143
+block141(v1344: i32):
+    v1345 = add v1343, v1344  : i32
+    v1346 = const.i32 164  : i32
+    v1347 = add v1345, v1346  : i32
+    v1348 = const.i32 152  : i32
+    v1349 = add v1345, v1348  : i32
+    v1350 = cast v1347  : u32
+    v1351 = inttoptr v1350  : *mut i32
+    store v1351, v1349
+    v1352 = const.i32 144  : i32
+    v1353 = add v1345, v1352  : i32
+    v1354 = cast v1349  : u32
+    v1355 = inttoptr v1354  : *mut i32
+    store v1355, v1353
+    v1356 = const.i32 156  : i32
+    v1357 = add v1345, v1356  : i32
+    v1358 = cast v1357  : u32
+    v1359 = inttoptr v1358  : *mut i32
+    store v1359, v1353
+    v1360 = const.i32 172  : i32
+    v1361 = add v1345, v1360  : i32
+    v1362 = const.i32 160  : i32
+    v1363 = add v1345, v1362  : i32
+    v1364 = cast v1361  : u32
+    v1365 = inttoptr v1364  : *mut i32
+    store v1365, v1363
+    v1366 = cast v1363  : u32
+    v1367 = inttoptr v1366  : *mut i32
+    store v1367, v1349
+    v1368 = const.i32 180  : i32
+    v1369 = add v1345, v1368  : i32
+    v1370 = const.i32 168  : i32
+    v1371 = add v1345, v1370  : i32
+    v1372 = cast v1369  : u32
+    v1373 = inttoptr v1372  : *mut i32
+    store v1373, v1371
+    v1374 = cast v1371  : u32
+    v1375 = inttoptr v1374  : *mut i32
+    store v1375, v1363
+    v1376 = const.i32 176  : i32
+    v1377 = add v1345, v1376  : i32
+    v1378 = cast v1377  : u32
+    v1379 = inttoptr v1378  : *mut i32
+    store v1379, v1371
+    v1380 = const.i32 32  : i32
+    v1381 = add v1344, v1380  : i32
+    v1382 = const.i32 256  : i32
+    v1383 = neq v1381, v1382  : i1
+    v1384 = cast v1383  : i32
+    v1385 = neq v1384, 0  : i1
+    condbr v1385, block141(v1381), block143
 
 block142:
-    v1479 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
-    v1480 = const.i32 8  : i32
-    v1481 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1479, v1480)  : i32
-    v1482 = const.i32 20  : i32
-    v1483 = const.i32 8  : i32
-    v1484 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1482, v1483)  : i32
-    v1485 = const.i32 16  : i32
-    v1486 = const.i32 8  : i32
-    v1487 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1485, v1486)  : i32
-    v1489 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1488)  : i32
-    v1490 = const.i32 8  : i32
-    v1491 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1489, v1490)  : i32
-    v1492 = sub v1491, v1489  : i32
-    v1493 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1418, v1492)  : i32
-    v1494 = cast v1435  : u32
-    v1495 = add v1494, 428  : u32
-    v1496 = inttoptr v1495  : *mut i32
-    store v1496, v1493
-    v1498 = add v1479, v1430  : i32
-    v1499 = add v1481, v1484  : i32
-    v1500 = add v1487, v1499  : i32
-    v1501 = add v1500, v1492  : i32
-    v1502 = sub v1498, v1501  : i32
-    v1503 = cast v1435  : u32
-    v1504 = add v1503, 420  : u32
-    v1505 = inttoptr v1504  : *mut i32
-    store v1505, v1502
-    v1506 = const.i32 1  : i32
-    v1507 = bor v1502, v1506  : i32
-    v1508 = cast v1493  : u32
-    v1509 = add v1508, 4  : u32
-    v1510 = inttoptr v1509  : *mut i32
-    store v1510, v1507
-    v1511 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
-    v1512 = const.i32 8  : i32
-    v1513 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1511, v1512)  : i32
-    v1514 = const.i32 20  : i32
-    v1515 = const.i32 8  : i32
-    v1516 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1514, v1515)  : i32
-    v1517 = const.i32 16  : i32
-    v1518 = const.i32 8  : i32
-    v1519 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1517, v1518)  : i32
-    v1520 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1493, v1502)  : i32
-    v1521 = const.i32 2097152  : i32
-    v1522 = cast v1435  : u32
-    v1523 = add v1522, 440  : u32
-    v1524 = inttoptr v1523  : *mut i32
-    store v1524, v1521
-    v1525 = sub v1513, v1511  : i32
-    v1526 = add v1516, v1525  : i32
-    v1527 = add v1519, v1526  : i32
-    v1528 = cast v1520  : u32
-    v1529 = add v1528, 4  : u32
-    v1530 = inttoptr v1529  : *mut i32
-    store v1530, v1527
-    br block76(v1435, v717, v739, v775)
+    v1386 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v1387 = const.i32 8  : i32
+    v1388 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1386, v1387)  : i32
+    v1389 = const.i32 20  : i32
+    v1390 = const.i32 8  : i32
+    v1391 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1389, v1390)  : i32
+    v1392 = const.i32 16  : i32
+    v1393 = const.i32 8  : i32
+    v1394 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1392, v1393)  : i32
+    v1396 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1395)  : i32
+    v1397 = const.i32 8  : i32
+    v1398 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1396, v1397)  : i32
+    v1399 = sub v1398, v1396  : i32
+    v1400 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1326, v1399)  : i32
+    v1401 = cast v1343  : u32
+    v1402 = add v1401, 428  : u32
+    v1403 = inttoptr v1402  : *mut i32
+    store v1403, v1400
+    v1405 = add v1386, v1338  : i32
+    v1406 = add v1388, v1391  : i32
+    v1407 = add v1394, v1406  : i32
+    v1408 = add v1407, v1399  : i32
+    v1409 = sub v1405, v1408  : i32
+    v1410 = cast v1343  : u32
+    v1411 = add v1410, 420  : u32
+    v1412 = inttoptr v1411  : *mut i32
+    store v1412, v1409
+    v1413 = const.i32 1  : i32
+    v1414 = bor v1409, v1413  : i32
+    v1415 = cast v1400  : u32
+    v1416 = add v1415, 4  : u32
+    v1417 = inttoptr v1416  : *mut i32
+    store v1417, v1414
+    v1418 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v1419 = const.i32 8  : i32
+    v1420 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1418, v1419)  : i32
+    v1421 = const.i32 20  : i32
+    v1422 = const.i32 8  : i32
+    v1423 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1421, v1422)  : i32
+    v1424 = const.i32 16  : i32
+    v1425 = const.i32 8  : i32
+    v1426 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v1424, v1425)  : i32
+    v1427 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1400, v1409)  : i32
+    v1428 = const.i32 2097152  : i32
+    v1429 = cast v1343  : u32
+    v1430 = add v1429, 440  : u32
+    v1431 = inttoptr v1430  : *mut i32
+    store v1431, v1428
+    v1432 = sub v1420, v1418  : i32
+    v1433 = add v1423, v1432  : i32
+    v1434 = add v1426, v1433  : i32
+    v1435 = cast v1427  : u32
+    v1436 = add v1435, 4  : u32
+    v1437 = inttoptr v1436  : *mut i32
+    store v1437, v1434
+    br block76(v1343, v662, v682, v718)
 
 block143:
     br block142
 
 block144:
-    v1553 = sub v1536, v1537  : i32
-    v1554 = cast v1531  : u32
-    v1555 = add v1554, 420  : u32
-    v1556 = inttoptr v1555  : *mut i32
-    store v1556, v1553
-    v1557 = cast v1531  : u32
-    v1558 = add v1557, 428  : u32
-    v1559 = inttoptr v1558  : *mut i32
-    v1560 = load v1559  : i32
-    v1561 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1560, v1537)  : i32
-    v1562 = cast v1531  : u32
-    v1563 = add v1562, 428  : u32
-    v1564 = inttoptr v1563  : *mut i32
-    store v1564, v1561
-    v1565 = const.i32 1  : i32
-    v1566 = bor v1553, v1565  : i32
-    v1567 = cast v1561  : u32
-    v1568 = add v1567, 4  : u32
-    v1569 = inttoptr v1568  : *mut i32
-    store v1569, v1566
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(v1560, v1537)
-    v1570 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1560)  : i32
-    br block2(v1582, v1570)
+    v1459 = sub v1443, v1444  : i32
+    v1460 = cast v1438  : u32
+    v1461 = add v1460, 420  : u32
+    v1462 = inttoptr v1461  : *mut i32
+    store v1462, v1459
+    v1463 = cast v1438  : u32
+    v1464 = add v1463, 428  : u32
+    v1465 = inttoptr v1464  : *mut i32
+    v1466 = load v1465  : i32
+    v1467 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v1466, v1444)  : i32
+    v1468 = cast v1438  : u32
+    v1469 = add v1468, 428  : u32
+    v1470 = inttoptr v1469  : *mut i32
+    store v1470, v1467
+    v1471 = const.i32 1  : i32
+    v1472 = bor v1459, v1471  : i32
+    v1473 = cast v1467  : u32
+    v1474 = add v1473, 4  : u32
+    v1475 = inttoptr v1474  : *mut i32
+    store v1475, v1472
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E(v1466, v1444)
+    v1476 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v1466)  : i32
+    br block2(v1488, v1476)
 }
 
 pub fn _ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$8init_top17he4cefe3b36a3bd87E(i32, i32, i32) {
@@ -3715,188 +3526,177 @@ block0(v0: i32, v1: i32, v2: i32):
     v9 = cast v1  : u32
     v10 = lte v8, v9  : i1
     v11 = cast v10  : i32
-    v12 = const.i32 0  : i32
-    v13 = neq v11, v12  : i1
-    condbr v13, block2(v1), block3
+    v12 = neq v11, 0  : i1
+    condbr v12, block2(v1), block3
 
 block1(v3: i32):
     ret v3
 
-block2(v50: i32):
-    v17 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
-    v18 = const.i32 8  : i32
-    v19 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v17, v18)  : i32
-    v20 = const.i32 20  : i32
-    v21 = const.i32 8  : i32
-    v22 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v20, v21)  : i32
-    v23 = const.i32 16  : i32
-    v24 = const.i32 8  : i32
-    v25 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v23, v24)  : i32
+block2(v48: i32):
+    v16 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v17 = const.i32 8  : i32
+    v18 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v16, v17)  : i32
+    v19 = const.i32 20  : i32
+    v20 = const.i32 8  : i32
+    v21 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v19, v20)  : i32
+    v22 = const.i32 16  : i32
+    v23 = const.i32 8  : i32
+    v24 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v22, v23)  : i32
+    v25 = const.i32 0  : i32
     v26 = const.i32 0  : i32
-    v27 = const.i32 0  : i32
-    v28 = const.i32 16  : i32
-    v29 = const.i32 8  : i32
-    v30 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v28, v29)  : i32
-    v31 = const.i32 2  : i32
-    v32 = shl v30, v31  : i32
-    v33 = sub v27, v32  : i32
-    v34 = add v19, v22  : i32
-    v35 = add v25, v34  : i32
-    v36 = sub v17, v35  : i32
-    v37 = const.i32 -65544  : i32
-    v38 = add v36, v37  : i32
-    v39 = const.i32 -9  : i32
-    v40 = band v38, v39  : i32
-    v41 = const.i32 -3  : i32
-    v42 = add v40, v41  : i32
-    v43 = cast v33  : u32
-    v44 = cast v42  : u32
-    v45 = lt v43, v44  : i1
-    v46 = cast v45  : i32
-    v47 = const.i32 0  : i32
-    v48 = neq v46, v47  : i1
-    v49 = select v48, v33, v42  : i32
-    v51 = sub v49, v50  : i32
-    v53 = cast v51  : u32
-    v54 = cast v2  : u32
-    v55 = lte v53, v54  : i1
-    v56 = cast v55  : i32
-    v57 = const.i32 0  : i32
-    v58 = neq v56, v57  : i1
-    condbr v58, block4(v26), block5
+    v27 = const.i32 16  : i32
+    v28 = const.i32 8  : i32
+    v29 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v27, v28)  : i32
+    v30 = const.i32 2  : i32
+    v31 = shl v29, v30  : i32
+    v32 = sub v26, v31  : i32
+    v33 = add v18, v21  : i32
+    v34 = add v24, v33  : i32
+    v35 = sub v16, v34  : i32
+    v36 = const.i32 -65544  : i32
+    v37 = add v35, v36  : i32
+    v38 = const.i32 -9  : i32
+    v39 = band v37, v38  : i32
+    v40 = const.i32 -3  : i32
+    v41 = add v39, v40  : i32
+    v42 = cast v32  : u32
+    v43 = cast v41  : u32
+    v44 = lt v42, v43  : i1
+    v45 = cast v44  : i32
+    v46 = neq v45, 0  : i1
+    v47 = select v46, v32, v41  : i32
+    v49 = sub v47, v48  : i32
+    v51 = cast v49  : u32
+    v52 = cast v2  : u32
+    v53 = lte v51, v52  : i1
+    v54 = cast v53  : i32
+    v55 = neq v54, 0  : i1
+    condbr v55, block4(v25), block5
 
 block3:
-    v14 = const.i32 16  : i32
-    v15 = const.i32 8  : i32
-    v16 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v14, v15)  : i32
-    br block2(v16)
+    v13 = const.i32 16  : i32
+    v14 = const.i32 8  : i32
+    v15 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v13, v14)  : i32
+    br block2(v15)
 
-block4(v151: i32):
-    br block1(v151)
+block4(v140: i32):
+    br block1(v140)
 
 block5:
+    v57 = const.i32 16  : i32
+    v58 = const.i32 4  : i32
+    v59 = add v50, v58  : i32
     v60 = const.i32 16  : i32
-    v61 = const.i32 4  : i32
-    v62 = add v52, v61  : i32
-    v63 = const.i32 16  : i32
-    v64 = const.i32 8  : i32
-    v65 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v63, v64)  : i32
-    v66 = const.i32 -5  : i32
-    v67 = add v65, v66  : i32
-    v68 = cast v67  : u32
-    v69 = cast v52  : u32
-    v70 = gt v68, v69  : i1
-    v71 = cast v70  : i32
-    v72 = const.i32 0  : i32
-    v73 = neq v71, v72  : i1
-    v74 = select v73, v60, v62  : i32
+    v61 = const.i32 8  : i32
+    v62 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v60, v61)  : i32
+    v63 = const.i32 -5  : i32
+    v64 = add v62, v63  : i32
+    v65 = cast v64  : u32
+    v66 = cast v50  : u32
+    v67 = gt v65, v66  : i1
+    v68 = cast v67  : i32
+    v69 = neq v68, 0  : i1
+    v70 = select v69, v57, v59  : i32
+    v71 = const.i32 8  : i32
+    v72 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v70, v71)  : i32
+    v73 = add v48, v72  : i32
+    v74 = const.i32 16  : i32
     v75 = const.i32 8  : i32
     v76 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v74, v75)  : i32
-    v77 = add v50, v76  : i32
-    v78 = const.i32 16  : i32
-    v79 = const.i32 8  : i32
-    v80 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v78, v79)  : i32
-    v81 = add v77, v80  : i32
-    v82 = const.i32 -4  : i32
-    v83 = add v81, v82  : i32
-    v84 = call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$6malloc17h1ae2390053e3628cE(v0, v83)  : i32
-    v85 = const.i32 0  : i32
-    v86 = eq v84, v85  : i1
-    v87 = cast v86  : i32
-    v88 = const.i32 0  : i32
-    v89 = neq v87, v88  : i1
-    condbr v89, block4(v26), block6
+    v77 = add v73, v76  : i32
+    v78 = const.i32 -4  : i32
+    v79 = add v77, v78  : i32
+    v80 = call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$6malloc17h1ae2390053e3628cE(v0, v79)  : i32
+    v81 = eq v80, 0  : i1
+    v82 = cast v81  : i32
+    v83 = neq v82, 0  : i1
+    condbr v83, block4(v25), block6
 
 block6:
-    v90 = call noname::_ZN8dlmalloc8dlmalloc5Chunk8from_mem17h11dd30c74f483706E(v84)  : i32
-    v91 = const.i32 -1  : i32
-    v92 = add v50, v91  : i32
-    v93 = band v92, v84  : i32
-    v94 = const.i32 0  : i32
-    v95 = neq v93, v94  : i1
-    condbr v95, block8, block9
+    v84 = call noname::_ZN8dlmalloc8dlmalloc5Chunk8from_mem17h11dd30c74f483706E(v80)  : i32
+    v85 = const.i32 -1  : i32
+    v86 = add v48, v85  : i32
+    v87 = band v86, v80  : i32
+    v88 = neq v87, 0  : i1
+    condbr v88, block8, block9
 
-block7(v129: i32):
-    v130 = call noname::_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(v129)  : i32
-    v131 = const.i32 0  : i32
-    v132 = neq v130, v131  : i1
-    condbr v132, block12, block13
+block7(v120: i32):
+    v121 = call noname::_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(v120)  : i32
+    v122 = neq v121, 0  : i1
+    condbr v122, block12, block13
 
 block8:
-    v96 = add v92, v84  : i32
-    v97 = const.i32 0  : i32
-    v98 = sub v97, v50  : i32
-    v99 = band v96, v98  : i32
-    v100 = call noname::_ZN8dlmalloc8dlmalloc5Chunk8from_mem17h11dd30c74f483706E(v99)  : i32
-    v101 = const.i32 16  : i32
-    v102 = const.i32 8  : i32
-    v103 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v101, v102)  : i32
-    v104 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v90)  : i32
-    v105 = const.i32 0  : i32
-    v106 = sub v100, v90  : i32
-    v107 = cast v106  : u32
-    v108 = cast v103  : u32
-    v109 = gt v107, v108  : i1
-    v110 = cast v109  : i32
-    v111 = const.i32 0  : i32
-    v112 = neq v110, v111  : i1
-    v113 = select v112, v105, v50  : i32
-    v114 = add v100, v113  : i32
-    v115 = sub v114, v90  : i32
-    v116 = sub v104, v115  : i32
-    v117 = call noname::_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(v90)  : i32
-    v118 = const.i32 0  : i32
-    v119 = neq v117, v118  : i1
-    condbr v119, block10, block11
+    v89 = add v86, v80  : i32
+    v90 = const.i32 0  : i32
+    v91 = sub v90, v48  : i32
+    v92 = band v89, v91  : i32
+    v93 = call noname::_ZN8dlmalloc8dlmalloc5Chunk8from_mem17h11dd30c74f483706E(v92)  : i32
+    v94 = const.i32 16  : i32
+    v95 = const.i32 8  : i32
+    v96 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v94, v95)  : i32
+    v97 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v84)  : i32
+    v98 = const.i32 0  : i32
+    v99 = sub v93, v84  : i32
+    v100 = cast v99  : u32
+    v101 = cast v96  : u32
+    v102 = gt v100, v101  : i1
+    v103 = cast v102  : i32
+    v104 = neq v103, 0  : i1
+    v105 = select v104, v98, v48  : i32
+    v106 = add v93, v105  : i32
+    v107 = sub v106, v84  : i32
+    v108 = sub v97, v107  : i32
+    v109 = call noname::_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(v84)  : i32
+    v110 = neq v109, 0  : i1
+    condbr v110, block10, block11
 
 block9:
-    br block7(v90)
+    br block7(v84)
 
 block10:
-    v120 = cast v90  : u32
-    v121 = inttoptr v120  : *mut i32
-    v122 = load v121  : i32
-    v123 = cast v114  : u32
-    v124 = add v123, 4  : u32
-    v125 = inttoptr v124  : *mut i32
-    store v125, v116
-    v126 = add v122, v115  : i32
-    v127 = cast v114  : u32
-    v128 = inttoptr v127  : *mut i32
-    store v128, v126
-    br block7(v114)
+    v111 = cast v84  : u32
+    v112 = inttoptr v111  : *mut i32
+    v113 = load v112  : i32
+    v114 = cast v106  : u32
+    v115 = add v114, 4  : u32
+    v116 = inttoptr v115  : *mut i32
+    store v116, v108
+    v117 = add v113, v107  : i32
+    v118 = cast v106  : u32
+    v119 = inttoptr v118  : *mut i32
+    store v119, v117
+    br block7(v106)
 
 block11:
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v114, v116)
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v90, v115)
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$13dispose_chunk17h577eb103dc04307bE(v59, v90, v115)
-    br block7(v114)
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v106, v108)
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v84, v107)
+    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$13dispose_chunk17h577eb103dc04307bE(v56, v84, v107)
+    br block7(v106)
 
 block12:
-    v149 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v129)  : i32
-    v150 = call noname::_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(v148)  : i32
-    br block4(v149)
+    v138 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v120)  : i32
+    v139 = call noname::_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(v137)  : i32
+    br block4(v138)
 
 block13:
-    v133 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v129)  : i32
-    v134 = const.i32 16  : i32
-    v135 = const.i32 8  : i32
-    v136 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v134, v135)  : i32
-    v138 = add v136, v76  : i32
-    v139 = cast v133  : u32
-    v140 = cast v138  : u32
-    v141 = lte v139, v140  : i1
-    v142 = cast v141  : i32
-    v143 = const.i32 0  : i32
-    v144 = neq v142, v143  : i1
-    condbr v144, block12, block14
+    v123 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v120)  : i32
+    v124 = const.i32 16  : i32
+    v125 = const.i32 8  : i32
+    v126 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v124, v125)  : i32
+    v128 = add v126, v72  : i32
+    v129 = cast v123  : u32
+    v130 = cast v128  : u32
+    v131 = lte v129, v130  : i1
+    v132 = cast v131  : i32
+    v133 = neq v132, 0  : i1
+    condbr v133, block12, block14
 
 block14:
-    v145 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v129, v137)  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v129, v137)
-    v146 = sub v133, v137  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v145, v146)
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$13dispose_chunk17h577eb103dc04307bE(v59, v145, v146)
+    v134 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v120, v127)  : i32
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v120, v127)
+    v135 = sub v123, v127  : i32
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v134, v135)
+    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$13dispose_chunk17h577eb103dc04307bE(v56, v134, v135)
     br block12
 }
 
@@ -3926,30 +3726,29 @@ block0(v0: i32, v1: i32):
     v13 = cast v11  : u32
     v14 = lt v12, v13  : i1
     v15 = cast v14  : i32
-    v16 = const.i32 0  : i32
-    v17 = neq v15, v16  : i1
-    condbr v17, block3, block4
+    v16 = neq v15, 0  : i1
+    condbr v16, block3, block4
 
 block1(v2: i32):
     ret v2
 
-block2(v26: i32):
-    v21 = const.i32 15  : i32
-    v22 = add v6, v21  : i32
-    call noname::_ZN68_$LT$dlmalloc..global..Instance$u20$as$u20$core..ops..drop..Drop$GT$4drop17he19d8d9c8ea92454E(v22)
-    v23 = const.i32 16  : i32
-    v24 = add v20, v23  : i32
-    v25 = global.symbol @__stack_pointer  : *mut i32
-    store v25, v24
-    br block1(v26)
+block2(v25: i32):
+    v20 = const.i32 15  : i32
+    v21 = add v6, v20  : i32
+    call noname::_ZN68_$LT$dlmalloc..global..Instance$u20$as$u20$core..ops..drop..Drop$GT$4drop17he19d8d9c8ea92454E(v21)
+    v22 = const.i32 16  : i32
+    v23 = add v19, v22  : i32
+    v24 = global.symbol @__stack_pointer  : *mut i32
+    store v24, v23
+    br block1(v25)
 
 block3:
-    v19 = call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$6malloc17h1ae2390053e3628cE(v10, v0)  : i32
-    br block2(v19)
+    v18 = call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$6malloc17h1ae2390053e3628cE(v10, v0)  : i32
+    br block2(v18)
 
 block4:
-    v18 = call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$8memalign17he8794c5d1cb954f9E(v10, v1, v0)  : i32
-    br block2(v18)
+    v17 = call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$8memalign17he8794c5d1cb954f9E(v10, v1, v0)  : i32
+    br block2(v17)
 }
 
 pub fn __rust_dealloc(i32, i32, i32) {
@@ -3995,536 +3794,501 @@ block0(v0: i32, v1: i32, v2: i32, v3: i32):
     v15 = cast v13  : u32
     v16 = lt v14, v15  : i1
     v17 = cast v16  : i32
-    v18 = const.i32 0  : i32
-    v19 = neq v17, v18  : i1
-    condbr v19, block7, block8
+    v18 = neq v17, 0  : i1
+    condbr v18, block7, block8
 
 block1(v4: i32):
     ret v4
 
-block2(v404: i32, v416: i32):
-    v411 = const.i32 15  : i32
-    v412 = add v404, v411  : i32
-    call noname::_ZN68_$LT$dlmalloc..global..Instance$u20$as$u20$core..ops..drop..Drop$GT$4drop17he19d8d9c8ea92454E(v412)
-    v413 = const.i32 16  : i32
-    v414 = add v404, v413  : i32
-    v415 = global.symbol @__stack_pointer  : *mut i32
-    store v415, v414
-    br block1(v416)
+block2(v369: i32, v381: i32):
+    v376 = const.i32 15  : i32
+    v377 = add v369, v376  : i32
+    call noname::_ZN68_$LT$dlmalloc..global..Instance$u20$as$u20$core..ops..drop..Drop$GT$4drop17he19d8d9c8ea92454E(v377)
+    v378 = const.i32 16  : i32
+    v379 = add v369, v378  : i32
+    v380 = global.symbol @__stack_pointer  : *mut i32
+    store v380, v379
+    br block1(v381)
 
-block3(v401: i32, v410: i32):
-    v402 = call noname::_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(v401)  : i32
-    v403 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v401)  : i32
-    br block2(v410, v403)
+block3(v366: i32, v375: i32):
+    v367 = call noname::_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(v366)  : i32
+    v368 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE(v366)  : i32
+    br block2(v375, v368)
 
-block4(v366: i32, v368: i32, v379: i32, v384: i32, v405: i32, v417: i32):
-    v373 = call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$6malloc17h1ae2390053e3628cE(v366, v368)  : i32
-    v374 = const.i32 0  : i32
-    v375 = eq v373, v374  : i1
-    v376 = cast v375  : i32
-    v377 = const.i32 0  : i32
-    v378 = neq v376, v377  : i1
-    condbr v378, block2(v405, v417), block45
+block4(v335: i32, v337: i32, v346: i32, v351: i32, v370: i32, v382: i32):
+    v342 = call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$6malloc17h1ae2390053e3628cE(v335, v337)  : i32
+    v343 = eq v342, 0  : i1
+    v344 = cast v343  : i32
+    v345 = neq v344, 0  : i1
+    condbr v345, block2(v370, v382), block45
 
 block5:
-    v351 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v80, v79)  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v80, v79)
-    v352 = cast v12  : u32
-    v353 = add v352, 428  : u32
-    v354 = inttoptr v353  : *mut i32
-    store v354, v351
-    v355 = sub v336, v79  : i32
-    v356 = const.i32 1  : i32
-    v357 = bor v355, v356  : i32
-    v358 = cast v351  : u32
-    v359 = add v358, 4  : u32
-    v360 = inttoptr v359  : *mut i32
-    store v360, v357
-    v361 = cast v12  : u32
-    v362 = add v361, 420  : u32
-    v363 = inttoptr v362  : *mut i32
-    store v363, v355
-    v364 = const.i32 0  : i32
-    v365 = neq v80, v364  : i1
-    condbr v365, block3(v80, v8), block44
+    v321 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v75, v74)  : i32
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v75, v74)
+    v322 = cast v12  : u32
+    v323 = add v322, 428  : u32
+    v324 = inttoptr v323  : *mut i32
+    store v324, v321
+    v325 = sub v308, v74  : i32
+    v326 = const.i32 1  : i32
+    v327 = bor v325, v326  : i32
+    v328 = cast v321  : u32
+    v329 = add v328, 4  : u32
+    v330 = inttoptr v329  : *mut i32
+    store v330, v327
+    v331 = cast v12  : u32
+    v332 = add v331, 420  : u32
+    v333 = inttoptr v332  : *mut i32
+    store v333, v325
+    v334 = neq v75, 0  : i1
+    condbr v334, block3(v75, v8), block44
 
 block6:
-    v343 = cast v1  : u32
-    v344 = cast v3  : u32
-    v345 = lt v343, v344  : i1
-    v346 = cast v345  : i32
-    v347 = const.i32 0  : i32
-    v348 = neq v346, v347  : i1
-    v349 = select v348, v1, v3  : i32
-    v350 = call noname::memcpy(v20, v0, v349)  : i32
+    v314 = cast v1  : u32
+    v315 = cast v3  : u32
+    v316 = lt v314, v315  : i1
+    v317 = cast v316  : i32
+    v318 = neq v317, 0  : i1
+    v319 = select v318, v1, v3  : i32
+    v320 = call noname::memcpy(v19, v0, v319)  : i32
     call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$4free17h501de2a6604ba1ffE(v12, v0)
-    br block2(v8, v20)
+    br block2(v8, v19)
 
 block7:
-    v24 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
-    v25 = const.i32 8  : i32
-    v26 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v24, v25)  : i32
-    v27 = const.i32 20  : i32
-    v28 = const.i32 8  : i32
-    v29 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v27, v28)  : i32
-    v30 = const.i32 16  : i32
-    v31 = const.i32 8  : i32
-    v32 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v30, v31)  : i32
-    v33 = const.i32 0  : i32
-    v34 = const.i32 0  : i32
-    v35 = const.i32 16  : i32
-    v36 = const.i32 8  : i32
-    v37 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v35, v36)  : i32
-    v38 = const.i32 2  : i32
-    v39 = shl v37, v38  : i32
-    v40 = sub v34, v39  : i32
-    v41 = add v26, v29  : i32
-    v42 = add v32, v41  : i32
-    v43 = sub v24, v42  : i32
-    v44 = const.i32 -65544  : i32
-    v45 = add v43, v44  : i32
-    v46 = const.i32 -9  : i32
-    v47 = band v45, v46  : i32
-    v48 = const.i32 -3  : i32
-    v49 = add v47, v48  : i32
-    v50 = cast v40  : u32
-    v51 = cast v49  : u32
-    v52 = lt v50, v51  : i1
-    v53 = cast v52  : i32
-    v54 = const.i32 0  : i32
-    v55 = neq v53, v54  : i1
-    v56 = select v55, v40, v49  : i32
-    v57 = cast v56  : u32
-    v58 = cast v3  : u32
-    v59 = lte v57, v58  : i1
-    v60 = cast v59  : i32
-    v61 = const.i32 0  : i32
-    v62 = neq v60, v61  : i1
-    condbr v62, block2(v8, v33), block10
+    v22 = call noname::_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E()  : i32
+    v23 = const.i32 8  : i32
+    v24 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v22, v23)  : i32
+    v25 = const.i32 20  : i32
+    v26 = const.i32 8  : i32
+    v27 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v25, v26)  : i32
+    v28 = const.i32 16  : i32
+    v29 = const.i32 8  : i32
+    v30 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v28, v29)  : i32
+    v31 = const.i32 0  : i32
+    v32 = const.i32 0  : i32
+    v33 = const.i32 16  : i32
+    v34 = const.i32 8  : i32
+    v35 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v33, v34)  : i32
+    v36 = const.i32 2  : i32
+    v37 = shl v35, v36  : i32
+    v38 = sub v32, v37  : i32
+    v39 = add v24, v27  : i32
+    v40 = add v30, v39  : i32
+    v41 = sub v22, v40  : i32
+    v42 = const.i32 -65544  : i32
+    v43 = add v41, v42  : i32
+    v44 = const.i32 -9  : i32
+    v45 = band v43, v44  : i32
+    v46 = const.i32 -3  : i32
+    v47 = add v45, v46  : i32
+    v48 = cast v38  : u32
+    v49 = cast v47  : u32
+    v50 = lt v48, v49  : i1
+    v51 = cast v50  : i32
+    v52 = neq v51, 0  : i1
+    v53 = select v52, v38, v47  : i32
+    v54 = cast v53  : u32
+    v55 = cast v3  : u32
+    v56 = lte v54, v55  : i1
+    v57 = cast v56  : i32
+    v58 = neq v57, 0  : i1
+    condbr v58, block2(v8, v31), block10
 
 block8:
-    v20 = call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$8memalign17he8794c5d1cb954f9E(v12, v2, v3)  : i32
-    v21 = const.i32 0  : i32
-    v22 = neq v20, v21  : i1
-    condbr v22, block6, block9
+    v19 = call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$8memalign17he8794c5d1cb954f9E(v12, v2, v3)  : i32
+    v20 = neq v19, 0  : i1
+    condbr v20, block6, block9
 
 block9:
-    v23 = const.i32 0  : i32
-    br block2(v8, v23)
+    v21 = const.i32 0  : i32
+    br block2(v8, v21)
 
 block10:
-    v63 = const.i32 16  : i32
-    v64 = const.i32 4  : i32
-    v65 = add v3, v64  : i32
-    v66 = const.i32 16  : i32
-    v67 = const.i32 8  : i32
-    v68 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v66, v67)  : i32
-    v69 = const.i32 -5  : i32
-    v70 = add v68, v69  : i32
-    v71 = cast v70  : u32
-    v72 = cast v3  : u32
-    v73 = gt v71, v72  : i1
-    v74 = cast v73  : i32
-    v75 = const.i32 0  : i32
-    v76 = neq v74, v75  : i1
-    v77 = select v76, v63, v65  : i32
-    v78 = const.i32 8  : i32
-    v79 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v77, v78)  : i32
-    v80 = call noname::_ZN8dlmalloc8dlmalloc5Chunk8from_mem17h11dd30c74f483706E(v0)  : i32
-    v81 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v80)  : i32
-    v82 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v80, v81)  : i32
-    v83 = call noname::_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(v80)  : i32
-    v84 = const.i32 0  : i32
-    v85 = neq v83, v84  : i1
-    condbr v85, block17, block18
+    v59 = const.i32 16  : i32
+    v60 = const.i32 4  : i32
+    v61 = add v3, v60  : i32
+    v62 = const.i32 16  : i32
+    v63 = const.i32 8  : i32
+    v64 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v62, v63)  : i32
+    v65 = const.i32 -5  : i32
+    v66 = add v64, v65  : i32
+    v67 = cast v66  : u32
+    v68 = cast v3  : u32
+    v69 = gt v67, v68  : i1
+    v70 = cast v69  : i32
+    v71 = neq v70, 0  : i1
+    v72 = select v71, v59, v61  : i32
+    v73 = const.i32 8  : i32
+    v74 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v72, v73)  : i32
+    v75 = call noname::_ZN8dlmalloc8dlmalloc5Chunk8from_mem17h11dd30c74f483706E(v0)  : i32
+    v76 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v75)  : i32
+    v77 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v75, v76)  : i32
+    v78 = call noname::_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(v75)  : i32
+    v79 = neq v78, 0  : i1
+    condbr v79, block17, block18
 
 block11:
-    v332 = cast v12  : u32
-    v333 = add v332, 420  : u32
-    v334 = inttoptr v333  : *mut i32
-    v335 = load v334  : i32
-    v336 = add v335, v81  : i32
-    v337 = cast v336  : u32
-    v338 = cast v79  : u32
-    v339 = gt v337, v338  : i1
-    v340 = cast v339  : i32
-    v341 = const.i32 0  : i32
-    v342 = neq v340, v341  : i1
-    condbr v342, block5, block43
+    v304 = cast v12  : u32
+    v305 = add v304, 420  : u32
+    v306 = inttoptr v305  : *mut i32
+    v307 = load v306  : i32
+    v308 = add v307, v76  : i32
+    v309 = cast v308  : u32
+    v310 = cast v74  : u32
+    v311 = gt v309, v310  : i1
+    v312 = cast v311  : i32
+    v313 = neq v312, 0  : i1
+    condbr v313, block5, block43
 
 block12:
-    v330 = const.i32 0  : i32
-    v331 = neq v80, v330  : i1
-    condbr v331, block3(v329, v409), block42
+    v303 = neq v75, 0  : i1
+    condbr v303, block3(v302, v374), block42
 
 block13:
-    v318 = sub v81, v79  : i32
-    v319 = const.i32 16  : i32
-    v320 = const.i32 8  : i32
-    v321 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v319, v320)  : i32
-    v322 = cast v318  : u32
-    v323 = cast v321  : u32
-    v324 = lt v322, v323  : i1
-    v325 = cast v324  : i32
-    v326 = const.i32 0  : i32
-    v327 = neq v325, v326  : i1
-    condbr v327, block12, block41
-
-block14:
-    v281 = cast v12  : u32
-    v282 = add v281, 416  : u32
-    v283 = inttoptr v282  : *mut i32
-    v284 = load v283  : i32
-    v285 = add v284, v81  : i32
-    v286 = cast v285  : u32
-    v287 = cast v79  : u32
-    v288 = lt v286, v287  : i1
-    v289 = cast v288  : i32
-    v290 = const.i32 0  : i32
-    v291 = neq v289, v290  : i1
-    condbr v291, block4(v12, v3, v0, v80, v8, v33), block36
-
-block15:
-    v263 = const.i32 16  : i32
-    v264 = const.i32 8  : i32
-    v265 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v263, v264)  : i32
-    v266 = cast v119  : u32
-    v267 = cast v265  : u32
-    v268 = lt v266, v267  : i1
-    v269 = cast v268  : i32
-    v270 = const.i32 0  : i32
-    v271 = neq v269, v270  : i1
-    condbr v271, block32, block33
-
-block16:
-    v229 = cast v82  : u32
-    v230 = add v229, 12  : u32
-    v231 = inttoptr v230  : *mut i32
-    v232 = load v231  : i32
-    v233 = cast v82  : u32
-    v234 = add v233, 8  : u32
-    v235 = inttoptr v234  : *mut i32
-    v236 = load v235  : i32
-    v237 = eq v232, v236  : i1
-    v238 = cast v237  : i32
-    v239 = const.i32 0  : i32
-    v240 = neq v238, v239  : i1
-    condbr v240, block30, block31
-
-block17:
-    v127 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v80)  : i32
-    v128 = const.i32 256  : i32
-    v129 = cast v79  : u32
-    v130 = cast v128  : u32
-    v131 = lt v129, v130  : i1
-    v132 = cast v131  : i32
-    v133 = const.i32 0  : i32
-    v134 = neq v132, v133  : i1
-    condbr v134, block4(v12, v3, v0, v80, v8, v33), block25
-
-block18:
-    v86 = cast v81  : u32
-    v87 = cast v79  : u32
-    v88 = gte v86, v87  : i1
-    v89 = cast v88  : i32
-    v90 = const.i32 0  : i32
-    v91 = neq v89, v90  : i1
-    condbr v91, block13, block19
-
-block19:
-    v92 = cast v12  : u32
-    v93 = add v92, 428  : u32
-    v94 = inttoptr v93  : *mut i32
-    v95 = load v94  : i32
-    v96 = eq v82, v95  : i1
-    v97 = cast v96  : i32
-    v98 = const.i32 0  : i32
-    v99 = neq v97, v98  : i1
-    condbr v99, block11, block20
-
-block20:
-    v100 = cast v12  : u32
-    v101 = add v100, 424  : u32
-    v102 = inttoptr v101  : *mut i32
-    v103 = load v102  : i32
-    v104 = eq v82, v103  : i1
-    v105 = cast v104  : i32
-    v106 = const.i32 0  : i32
-    v107 = neq v105, v106  : i1
-    condbr v107, block14, block21
-
-block21:
-    v108 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6cinuse17h58499de57c2d37e2E(v82)  : i32
-    v109 = const.i32 0  : i32
-    v110 = neq v108, v109  : i1
-    condbr v110, block4(v12, v3, v0, v80, v8, v33), block22
-
-block22:
-    v111 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v82)  : i32
-    v112 = add v111, v81  : i32
-    v113 = cast v112  : u32
-    v114 = cast v79  : u32
-    v115 = lt v113, v114  : i1
-    v116 = cast v115  : i32
-    v117 = const.i32 0  : i32
-    v118 = neq v116, v117  : i1
-    condbr v118, block4(v12, v3, v0, v80, v8, v33), block23
-
-block23:
-    v119 = sub v112, v79  : i32
-    v120 = const.i32 256  : i32
-    v121 = cast v111  : u32
-    v122 = cast v120  : u32
-    v123 = lt v121, v122  : i1
-    v124 = cast v123  : i32
-    v125 = const.i32 0  : i32
-    v126 = neq v124, v125  : i1
-    condbr v126, block16, block24
-
-block24:
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v12, v82)
-    br block15
-
-block25:
-    v135 = const.i32 4  : i32
-    v136 = add v79, v135  : i32
-    v137 = cast v127  : u32
-    v138 = cast v136  : u32
-    v139 = lt v137, v138  : i1
-    v140 = cast v139  : i32
-    v141 = const.i32 0  : i32
-    v142 = neq v140, v141  : i1
-    condbr v142, block26, block27
-
-block26:
-    v153 = cast v152  : u32
-    v154 = inttoptr v153  : *mut i32
-    v155 = load v154  : i32
-    v156 = sub v80, v155  : i32
-    v158 = add v127, v155  : i32
-    v159 = const.i32 16  : i32
-    v160 = add v158, v159  : i32
-    v162 = const.i32 31  : i32
-    v163 = add v79, v162  : i32
-    v164 = call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$9page_size17h0fdd55b2693d440cE(v151)  : i32
-    v165 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v163, v164)  : i32
-    v166 = const.i32 1  : i32
-    v167 = call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$5remap17hf5ff3c6a92680f40E(v12, v156, v160, v165, v166)  : i32
-    v168 = const.i32 0  : i32
-    v169 = eq v167, v168  : i1
-    v170 = cast v169  : i32
-    v171 = const.i32 0  : i32
-    v172 = neq v170, v171  : i1
-    condbr v172, block4(v151, v3, v0, v152, v8, v33), block29
-
-block27:
-    v143 = sub v127, v79  : i32
-    v144 = const.i32 131073  : i32
-    v145 = cast v143  : u32
-    v146 = cast v144  : u32
-    v147 = lt v145, v146  : i1
-    v148 = cast v147  : i32
-    v149 = const.i32 0  : i32
-    v150 = neq v148, v149  : i1
-    condbr v150, block12, block28
-
-block28:
-    br block26
-
-block29:
-    v173 = add v167, v155  : i32
-    v174 = sub v165, v155  : i32
-    v175 = const.i32 -16  : i32
-    v176 = add v174, v175  : i32
-    v177 = cast v173  : u32
-    v178 = add v177, 4  : u32
-    v179 = inttoptr v178  : *mut i32
-    store v179, v176
-    v180 = call noname::_ZN8dlmalloc8dlmalloc5Chunk14fencepost_head17he07aaa52f3b50dfdE()  : i32
-    v181 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v173, v176)  : i32
-    v182 = cast v181  : u32
-    v183 = add v182, 4  : u32
-    v184 = inttoptr v183  : *mut i32
-    store v184, v180
-    v185 = const.i32 -12  : i32
-    v186 = add v174, v185  : i32
-    v187 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v173, v186)  : i32
-    v188 = const.i32 0  : i32
-    v189 = cast v187  : u32
-    v190 = add v189, 4  : u32
-    v191 = inttoptr v190  : *mut i32
-    store v191, v188
-    v192 = cast v151  : u32
-    v193 = add v192, 432  : u32
-    v194 = inttoptr v193  : *mut i32
-    v195 = load v194  : i32
-    v196 = sub v165, v160  : i32
-    v197 = add v195, v196  : i32
-    v198 = cast v151  : u32
-    v199 = add v198, 432  : u32
-    v200 = inttoptr v199  : *mut i32
-    store v200, v197
-    v201 = cast v151  : u32
-    v202 = add v201, 444  : u32
-    v203 = inttoptr v202  : *mut i32
-    v204 = load v203  : i32
-    v205 = cast v167  : u32
-    v206 = cast v204  : u32
-    v207 = gt v205, v206  : i1
-    v208 = cast v207  : i32
-    v209 = const.i32 0  : i32
-    v210 = neq v208, v209  : i1
-    v211 = select v210, v204, v167  : i32
-    v212 = cast v151  : u32
-    v213 = add v212, 444  : u32
-    v214 = inttoptr v213  : *mut i32
-    store v214, v211
-    v215 = cast v151  : u32
-    v216 = add v215, 436  : u32
-    v217 = inttoptr v216  : *mut i32
-    v218 = load v217  : i32
-    v219 = cast v218  : u32
-    v220 = cast v197  : u32
-    v221 = gt v219, v220  : i1
-    v222 = cast v221  : i32
-    v223 = const.i32 0  : i32
-    v224 = neq v222, v223  : i1
-    v225 = select v224, v218, v197  : i32
-    v226 = cast v151  : u32
-    v227 = add v226, 436  : u32
-    v228 = inttoptr v227  : *mut i32
-    store v228, v225
-    br block3(v173, v406)
-
-block30:
-    v247 = cast v12  : u32
-    v248 = add v247, 408  : u32
-    v249 = inttoptr v248  : *mut i32
-    v250 = load v249  : i32
-    v251 = const.i32 -2  : i32
-    v252 = const.i32 3  : i32
-    v253 = cast v111  : u32
-    v254 = cast v252  : u32
-    v255 = shr v253, v254  : u32
-    v256 = cast v255  : i32
-    v257 = shl v251, v256  : i32
-    v258 = band v250, v257  : i32
-    v259 = cast v12  : u32
-    v260 = add v259, 408  : u32
-    v261 = inttoptr v260  : *mut i32
-    store v261, v258
-    br block15
-
-block31:
-    v241 = cast v236  : u32
-    v242 = add v241, 12  : u32
-    v243 = inttoptr v242  : *mut i32
-    store v243, v232
-    v244 = cast v232  : u32
-    v245 = add v244, 8  : u32
-    v246 = inttoptr v245  : *mut i32
-    store v246, v236
-    br block15
-
-block32:
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v272, v112)
-    v279 = const.i32 0  : i32
-    v280 = neq v272, v279  : i1
-    condbr v280, block3(v272, v407), block35
-
-block33:
-    v274 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v80, v79)  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v272, v273)
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v274, v262)
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$13dispose_chunk17h577eb103dc04307bE(v12, v274, v262)
-    v276 = const.i32 0  : i32
-    v277 = neq v272, v276  : i1
-    condbr v277, block3(v272, v407), block34
-
-block34:
-    br block4(v275, v3, v0, v272, v8, v33)
-
-block35:
-    br block4(v275, v370, v381, v272, v407, v419)
-
-block36:
-    v292 = sub v285, v79  : i32
+    v292 = sub v76, v74  : i32
     v293 = const.i32 16  : i32
     v294 = const.i32 8  : i32
     v295 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v293, v294)  : i32
     v296 = cast v292  : u32
     v297 = cast v295  : u32
-    v298 = gte v296, v297  : i1
+    v298 = lt v296, v297  : i1
     v299 = cast v298  : i32
-    v300 = const.i32 0  : i32
-    v301 = neq v299, v300  : i1
-    condbr v301, block38, block39
+    v300 = neq v299, 0  : i1
+    condbr v300, block12, block41
 
-block37(v307: i32, v311: i32):
-    v308 = cast v12  : u32
-    v309 = add v308, 424  : u32
-    v310 = inttoptr v309  : *mut i32
-    store v310, v307
-    v312 = cast v306  : u32
-    v313 = add v312, 416  : u32
-    v314 = inttoptr v313  : *mut i32
-    store v314, v311
-    v316 = const.i32 0  : i32
-    v317 = neq v80, v316  : i1
-    condbr v317, block3(v315, v408), block40
+block14:
+    v258 = cast v12  : u32
+    v259 = add v258, 416  : u32
+    v260 = inttoptr v259  : *mut i32
+    v261 = load v260  : i32
+    v262 = add v261, v76  : i32
+    v263 = cast v262  : u32
+    v264 = cast v74  : u32
+    v265 = lt v263, v264  : i1
+    v266 = cast v265  : i32
+    v267 = neq v266, 0  : i1
+    condbr v267, block4(v12, v3, v0, v75, v8, v31), block36
+
+block15:
+    v243 = const.i32 16  : i32
+    v244 = const.i32 8  : i32
+    v245 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v243, v244)  : i32
+    v246 = cast v108  : u32
+    v247 = cast v245  : u32
+    v248 = lt v246, v247  : i1
+    v249 = cast v248  : i32
+    v250 = neq v249, 0  : i1
+    condbr v250, block32, block33
+
+block16:
+    v210 = cast v77  : u32
+    v211 = add v210, 12  : u32
+    v212 = inttoptr v211  : *mut i32
+    v213 = load v212  : i32
+    v214 = cast v77  : u32
+    v215 = add v214, 8  : u32
+    v216 = inttoptr v215  : *mut i32
+    v217 = load v216  : i32
+    v218 = eq v213, v217  : i1
+    v219 = cast v218  : i32
+    v220 = neq v219, 0  : i1
+    condbr v220, block30, block31
+
+block17:
+    v115 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v75)  : i32
+    v116 = const.i32 256  : i32
+    v117 = cast v74  : u32
+    v118 = cast v116  : u32
+    v119 = lt v117, v118  : i1
+    v120 = cast v119  : i32
+    v121 = neq v120, 0  : i1
+    condbr v121, block4(v12, v3, v0, v75, v8, v31), block25
+
+block18:
+    v80 = cast v76  : u32
+    v81 = cast v74  : u32
+    v82 = gte v80, v81  : i1
+    v83 = cast v82  : i32
+    v84 = neq v83, 0  : i1
+    condbr v84, block13, block19
+
+block19:
+    v85 = cast v12  : u32
+    v86 = add v85, 428  : u32
+    v87 = inttoptr v86  : *mut i32
+    v88 = load v87  : i32
+    v89 = eq v77, v88  : i1
+    v90 = cast v89  : i32
+    v91 = neq v90, 0  : i1
+    condbr v91, block11, block20
+
+block20:
+    v92 = cast v12  : u32
+    v93 = add v92, 424  : u32
+    v94 = inttoptr v93  : *mut i32
+    v95 = load v94  : i32
+    v96 = eq v77, v95  : i1
+    v97 = cast v96  : i32
+    v98 = neq v97, 0  : i1
+    condbr v98, block14, block21
+
+block21:
+    v99 = call noname::_ZN8dlmalloc8dlmalloc5Chunk6cinuse17h58499de57c2d37e2E(v77)  : i32
+    v100 = neq v99, 0  : i1
+    condbr v100, block4(v12, v3, v0, v75, v8, v31), block22
+
+block22:
+    v101 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v77)  : i32
+    v102 = add v101, v76  : i32
+    v103 = cast v102  : u32
+    v104 = cast v74  : u32
+    v105 = lt v103, v104  : i1
+    v106 = cast v105  : i32
+    v107 = neq v106, 0  : i1
+    condbr v107, block4(v12, v3, v0, v75, v8, v31), block23
+
+block23:
+    v108 = sub v102, v74  : i32
+    v109 = const.i32 256  : i32
+    v110 = cast v101  : u32
+    v111 = cast v109  : u32
+    v112 = lt v110, v111  : i1
+    v113 = cast v112  : i32
+    v114 = neq v113, 0  : i1
+    condbr v114, block16, block24
+
+block24:
+    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E(v12, v77)
+    br block15
+
+block25:
+    v122 = const.i32 4  : i32
+    v123 = add v74, v122  : i32
+    v124 = cast v115  : u32
+    v125 = cast v123  : u32
+    v126 = lt v124, v125  : i1
+    v127 = cast v126  : i32
+    v128 = neq v127, 0  : i1
+    condbr v128, block26, block27
+
+block26:
+    v138 = cast v137  : u32
+    v139 = inttoptr v138  : *mut i32
+    v140 = load v139  : i32
+    v141 = sub v75, v140  : i32
+    v143 = add v115, v140  : i32
+    v144 = const.i32 16  : i32
+    v145 = add v143, v144  : i32
+    v147 = const.i32 31  : i32
+    v148 = add v74, v147  : i32
+    v149 = call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$9page_size17h0fdd55b2693d440cE(v136)  : i32
+    v150 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v148, v149)  : i32
+    v151 = const.i32 1  : i32
+    v152 = call noname::_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$5remap17hf5ff3c6a92680f40E(v12, v141, v145, v150, v151)  : i32
+    v153 = eq v152, 0  : i1
+    v154 = cast v153  : i32
+    v155 = neq v154, 0  : i1
+    condbr v155, block4(v136, v3, v0, v137, v8, v31), block29
+
+block27:
+    v129 = sub v115, v74  : i32
+    v130 = const.i32 131073  : i32
+    v131 = cast v129  : u32
+    v132 = cast v130  : u32
+    v133 = lt v131, v132  : i1
+    v134 = cast v133  : i32
+    v135 = neq v134, 0  : i1
+    condbr v135, block12, block28
+
+block28:
+    br block26
+
+block29:
+    v156 = add v152, v140  : i32
+    v157 = sub v150, v140  : i32
+    v158 = const.i32 -16  : i32
+    v159 = add v157, v158  : i32
+    v160 = cast v156  : u32
+    v161 = add v160, 4  : u32
+    v162 = inttoptr v161  : *mut i32
+    store v162, v159
+    v163 = call noname::_ZN8dlmalloc8dlmalloc5Chunk14fencepost_head17he07aaa52f3b50dfdE()  : i32
+    v164 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v156, v159)  : i32
+    v165 = cast v164  : u32
+    v166 = add v165, 4  : u32
+    v167 = inttoptr v166  : *mut i32
+    store v167, v163
+    v168 = const.i32 -12  : i32
+    v169 = add v157, v168  : i32
+    v170 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v156, v169)  : i32
+    v171 = const.i32 0  : i32
+    v172 = cast v170  : u32
+    v173 = add v172, 4  : u32
+    v174 = inttoptr v173  : *mut i32
+    store v174, v171
+    v175 = cast v136  : u32
+    v176 = add v175, 432  : u32
+    v177 = inttoptr v176  : *mut i32
+    v178 = load v177  : i32
+    v179 = sub v150, v145  : i32
+    v180 = add v178, v179  : i32
+    v181 = cast v136  : u32
+    v182 = add v181, 432  : u32
+    v183 = inttoptr v182  : *mut i32
+    store v183, v180
+    v184 = cast v136  : u32
+    v185 = add v184, 444  : u32
+    v186 = inttoptr v185  : *mut i32
+    v187 = load v186  : i32
+    v188 = cast v152  : u32
+    v189 = cast v187  : u32
+    v190 = gt v188, v189  : i1
+    v191 = cast v190  : i32
+    v192 = neq v191, 0  : i1
+    v193 = select v192, v187, v152  : i32
+    v194 = cast v136  : u32
+    v195 = add v194, 444  : u32
+    v196 = inttoptr v195  : *mut i32
+    store v196, v193
+    v197 = cast v136  : u32
+    v198 = add v197, 436  : u32
+    v199 = inttoptr v198  : *mut i32
+    v200 = load v199  : i32
+    v201 = cast v200  : u32
+    v202 = cast v180  : u32
+    v203 = gt v201, v202  : i1
+    v204 = cast v203  : i32
+    v205 = neq v204, 0  : i1
+    v206 = select v205, v200, v180  : i32
+    v207 = cast v136  : u32
+    v208 = add v207, 436  : u32
+    v209 = inttoptr v208  : *mut i32
+    store v209, v206
+    br block3(v156, v371)
+
+block30:
+    v227 = cast v12  : u32
+    v228 = add v227, 408  : u32
+    v229 = inttoptr v228  : *mut i32
+    v230 = load v229  : i32
+    v231 = const.i32 -2  : i32
+    v232 = const.i32 3  : i32
+    v233 = cast v101  : u32
+    v234 = cast v232  : u32
+    v235 = shr v233, v234  : u32
+    v236 = cast v235  : i32
+    v237 = shl v231, v236  : i32
+    v238 = band v230, v237  : i32
+    v239 = cast v12  : u32
+    v240 = add v239, 408  : u32
+    v241 = inttoptr v240  : *mut i32
+    store v241, v238
+    br block15
+
+block31:
+    v221 = cast v217  : u32
+    v222 = add v221, 12  : u32
+    v223 = inttoptr v222  : *mut i32
+    store v223, v213
+    v224 = cast v213  : u32
+    v225 = add v224, 8  : u32
+    v226 = inttoptr v225  : *mut i32
+    store v226, v217
+    br block15
+
+block32:
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v251, v102)
+    v257 = neq v251, 0  : i1
+    condbr v257, block3(v251, v372), block35
+
+block33:
+    v253 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v75, v74)  : i32
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v251, v252)
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v253, v242)
+    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$13dispose_chunk17h577eb103dc04307bE(v12, v253, v242)
+    v255 = neq v251, 0  : i1
+    condbr v255, block3(v251, v372), block34
+
+block34:
+    br block4(v254, v3, v0, v251, v8, v31)
+
+block35:
+    br block4(v254, v339, v348, v251, v372, v384)
+
+block36:
+    v268 = sub v262, v74  : i32
+    v269 = const.i32 16  : i32
+    v270 = const.i32 8  : i32
+    v271 = call noname::_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E(v269, v270)  : i32
+    v272 = cast v268  : u32
+    v273 = cast v271  : u32
+    v274 = gte v272, v273  : i1
+    v275 = cast v274  : i32
+    v276 = neq v275, 0  : i1
+    condbr v276, block38, block39
+
+block37(v282: i32, v286: i32):
+    v283 = cast v12  : u32
+    v284 = add v283, 424  : u32
+    v285 = inttoptr v284  : *mut i32
+    store v285, v282
+    v287 = cast v281  : u32
+    v288 = add v287, 416  : u32
+    v289 = inttoptr v288  : *mut i32
+    store v289, v286
+    v291 = neq v75, 0  : i1
+    condbr v291, block3(v290, v373), block40
 
 block38:
-    v304 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v80, v79)  : i32
-    v305 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v304, v292)  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v80, v79)
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v304, v292)
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk12clear_pinuse17h3c1a99d0f5bddc22E(v305)
-    br block37(v304, v292)
+    v279 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v75, v74)  : i32
+    v280 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v279, v268)  : i32
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v75, v74)
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E(v279, v268)
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk12clear_pinuse17h3c1a99d0f5bddc22E(v280)
+    br block37(v279, v268)
 
 block39:
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v80, v285)
-    v302 = const.i32 0  : i32
-    v303 = const.i32 0  : i32
-    br block37(v303, v302)
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v75, v262)
+    v277 = const.i32 0  : i32
+    v278 = const.i32 0  : i32
+    br block37(v278, v277)
 
 block40:
-    br block4(v306, v3, v0, v315, v8, v33)
+    br block4(v281, v3, v0, v290, v8, v31)
 
 block41:
-    v328 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v80, v79)  : i32
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v80, v79)
-    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v328, v318)
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$13dispose_chunk17h577eb103dc04307bE(v12, v328, v318)
+    v301 = call noname::_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E(v75, v74)  : i32
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v75, v74)
+    call noname::_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E(v301, v292)
+    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$13dispose_chunk17h577eb103dc04307bE(v12, v301, v292)
     br block12
 
 block42:
-    br block4(v12, v3, v0, v329, v8, v33)
+    br block4(v12, v3, v0, v302, v8, v31)
 
 block43:
-    br block4(v12, v3, v0, v80, v8, v33)
+    br block4(v12, v3, v0, v75, v8, v31)
 
 block44:
-    br block4(v12, v3, v0, v80, v8, v33)
+    br block4(v12, v3, v0, v75, v8, v31)
 
 block45:
-    v385 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v384)  : i32
-    v386 = const.i32 -8  : i32
-    v387 = const.i32 -4  : i32
-    v388 = call noname::_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(v384)  : i32
-    v389 = const.i32 0  : i32
-    v390 = neq v388, v389  : i1
-    v391 = select v390, v386, v387  : i32
-    v392 = add v385, v391  : i32
-    v393 = cast v392  : u32
-    v394 = cast v368  : u32
-    v395 = lt v393, v394  : i1
-    v396 = cast v395  : i32
-    v397 = const.i32 0  : i32
-    v398 = neq v396, v397  : i1
-    v399 = select v398, v392, v368  : i32
-    v400 = call noname::memcpy(v373, v379, v399)  : i32
-    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$4free17h501de2a6604ba1ffE(v366, v379)
-    br block2(v405, v400)
+    v352 = call noname::_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E(v351)  : i32
+    v353 = const.i32 -8  : i32
+    v354 = const.i32 -4  : i32
+    v355 = call noname::_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E(v351)  : i32
+    v356 = neq v355, 0  : i1
+    v357 = select v356, v353, v354  : i32
+    v358 = add v352, v357  : i32
+    v359 = cast v358  : u32
+    v360 = cast v337  : u32
+    v361 = lt v359, v360  : i1
+    v362 = cast v361  : i32
+    v363 = neq v362, 0  : i1
+    v364 = select v363, v358, v337  : i32
+    v365 = call noname::memcpy(v342, v346, v364)  : i32
+    call noname::_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$4free17h501de2a6604ba1ffE(v335, v346)
+    br block2(v370, v365)
 }
 
 pub fn __rust_alloc_error_handler(i32, i32) {
@@ -4538,153 +4302,143 @@ block1:
 pub fn _ZN5alloc7raw_vec11finish_grow17hcefa6a06206fd52bE(i32, i32, i32, i32) {
 block0(v0: i32, v1: i32, v2: i32, v3: i32):
     v4 = const.i32 0  : i32
-    v5 = const.i32 0  : i32
-    v6 = eq v1, v5  : i1
-    v7 = cast v6  : i32
-    v8 = const.i32 0  : i32
-    v9 = neq v7, v8  : i1
-    condbr v9, block4, block5
+    v5 = eq v1, 0  : i1
+    v6 = cast v5  : i32
+    v7 = neq v6, 0  : i1
+    condbr v7, block4, block5
 
 block1:
     ret 
 
-block2(v93: i32):
-    v94 = const.i32 1  : i32
-    v95 = cast v93  : u32
-    v96 = inttoptr v95  : *mut i32
-    store v96, v94
+block2(v83: i32):
+    v84 = const.i32 1  : i32
+    v85 = cast v83  : u32
+    v86 = inttoptr v85  : *mut i32
+    store v86, v84
     br block1
 
 block3:
-    v89 = const.i32 0  : i32
-    v90 = cast v0  : u32
-    v91 = add v90, 4  : u32
-    v92 = inttoptr v91  : *mut i32
-    store v92, v89
+    v79 = const.i32 0  : i32
+    v80 = cast v0  : u32
+    v81 = add v80, 4  : u32
+    v82 = inttoptr v81  : *mut i32
+    store v82, v79
     br block2(v0)
 
 block4:
-    v81 = const.i32 0  : i32
-    v82 = cast v0  : u32
-    v83 = add v82, 4  : u32
-    v84 = inttoptr v83  : *mut i32
-    store v84, v81
-    v85 = const.i32 8  : i32
-    v86 = add v0, v85  : i32
-    v87 = cast v86  : u32
-    v88 = inttoptr v87  : *mut i32
-    store v88, v2
+    v71 = const.i32 0  : i32
+    v72 = cast v0  : u32
+    v73 = add v72, 4  : u32
+    v74 = inttoptr v73  : *mut i32
+    store v74, v71
+    v75 = const.i32 8  : i32
+    v76 = add v0, v75  : i32
+    v77 = cast v76  : u32
+    v78 = inttoptr v77  : *mut i32
+    store v78, v2
     br block2(v0)
 
 block5:
-    v10 = const.i32 -1  : i32
-    v11 = lte v2, v10  : i1
-    v12 = cast v11  : i32
-    v13 = const.i32 0  : i32
-    v14 = neq v12, v13  : i1
-    condbr v14, block3, block6
+    v8 = const.i32 -1  : i32
+    v9 = lte v2, v8  : i1
+    v10 = cast v9  : i32
+    v11 = neq v10, 0  : i1
+    condbr v11, block3, block6
 
 block6:
-    v15 = cast v3  : u32
-    v16 = add v15, 4  : u32
-    v17 = inttoptr v16  : *mut i32
-    v18 = load v17  : i32
-    v19 = const.i32 0  : i32
-    v20 = eq v18, v19  : i1
-    v21 = cast v20  : i32
-    v22 = const.i32 0  : i32
-    v23 = neq v21, v22  : i1
-    condbr v23, block9, block10
+    v12 = cast v3  : u32
+    v13 = add v12, 4  : u32
+    v14 = inttoptr v13  : *mut i32
+    v15 = load v14  : i32
+    v16 = eq v15, 0  : i1
+    v17 = cast v16  : i32
+    v18 = neq v17, 0  : i1
+    condbr v18, block9, block10
 
-block7(v54: i32, v67: i32, v73: i32):
-    v55 = const.i32 0  : i32
-    v56 = eq v54, v55  : i1
-    v57 = cast v56  : i32
-    v58 = const.i32 0  : i32
-    v59 = neq v57, v58  : i1
-    condbr v59, block17, block18
+block7(v46: i32, v57: i32, v63: i32):
+    v47 = eq v46, 0  : i1
+    v48 = cast v47  : i32
+    v49 = neq v48, 0  : i1
+    condbr v49, block17, block18
 
 block8:
-    v53 = call noname::__rust_alloc(v2, v1)  : i32
-    br block7(v53, v51, v52)
+    v45 = call noname::__rust_alloc(v2, v1)  : i32
+    br block7(v45, v43, v44)
 
 block9:
-    v43 = const.i32 0  : i32
-    v44 = neq v2, v43  : i1
-    condbr v44, block15, block16
+    v36 = neq v2, 0  : i1
+    condbr v36, block15, block16
 
 block10:
-    v24 = const.i32 8  : i32
-    v25 = add v3, v24  : i32
-    v26 = cast v25  : u32
-    v27 = inttoptr v26  : *mut i32
-    v28 = load v27  : i32
-    v29 = const.i32 0  : i32
-    v30 = neq v28, v29  : i1
-    condbr v30, block11, block12
+    v19 = const.i32 8  : i32
+    v20 = add v3, v19  : i32
+    v21 = cast v20  : u32
+    v22 = inttoptr v21  : *mut i32
+    v23 = load v22  : i32
+    v24 = neq v23, 0  : i1
+    condbr v24, block11, block12
 
 block11:
-    v39 = cast v3  : u32
-    v40 = inttoptr v39  : *mut i32
-    v41 = load v40  : i32
-    v42 = call noname::__rust_realloc(v41, v28, v1, v2)  : i32
-    br block7(v42, v2, v1)
+    v32 = cast v3  : u32
+    v33 = inttoptr v32  : *mut i32
+    v34 = load v33  : i32
+    v35 = call noname::__rust_realloc(v34, v23, v1, v2)  : i32
+    br block7(v35, v2, v1)
 
 block12:
-    v31 = const.i32 0  : i32
-    v32 = neq v2, v31  : i1
-    condbr v32, block13, block14
+    v25 = neq v2, 0  : i1
+    condbr v25, block13, block14
 
 block13:
-    v33 = const.i32 0  : i32
-    v34 = cast v33  : u32
-    v35 = add v34, 1048576  : u32
-    v36 = inttoptr v35  : *mut u8
-    v37 = load v36  : u8
-    v38 = zext v37  : i32
+    v26 = const.i32 0  : i32
+    v27 = cast v26  : u32
+    v28 = add v27, 1048576  : u32
+    v29 = inttoptr v28  : *mut u8
+    v30 = load v29  : u8
+    v31 = zext v30  : i32
     br block8
 
 block14:
     br block7(v1, v2, v1)
 
 block15:
-    v45 = const.i32 0  : i32
-    v46 = cast v45  : u32
-    v47 = add v46, 1048576  : u32
-    v48 = inttoptr v47  : *mut u8
-    v49 = load v48  : u8
-    v50 = zext v49  : i32
+    v37 = const.i32 0  : i32
+    v38 = cast v37  : u32
+    v39 = add v38, 1048576  : u32
+    v40 = inttoptr v39  : *mut u8
+    v41 = load v40  : u8
+    v42 = zext v41  : i32
     br block8
 
 block16:
     br block7(v1, v2, v1)
 
 block17:
-    v74 = cast v60  : u32
-    v75 = add v74, 4  : u32
-    v76 = inttoptr v75  : *mut i32
-    store v76, v73
-    v77 = const.i32 8  : i32
-    v78 = add v60, v77  : i32
-    v79 = cast v78  : u32
-    v80 = inttoptr v79  : *mut i32
-    store v80, v67
-    br block2(v60)
+    v64 = cast v50  : u32
+    v65 = add v64, 4  : u32
+    v66 = inttoptr v65  : *mut i32
+    store v66, v63
+    v67 = const.i32 8  : i32
+    v68 = add v50, v67  : i32
+    v69 = cast v68  : u32
+    v70 = inttoptr v69  : *mut i32
+    store v70, v57
+    br block2(v50)
 
 block18:
-    v62 = cast v0  : u32
-    v63 = add v62, 4  : u32
-    v64 = inttoptr v63  : *mut i32
-    store v64, v54
-    v65 = const.i32 8  : i32
-    v66 = add v60, v65  : i32
-    v68 = cast v66  : u32
-    v69 = inttoptr v68  : *mut i32
-    store v69, v67
-    v70 = const.i32 0  : i32
-    v71 = cast v60  : u32
-    v72 = inttoptr v71  : *mut i32
-    store v72, v70
+    v52 = cast v0  : u32
+    v53 = add v52, 4  : u32
+    v54 = inttoptr v53  : *mut i32
+    store v54, v46
+    v55 = const.i32 8  : i32
+    v56 = add v50, v55  : i32
+    v58 = cast v56  : u32
+    v59 = inttoptr v58  : *mut i32
+    store v59, v57
+    v60 = const.i32 0  : i32
+    v61 = cast v50  : u32
+    v62 = inttoptr v61  : *mut i32
+    store v62, v60
     ret 
 }
 
@@ -4708,119 +4462,112 @@ block0(v0: i32):
     v15 = cast v13  : u32
     v16 = gt v14, v15  : i1
     v17 = cast v16  : i32
-    v18 = const.i32 0  : i32
-    v19 = neq v17, v18  : i1
-    v20 = select v19, v11, v12  : i32
-    v21 = const.i32 2  : i32
-    v22 = shl v20, v21  : i32
-    v23 = const.i32 536870912  : i32
-    v24 = cast v20  : u32
-    v25 = cast v23  : u32
-    v26 = lt v24, v25  : i1
-    v27 = cast v26  : i32
-    v28 = const.i32 2  : i32
-    v29 = shl v27, v28  : i32
-    v30 = const.i32 0  : i32
-    v31 = eq v9, v30  : i1
-    v32 = cast v31  : i32
-    v33 = const.i32 0  : i32
-    v34 = neq v32, v33  : i1
-    condbr v34, block3, block4
+    v18 = neq v17, 0  : i1
+    v19 = select v18, v11, v12  : i32
+    v20 = const.i32 2  : i32
+    v21 = shl v19, v20  : i32
+    v22 = const.i32 536870912  : i32
+    v23 = cast v19  : u32
+    v24 = cast v22  : u32
+    v25 = lt v23, v24  : i1
+    v26 = cast v25  : i32
+    v27 = const.i32 2  : i32
+    v28 = shl v26, v27  : i32
+    v29 = eq v9, 0  : i1
+    v30 = cast v29  : i32
+    v31 = neq v30, 0  : i1
+    condbr v31, block3, block4
 
 block1:
     ret 
 
 block2:
-    v55 = const.i32 8  : i32
-    v56 = add v4, v55  : i32
-    v59 = const.i32 20  : i32
-    v60 = add v54, v59  : i32
-    call noname::_ZN5alloc7raw_vec11finish_grow17hcefa6a06206fd52bE(v56, v29, v22, v60)
-    v61 = cast v54  : u32
-    v62 = add v61, 12  : u32
-    v63 = inttoptr v62  : *mut i32
-    v64 = load v63  : i32
-    v65 = cast v54  : u32
-    v66 = add v65, 8  : u32
-    v67 = inttoptr v66  : *mut i32
-    v68 = load v67  : i32
-    v69 = const.i32 0  : i32
-    v70 = neq v68, v69  : i1
-    condbr v70, block6, block7
+    v52 = const.i32 8  : i32
+    v53 = add v4, v52  : i32
+    v56 = const.i32 20  : i32
+    v57 = add v51, v56  : i32
+    call noname::_ZN5alloc7raw_vec11finish_grow17hcefa6a06206fd52bE(v53, v28, v21, v57)
+    v58 = cast v51  : u32
+    v59 = add v58, 12  : u32
+    v60 = inttoptr v59  : *mut i32
+    v61 = load v60  : i32
+    v62 = cast v51  : u32
+    v63 = add v62, 8  : u32
+    v64 = inttoptr v63  : *mut i32
+    v65 = load v64  : i32
+    v66 = neq v65, 0  : i1
+    condbr v66, block6, block7
 
 block3:
-    v50 = const.i32 0  : i32
-    v51 = cast v4  : u32
-    v52 = add v51, 24  : u32
-    v53 = inttoptr v52  : *mut i32
-    store v53, v50
+    v47 = const.i32 0  : i32
+    v48 = cast v4  : u32
+    v49 = add v48, 24  : u32
+    v50 = inttoptr v49  : *mut i32
+    store v50, v47
     br block2
 
 block4:
-    v35 = const.i32 4  : i32
-    v36 = cast v4  : u32
-    v37 = add v36, 24  : u32
-    v38 = inttoptr v37  : *mut i32
-    store v38, v35
-    v39 = const.i32 2  : i32
-    v40 = shl v9, v39  : i32
-    v41 = cast v4  : u32
-    v42 = add v41, 28  : u32
-    v43 = inttoptr v42  : *mut i32
-    store v43, v40
-    v44 = cast v0  : u32
-    v45 = inttoptr v44  : *mut i32
-    v46 = load v45  : i32
-    v47 = cast v4  : u32
-    v48 = add v47, 20  : u32
-    v49 = inttoptr v48  : *mut i32
-    store v49, v46
+    v32 = const.i32 4  : i32
+    v33 = cast v4  : u32
+    v34 = add v33, 24  : u32
+    v35 = inttoptr v34  : *mut i32
+    store v35, v32
+    v36 = const.i32 2  : i32
+    v37 = shl v9, v36  : i32
+    v38 = cast v4  : u32
+    v39 = add v38, 28  : u32
+    v40 = inttoptr v39  : *mut i32
+    store v40, v37
+    v41 = cast v0  : u32
+    v42 = inttoptr v41  : *mut i32
+    v43 = load v42  : i32
+    v44 = cast v4  : u32
+    v45 = add v44, 20  : u32
+    v46 = inttoptr v45  : *mut i32
+    store v46, v43
     br block2
 
 block5:
-    v94 = const.i32 32  : i32
-    v95 = add v54, v94  : i32
-    v96 = global.symbol @__stack_pointer  : *mut i32
-    store v96, v95
+    v87 = const.i32 32  : i32
+    v88 = add v51, v87  : i32
+    v89 = global.symbol @__stack_pointer  : *mut i32
+    store v89, v88
     br block1
 
 block6:
-    v78 = const.i32 -2147483647  : i32
-    v79 = eq v64, v78  : i1
-    v80 = cast v79  : i32
-    v81 = const.i32 0  : i32
-    v82 = neq v80, v81  : i1
-    condbr v82, block5, block8
+    v74 = const.i32 -2147483647  : i32
+    v75 = eq v61, v74  : i1
+    v76 = cast v75  : i32
+    v77 = neq v76, 0  : i1
+    condbr v77, block5, block8
 
 block7:
-    v73 = cast v0  : u32
-    v74 = add v73, 4  : u32
-    v75 = inttoptr v74  : *mut i32
-    store v75, v20
-    v76 = cast v71  : u32
-    v77 = inttoptr v76  : *mut i32
-    store v77, v64
+    v69 = cast v0  : u32
+    v70 = add v69, 4  : u32
+    v71 = inttoptr v70  : *mut i32
+    store v71, v19
+    v72 = cast v67  : u32
+    v73 = inttoptr v72  : *mut i32
+    store v73, v61
     br block5
 
 block8:
-    v83 = const.i32 0  : i32
-    v84 = eq v64, v83  : i1
-    v85 = cast v84  : i32
-    v86 = const.i32 0  : i32
-    v87 = neq v85, v86  : i1
-    condbr v87, block9, block10
+    v78 = eq v61, 0  : i1
+    v79 = cast v78  : i32
+    v80 = neq v79, 0  : i1
+    condbr v80, block9, block10
 
 block9:
     call noname::_ZN5alloc7raw_vec17capacity_overflow17h6c250c8ca346b5adE()
     unreachable 
 
 block10:
-    v88 = const.i32 16  : i32
-    v89 = add v54, v88  : i32
-    v90 = cast v89  : u32
-    v91 = inttoptr v90  : *mut i32
-    v92 = load v91  : i32
-    call noname::_ZN5alloc5alloc18handle_alloc_error17h4f3cb0c5afb21c76E(v64, v92)
+    v81 = const.i32 16  : i32
+    v82 = add v51, v81  : i32
+    v83 = cast v82  : u32
+    v84 = inttoptr v83  : *mut i32
+    v85 = load v84  : i32
+    call noname::_ZN5alloc5alloc18handle_alloc_error17h4f3cb0c5afb21c76E(v61, v85)
     unreachable 
 }
 
@@ -4863,9 +4610,8 @@ block0:
     v30 = const.i32 -1  : i32
     v31 = eq v23, v30  : i1
     v32 = cast v31  : i32
-    v33 = const.i32 0  : i32
-    v34 = neq v32, v33  : i1
-    condbr v34, block2, block3
+    v33 = neq v32, 0  : i1
+    condbr v33, block2, block3
 
 block1(v0: i32):
 
@@ -4873,30 +4619,28 @@ block2:
     unreachable 
 
 block3:
-    v35 = cast v4  : u32
-    v36 = add v35, 8  : u32
-    v37 = inttoptr v36  : *mut i32
-    v38 = load v37  : i32
-    v39 = const.i32 0  : i32
-    v40 = eq v38, v39  : i1
-    v41 = cast v40  : i32
-    v42 = const.i32 0  : i32
-    v43 = neq v41, v42  : i1
-    condbr v43, block4, block5
+    v34 = cast v4  : u32
+    v35 = add v34, 8  : u32
+    v36 = inttoptr v35  : *mut i32
+    v37 = load v36  : i32
+    v38 = eq v37, 0  : i1
+    v39 = cast v38  : i32
+    v40 = neq v39, 0  : i1
+    condbr v40, block4, block5
 
 block4:
-    v48 = const.i32 16  : i32
-    v49 = add v4, v48  : i32
-    v50 = global.symbol @__stack_pointer  : *mut i32
-    store v50, v49
-    v51 = const.i32 1  : i32
-    ret v51
+    v45 = const.i32 16  : i32
+    v46 = add v4, v45  : i32
+    v47 = global.symbol @__stack_pointer  : *mut i32
+    store v47, v46
+    v48 = const.i32 1  : i32
+    ret v48
 
 block5:
-    v44 = const.i32 2  : i32
-    v45 = shl v38, v44  : i32
-    v46 = const.i32 4  : i32
-    call noname::__rust_dealloc(v19, v45, v46)
+    v41 = const.i32 2  : i32
+    v42 = shl v37, v41  : i32
+    v43 = const.i32 4  : i32
+    call noname::__rust_dealloc(v19, v42, v43)
     br block4
 }
 
@@ -4981,10 +4725,9 @@ block0(v0: i32):
     v10 = const.i32 31  : i32
     v11 = eq v0, v10  : i1
     v12 = cast v11  : i32
-    v13 = const.i32 0  : i32
-    v14 = neq v12, v13  : i1
-    v15 = select v14, v2, v9  : i32
-    br block1(v15)
+    v13 = neq v12, 0  : i1
+    v14 = select v13, v2, v9  : i32
+    br block1(v14)
 
 block1(v1: i32):
     ret v1
@@ -5091,10 +4834,9 @@ block0(v0: i32):
     v6 = zext v5  : i32
     v7 = const.i32 3  : i32
     v8 = band v6, v7  : i32
-    v9 = const.i32 0  : i32
-    v10 = eq v8, v9  : i1
-    v11 = cast v10  : i32
-    br block1(v11)
+    v9 = eq v8, 0  : i1
+    v10 = cast v9  : i32
+    br block1(v10)
 
 block1(v1: i32):
     ret v1
@@ -5271,23 +5013,22 @@ block0(v0: i32):
     v4 = add v3, 16  : u32
     v5 = inttoptr v4  : *mut i32
     v6 = load v5  : i32
-    v7 = const.i32 0  : i32
-    v8 = neq v6, v7  : i1
-    condbr v8, block2(v6), block3
+    v7 = neq v6, 0  : i1
+    condbr v7, block2(v6), block3
 
 block1(v1: i32):
     ret v1
 
-block2(v14: i32):
-    br block1(v14)
+block2(v13: i32):
+    br block1(v13)
 
 block3:
-    v9 = const.i32 20  : i32
-    v10 = add v0, v9  : i32
-    v11 = cast v10  : u32
-    v12 = inttoptr v11  : *mut i32
-    v13 = load v12  : i32
-    br block2(v13)
+    v8 = const.i32 20  : i32
+    v9 = add v0, v8  : i32
+    v10 = cast v9  : u32
+    v11 = inttoptr v10  : *mut i32
+    v12 = load v11  : i32
+    br block2(v12)
 }
 
 pub fn _ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E(i32) -> i32 {
@@ -5364,27 +5105,26 @@ block0(v0: i32, v1: i32):
     v9 = cast v1  : u32
     v10 = gt v8, v9  : i1
     v11 = cast v10  : i32
-    v12 = const.i32 0  : i32
-    v13 = neq v11, v12  : i1
-    condbr v13, block2(v4), block3
+    v12 = neq v11, 0  : i1
+    condbr v12, block2(v4), block3
 
 block1(v2: i32):
     ret v2
 
-block2(v23: i32):
-    br block1(v23)
+block2(v22: i32):
+    br block1(v22)
 
 block3:
-    v14 = cast v0  : u32
-    v15 = add v14, 4  : u32
-    v16 = inttoptr v15  : *mut i32
-    v17 = load v16  : i32
-    v18 = add v7, v17  : i32
-    v19 = cast v18  : u32
-    v20 = cast v1  : u32
-    v21 = gt v19, v20  : i1
-    v22 = cast v21  : i32
-    br block2(v22)
+    v13 = cast v0  : u32
+    v14 = add v13, 4  : u32
+    v15 = inttoptr v14  : *mut i32
+    v16 = load v15  : i32
+    v17 = add v7, v16  : i32
+    v18 = cast v17  : u32
+    v19 = cast v1  : u32
+    v20 = gt v18, v19  : i1
+    v21 = cast v20  : i32
+    br block2(v21)
 }
 
 pub fn _ZN8dlmalloc8dlmalloc7Segment3top17he7e9e2493151d036E(i32) -> i32 {
@@ -5441,22 +5181,20 @@ block0(v0: i32, v1: i32, v2: i32):
     v18 = const.i32 -1  : i32
     v19 = eq v10, v18  : i1
     v20 = cast v19  : i32
-    v21 = const.i32 0  : i32
-    v22 = neq v20, v21  : i1
-    v23 = select v22, v15, v17  : i32
-    v24 = cast v0  : u32
-    v25 = add v24, 4  : u32
-    v26 = inttoptr v25  : *mut i32
-    store v26, v23
-    v27 = const.i32 0  : i32
-    v28 = const.i32 16  : i32
-    v29 = shl v10, v28  : i32
-    v30 = const.i32 0  : i32
-    v31 = neq v20, v30  : i1
-    v32 = select v31, v27, v29  : i32
-    v33 = cast v0  : u32
-    v34 = inttoptr v33  : *mut i32
-    store v34, v32
+    v21 = neq v20, 0  : i1
+    v22 = select v21, v15, v17  : i32
+    v23 = cast v0  : u32
+    v24 = add v23, 4  : u32
+    v25 = inttoptr v24  : *mut i32
+    store v25, v22
+    v26 = const.i32 0  : i32
+    v27 = const.i32 16  : i32
+    v28 = shl v10, v27  : i32
+    v29 = neq v20, 0  : i1
+    v30 = select v29, v26, v28  : i32
+    v31 = cast v0  : u32
+    v32 = inttoptr v31  : *mut i32
+    store v32, v30
     br block1
 
 block1:
@@ -5533,207 +5271,194 @@ block0(v0: i32, v1: i32, v2: i32):
     v7 = cast v5  : u32
     v8 = gt v6, v7  : i1
     v9 = cast v8  : i32
-    v10 = const.i32 0  : i32
-    v11 = neq v9, v10  : i1
-    condbr v11, block3, block4
+    v10 = neq v9, 0  : i1
+    condbr v10, block3, block4
 
 block1(v3: i32):
     ret v3
 
-block2(v143: i32, v149: i32, v172: i32, v174: i32):
-    v144 = const.i32 0  : i32
-    v145 = eq v143, v144  : i1
-    v146 = cast v145  : i32
-    v147 = const.i32 0  : i32
-    v148 = neq v146, v147  : i1
-    condbr v148, block21, block22
+block2(v133: i32, v137: i32, v159: i32, v161: i32):
+    v134 = eq v133, 0  : i1
+    v135 = cast v134  : i32
+    v136 = neq v135, 0  : i1
+    condbr v136, block21, block22
 
 block3:
-    v12 = const.i32 0  : i32
-    v13 = sub v12, v0  : i32
-    v14 = const.i32 3  : i32
-    v15 = band v13, v14  : i32
-    v16 = add v0, v15  : i32
-    v17 = const.i32 0  : i32
-    v18 = eq v15, v17  : i1
-    v19 = cast v18  : i32
-    v20 = const.i32 0  : i32
-    v21 = neq v19, v20  : i1
-    condbr v21, block5(v16), block6
+    v11 = const.i32 0  : i32
+    v12 = sub v11, v0  : i32
+    v13 = const.i32 3  : i32
+    v14 = band v12, v13  : i32
+    v15 = add v0, v14  : i32
+    v16 = eq v14, 0  : i1
+    v17 = cast v16  : i32
+    v18 = neq v17, 0  : i1
+    condbr v18, block5(v15), block6
 
 block4:
     br block2(v2, v0, v1, v0)
 
-block5(v42: i32):
-    v47 = sub v2, v15  : i32
-    v48 = const.i32 -4  : i32
-    v49 = band v47, v48  : i32
-    v50 = add v42, v49  : i32
-    v53 = add v1, v45  : i32
-    v54 = const.i32 3  : i32
-    v55 = band v53, v54  : i32
-    v56 = const.i32 0  : i32
-    v57 = eq v55, v56  : i1
-    v58 = cast v57  : i32
-    v59 = const.i32 0  : i32
-    v60 = neq v58, v59  : i1
-    condbr v60, block11, block12
+block5(v38: i32):
+    v43 = sub v2, v14  : i32
+    v44 = const.i32 -4  : i32
+    v45 = band v43, v44  : i32
+    v46 = add v38, v45  : i32
+    v49 = add v1, v41  : i32
+    v50 = const.i32 3  : i32
+    v51 = band v49, v50  : i32
+    v52 = eq v51, 0  : i1
+    v53 = cast v52  : i32
+    v54 = neq v53, 0  : i1
+    condbr v54, block11, block12
 
 block6:
     br block7(v0, v1)
 
-block7(v22: i32, v23: i32):
-    v24 = cast v23  : u32
-    v25 = inttoptr v24  : *mut u8
-    v26 = load v25  : u8
-    v27 = zext v26  : i32
-    v28 = trunc v27  : u8
-    v29 = cast v22  : u32
-    v30 = inttoptr v29  : *mut u8
-    store v30, v28
-    v31 = const.i32 1  : i32
-    v32 = add v23, v31  : i32
-    v33 = const.i32 1  : i32
-    v34 = add v22, v33  : i32
-    v36 = cast v34  : u32
-    v37 = cast v35  : u32
-    v38 = lt v36, v37  : i1
-    v39 = cast v38  : i32
-    v40 = const.i32 0  : i32
-    v41 = neq v39, v40  : i1
-    condbr v41, block7(v34, v32), block9
+block7(v19: i32, v20: i32):
+    v21 = cast v20  : u32
+    v22 = inttoptr v21  : *mut u8
+    v23 = load v22  : u8
+    v24 = zext v23  : i32
+    v25 = trunc v24  : u8
+    v26 = cast v19  : u32
+    v27 = inttoptr v26  : *mut u8
+    store v27, v25
+    v28 = const.i32 1  : i32
+    v29 = add v20, v28  : i32
+    v30 = const.i32 1  : i32
+    v31 = add v19, v30  : i32
+    v33 = cast v31  : u32
+    v34 = cast v32  : u32
+    v35 = lt v33, v34  : i1
+    v36 = cast v35  : i32
+    v37 = neq v36, 0  : i1
+    condbr v37, block7(v31, v29), block9
 
 block8:
-    br block5(v35)
+    br block5(v32)
 
 block9:
     br block8
 
-block10(v150: i32, v175: i32):
-    v134 = const.i32 3  : i32
-    v135 = band v47, v134  : i32
-    v142 = add v53, v49  : i32
-    br block2(v135, v150, v142, v175)
+block10(v138: i32, v162: i32):
+    v124 = const.i32 3  : i32
+    v125 = band v43, v124  : i32
+    v132 = add v49, v45  : i32
+    br block2(v125, v138, v132, v162)
 
 block11:
-    v108 = const.i32 1  : i32
-    v109 = lt v49, v108  : i1
-    v110 = cast v109  : i32
-    v111 = const.i32 0  : i32
-    v112 = neq v110, v111  : i1
-    condbr v112, block10(v50, v176), block17
+    v100 = const.i32 1  : i32
+    v101 = lt v45, v100  : i1
+    v102 = cast v101  : i32
+    v103 = neq v102, 0  : i1
+    condbr v103, block10(v46, v163), block17
 
 block12:
-    v61 = const.i32 1  : i32
-    v62 = lt v49, v61  : i1
-    v63 = cast v62  : i32
-    v64 = const.i32 0  : i32
-    v65 = neq v63, v64  : i1
-    condbr v65, block10(v50, v0), block13
+    v55 = const.i32 1  : i32
+    v56 = lt v45, v55  : i1
+    v57 = cast v56  : i32
+    v58 = neq v57, 0  : i1
+    condbr v58, block10(v46, v0), block13
 
 block13:
-    v66 = const.i32 3  : i32
-    v67 = shl v53, v66  : i32
-    v68 = const.i32 24  : i32
-    v69 = band v67, v68  : i32
-    v70 = const.i32 -4  : i32
-    v71 = band v53, v70  : i32
-    v72 = const.i32 4  : i32
-    v73 = add v71, v72  : i32
-    v74 = const.i32 0  : i32
-    v75 = sub v74, v67  : i32
-    v76 = const.i32 24  : i32
-    v77 = band v75, v76  : i32
-    v78 = cast v71  : u32
-    v79 = inttoptr v78  : *mut i32
-    v80 = load v79  : i32
-    br block14(v42, v80, v73)
+    v59 = const.i32 3  : i32
+    v60 = shl v49, v59  : i32
+    v61 = const.i32 24  : i32
+    v62 = band v60, v61  : i32
+    v63 = const.i32 -4  : i32
+    v64 = band v49, v63  : i32
+    v65 = const.i32 4  : i32
+    v66 = add v64, v65  : i32
+    v67 = const.i32 0  : i32
+    v68 = sub v67, v60  : i32
+    v69 = const.i32 24  : i32
+    v70 = band v68, v69  : i32
+    v71 = cast v64  : u32
+    v72 = inttoptr v71  : *mut i32
+    v73 = load v72  : i32
+    br block14(v38, v73, v66)
 
-block14(v81: i32, v82: i32, v88: i32):
-    v84 = cast v82  : u32
-    v85 = cast v83  : u32
-    v86 = shr v84, v85  : u32
-    v87 = cast v86  : i32
-    v89 = cast v88  : u32
-    v90 = inttoptr v89  : *mut i32
-    v91 = load v90  : i32
-    v93 = shl v91, v92  : i32
-    v94 = bor v87, v93  : i32
-    v95 = cast v81  : u32
-    v96 = inttoptr v95  : *mut i32
-    store v96, v94
-    v97 = const.i32 4  : i32
-    v98 = add v88, v97  : i32
-    v99 = const.i32 4  : i32
-    v100 = add v81, v99  : i32
-    v102 = cast v100  : u32
-    v103 = cast v101  : u32
-    v104 = lt v102, v103  : i1
-    v105 = cast v104  : i32
-    v106 = const.i32 0  : i32
-    v107 = neq v105, v106  : i1
-    condbr v107, block14(v100, v91, v98), block16
+block14(v74: i32, v75: i32, v81: i32):
+    v77 = cast v75  : u32
+    v78 = cast v76  : u32
+    v79 = shr v77, v78  : u32
+    v80 = cast v79  : i32
+    v82 = cast v81  : u32
+    v83 = inttoptr v82  : *mut i32
+    v84 = load v83  : i32
+    v86 = shl v84, v85  : i32
+    v87 = bor v80, v86  : i32
+    v88 = cast v74  : u32
+    v89 = inttoptr v88  : *mut i32
+    store v89, v87
+    v90 = const.i32 4  : i32
+    v91 = add v81, v90  : i32
+    v92 = const.i32 4  : i32
+    v93 = add v74, v92  : i32
+    v95 = cast v93  : u32
+    v96 = cast v94  : u32
+    v97 = lt v95, v96  : i1
+    v98 = cast v97  : i32
+    v99 = neq v98, 0  : i1
+    condbr v99, block14(v93, v84, v91), block16
 
 block15:
 
 block16:
-    br block10(v101, v176)
+    br block10(v94, v163)
 
 block17:
-    br block18(v42, v53)
+    br block18(v38, v49)
 
-block18(v113: i32, v114: i32):
-    v115 = cast v114  : u32
-    v116 = inttoptr v115  : *mut i32
-    v117 = load v116  : i32
-    v118 = cast v113  : u32
-    v119 = inttoptr v118  : *mut i32
-    store v119, v117
-    v120 = const.i32 4  : i32
-    v121 = add v114, v120  : i32
-    v122 = const.i32 4  : i32
-    v123 = add v113, v122  : i32
-    v125 = cast v123  : u32
-    v126 = cast v124  : u32
-    v127 = lt v125, v126  : i1
-    v128 = cast v127  : i32
-    v129 = const.i32 0  : i32
-    v130 = neq v128, v129  : i1
-    condbr v130, block18(v123, v121), block20
+block18(v104: i32, v105: i32):
+    v106 = cast v105  : u32
+    v107 = inttoptr v106  : *mut i32
+    v108 = load v107  : i32
+    v109 = cast v104  : u32
+    v110 = inttoptr v109  : *mut i32
+    store v110, v108
+    v111 = const.i32 4  : i32
+    v112 = add v105, v111  : i32
+    v113 = const.i32 4  : i32
+    v114 = add v104, v113  : i32
+    v116 = cast v114  : u32
+    v117 = cast v115  : u32
+    v118 = lt v116, v117  : i1
+    v119 = cast v118  : i32
+    v120 = neq v119, 0  : i1
+    condbr v120, block18(v114, v112), block20
 
 block19:
-    br block10(v124, v176)
+    br block10(v115, v163)
 
 block20:
     br block19
 
 block21:
-    br block1(v174)
+    br block1(v161)
 
 block22:
-    v151 = add v149, v143  : i32
-    br block23(v149, v172)
+    v139 = add v137, v133  : i32
+    br block23(v137, v159)
 
-block23(v152: i32, v153: i32):
-    v154 = cast v153  : u32
-    v155 = inttoptr v154  : *mut u8
-    v156 = load v155  : u8
-    v157 = zext v156  : i32
-    v158 = trunc v157  : u8
-    v159 = cast v152  : u32
-    v160 = inttoptr v159  : *mut u8
-    store v160, v158
-    v161 = const.i32 1  : i32
-    v162 = add v153, v161  : i32
-    v163 = const.i32 1  : i32
-    v164 = add v152, v163  : i32
-    v166 = cast v164  : u32
-    v167 = cast v165  : u32
-    v168 = lt v166, v167  : i1
-    v169 = cast v168  : i32
-    v170 = const.i32 0  : i32
-    v171 = neq v169, v170  : i1
-    condbr v171, block23(v164, v162), block25
+block23(v140: i32, v141: i32):
+    v142 = cast v141  : u32
+    v143 = inttoptr v142  : *mut u8
+    v144 = load v143  : u8
+    v145 = zext v144  : i32
+    v146 = trunc v145  : u8
+    v147 = cast v140  : u32
+    v148 = inttoptr v147  : *mut u8
+    store v148, v146
+    v149 = const.i32 1  : i32
+    v150 = add v141, v149  : i32
+    v151 = const.i32 1  : i32
+    v152 = add v140, v151  : i32
+    v154 = cast v152  : u32
+    v155 = cast v153  : u32
+    v156 = lt v154, v155  : i1
+    v157 = cast v156  : i32
+    v158 = neq v157, 0  : i1
+    condbr v158, block23(v152, v150), block25
 
 block24:
     br block21

--- a/frontend-wasm/tests/expected/dlmalloc.wat
+++ b/frontend-wasm/tests/expected/dlmalloc.wat
@@ -10,24 +10,24 @@
   (type (;8;) (func (param i32)))
   (type (;9;) (func))
   (type (;10;) (func (param i32 i32 i32 i32 i32) (result i32)))
-  (func $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$13dispose_chunk17h577eb103dc04307bE (;0;) (type 0) (param i32 i32 i32)
+  (func $dlmalloc::dlmalloc::Dlmalloc<A>::dispose_chunk (;0;) (type 0) (param i32 i32 i32)
     (local i32 i32 i32 i32)
     local.get 1
     local.get 2
-    call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+    call $dlmalloc::dlmalloc::Chunk::plus_offset
     local.set 3
     block ;; label = @1
       block ;; label = @2
         block ;; label = @3
           local.get 1
-          call $_ZN8dlmalloc8dlmalloc5Chunk6pinuse17h92d5107047b03ba7E
+          call $dlmalloc::dlmalloc::Chunk::pinuse
           br_if 0 (;@3;)
           local.get 1
           i32.load
           local.set 4
           block ;; label = @4
             local.get 1
-            call $_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E
+            call $dlmalloc::dlmalloc::Chunk::mmapped
             br_if 0 (;@4;)
             local.get 4
             local.get 2
@@ -36,7 +36,7 @@
             block ;; label = @5
               local.get 1
               local.get 4
-              call $_ZN8dlmalloc8dlmalloc5Chunk12minus_offset17h7c3eec81761249d9E
+              call $dlmalloc::dlmalloc::Chunk::minus_offset
               local.tee 1
               local.get 0
               i32.load offset=424
@@ -55,7 +55,7 @@
               local.get 1
               local.get 2
               local.get 3
-              call $_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E
+              call $dlmalloc::dlmalloc::Chunk::set_free_with_pinuse
               return
             end
             block ;; label = @5
@@ -65,7 +65,7 @@
               br_if 0 (;@5;)
               local.get 0
               local.get 1
-              call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E
+              call $dlmalloc::dlmalloc::Dlmalloc<A>::unlink_large_chunk
               br 2 (;@3;)
             end
             block ;; label = @5
@@ -107,7 +107,7 @@
           i32.const 16
           i32.add
           local.tee 1
-          call $_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$4free17h993c5f05ba1214bcE
+          call $<dlmalloc::sys::System as dlmalloc::Allocator>::free
           i32.eqz
           br_if 1 (;@2;)
           local.get 0
@@ -120,13 +120,13 @@
         end
         block ;; label = @3
           local.get 3
-          call $_ZN8dlmalloc8dlmalloc5Chunk6cinuse17h58499de57c2d37e2E
+          call $dlmalloc::dlmalloc::Chunk::cinuse
           i32.eqz
           br_if 0 (;@3;)
           local.get 1
           local.get 2
           local.get 3
-          call $_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E
+          call $dlmalloc::dlmalloc::Chunk::set_free_with_pinuse
           br 2 (;@1;)
         end
         block ;; label = @3
@@ -142,7 +142,7 @@
             i32.eq
             br_if 1 (;@3;)
             local.get 3
-            call $_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E
+            call $dlmalloc::dlmalloc::Chunk::size
             local.tee 4
             local.get 2
             i32.add
@@ -155,7 +155,7 @@
                 br_if 0 (;@6;)
                 local.get 0
                 local.get 3
-                call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E
+                call $dlmalloc::dlmalloc::Dlmalloc<A>::unlink_large_chunk
                 br 1 (;@5;)
               end
               block ;; label = @6
@@ -188,7 +188,7 @@
             end
             local.get 1
             local.get 2
-            call $_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E
+            call $dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_free_chunk
             local.get 1
             local.get 0
             i32.load offset=424
@@ -239,7 +239,7 @@
         i32.store offset=416
         local.get 1
         local.get 2
-        call $_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E
+        call $dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_free_chunk
         return
       end
       return
@@ -252,7 +252,7 @@
       local.get 0
       local.get 1
       local.get 2
-      call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E
+      call $dlmalloc::dlmalloc::Dlmalloc<A>::insert_large_chunk
       return
     end
     local.get 0
@@ -303,7 +303,7 @@
     local.get 2
     i32.store offset=8
   )
-  (func $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E (;1;) (type 1) (param i32 i32)
+  (func $dlmalloc::dlmalloc::Dlmalloc<A>::unlink_large_chunk (;1;) (type 1) (param i32 i32)
     (local i32 i32 i32 i32 i32)
     local.get 1
     i32.load offset=24
@@ -312,7 +312,7 @@
       block ;; label = @2
         block ;; label = @3
           local.get 1
-          call $_ZN8dlmalloc8dlmalloc9TreeChunk4next17he250edbec5d87123E
+          call $dlmalloc::dlmalloc::TreeChunk::next
           local.get 1
           i32.ne
           br_if 0 (;@3;)
@@ -335,16 +335,16 @@
           br 2 (;@1;)
         end
         local.get 1
-        call $_ZN8dlmalloc8dlmalloc9TreeChunk4prev17h7a0f1d46544cc14aE
+        call $dlmalloc::dlmalloc::TreeChunk::prev
         local.tee 5
         local.get 1
-        call $_ZN8dlmalloc8dlmalloc9TreeChunk4next17he250edbec5d87123E
+        call $dlmalloc::dlmalloc::TreeChunk::next
         local.tee 3
-        call $_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E
+        call $dlmalloc::dlmalloc::TreeChunk::chunk
         i32.store offset=12
         local.get 3
         local.get 5
-        call $_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E
+        call $dlmalloc::dlmalloc::TreeChunk::chunk
         i32.store offset=8
         br 1 (;@1;)
       end
@@ -467,7 +467,7 @@
       return
     end
   )
-  (func $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E (;2;) (type 0) (param i32 i32 i32)
+  (func $dlmalloc::dlmalloc::Dlmalloc<A>::insert_large_chunk (;2;) (type 0) (param i32 i32 i32)
     (local i32 i32 i32 i32 i32)
     i32.const 0
     local.set 3
@@ -514,7 +514,7 @@
     i32.add
     local.set 4
     local.get 1
-    call $_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E
+    call $dlmalloc::dlmalloc::TreeChunk::chunk
     local.set 5
     block ;; label = @1
       block ;; label = @2
@@ -533,20 +533,20 @@
         local.set 0
         local.get 2
         local.get 3
-        call $_ZN8dlmalloc8dlmalloc24leftshift_for_tree_index17h31d064fdd867f502E
+        call $dlmalloc::dlmalloc::leftshift_for_tree_index
         i32.shl
         local.set 3
         loop ;; label = @3
           block ;; label = @4
             local.get 0
             local.tee 4
-            call $_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E
-            call $_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E
+            call $dlmalloc::dlmalloc::TreeChunk::chunk
+            call $dlmalloc::dlmalloc::Chunk::size
             local.get 2
             i32.ne
             br_if 0 (;@4;)
             local.get 4
-            call $_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E
+            call $dlmalloc::dlmalloc::TreeChunk::chunk
             local.tee 3
             i32.load offset=8
             local.tee 0
@@ -613,7 +613,7 @@
     local.get 5
     i32.store offset=12
   )
-  (func $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$23release_unused_segments17h25622465f0742468E (;3;) (type 2) (param i32) (result i32)
+  (func $dlmalloc::dlmalloc::Dlmalloc<A>::release_unused_segments (;3;) (type 2) (param i32) (result i32)
     (local i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32)
     block ;; label = @1
       block ;; label = @2
@@ -655,39 +655,39 @@
             i32.load offset=12
             i32.const 1
             i32.shr_u
-            call $_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$16can_release_part17h43bfb7d8666fcc31E
+            call $<dlmalloc::sys::System as dlmalloc::Allocator>::can_release_part
             i32.eqz
             br_if 0 (;@4;)
             local.get 5
-            call $_ZN8dlmalloc8dlmalloc7Segment9is_extern17h6f6db2c70b891fd9E
+            call $dlmalloc::dlmalloc::Segment::is_extern
             br_if 0 (;@4;)
             local.get 7
             local.get 7
-            call $_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE
+            call $dlmalloc::dlmalloc::Chunk::to_mem
             local.tee 8
             i32.const 8
-            call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+            call $dlmalloc::dlmalloc::align_up
             local.get 8
             i32.sub
             i32.add
             local.tee 8
-            call $_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E
+            call $dlmalloc::dlmalloc::Chunk::size
             local.set 9
-            call $_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E
+            call $dlmalloc::dlmalloc::Chunk::mem_offset
             local.tee 10
             i32.const 8
-            call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+            call $dlmalloc::dlmalloc::align_up
             local.set 11
             i32.const 20
             i32.const 8
-            call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+            call $dlmalloc::dlmalloc::align_up
             local.set 12
             i32.const 16
             i32.const 8
-            call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+            call $dlmalloc::dlmalloc::align_up
             local.set 13
             local.get 8
-            call $_ZN8dlmalloc8dlmalloc5Chunk5inuse17h2d327e4c36b84dfeE
+            call $dlmalloc::dlmalloc::Chunk::inuse
             br_if 0 (;@4;)
             local.get 8
             local.get 9
@@ -714,7 +714,7 @@
                 br_if 0 (;@6;)
                 local.get 0
                 local.get 8
-                call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E
+                call $dlmalloc::dlmalloc::Dlmalloc<A>::unlink_large_chunk
                 br 1 (;@5;)
               end
               local.get 0
@@ -728,12 +728,12 @@
               local.get 0
               local.get 7
               local.get 6
-              call $_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$4free17h993c5f05ba1214bcE
+              call $<dlmalloc::sys::System as dlmalloc::Allocator>::free
               br_if 0 (;@5;)
               local.get 0
               local.get 8
               local.get 9
-              call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E
+              call $dlmalloc::dlmalloc::Dlmalloc<A>::insert_large_chunk
               br 1 (;@4;)
             end
             local.get 0
@@ -772,28 +772,28 @@
     i32.store offset=448
     local.get 3
   )
-  (func $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$4free17h501de2a6604ba1ffE (;4;) (type 1) (param i32 i32)
+  (func $dlmalloc::dlmalloc::Dlmalloc<A>::free (;4;) (type 1) (param i32 i32)
     (local i32 i32 i32 i32 i32 i32)
     local.get 1
-    call $_ZN8dlmalloc8dlmalloc5Chunk8from_mem17h11dd30c74f483706E
+    call $dlmalloc::dlmalloc::Chunk::from_mem
     local.set 1
     local.get 1
     local.get 1
-    call $_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E
+    call $dlmalloc::dlmalloc::Chunk::size
     local.tee 2
-    call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+    call $dlmalloc::dlmalloc::Chunk::plus_offset
     local.set 3
     block ;; label = @1
       block ;; label = @2
         local.get 1
-        call $_ZN8dlmalloc8dlmalloc5Chunk6pinuse17h92d5107047b03ba7E
+        call $dlmalloc::dlmalloc::Chunk::pinuse
         br_if 0 (;@2;)
         local.get 1
         i32.load
         local.set 4
         block ;; label = @3
           local.get 1
-          call $_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E
+          call $dlmalloc::dlmalloc::Chunk::mmapped
           br_if 0 (;@3;)
           local.get 4
           local.get 2
@@ -802,7 +802,7 @@
           block ;; label = @4
             local.get 1
             local.get 4
-            call $_ZN8dlmalloc8dlmalloc5Chunk12minus_offset17h7c3eec81761249d9E
+            call $dlmalloc::dlmalloc::Chunk::minus_offset
             local.tee 1
             local.get 0
             i32.load offset=424
@@ -821,7 +821,7 @@
             local.get 1
             local.get 2
             local.get 3
-            call $_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E
+            call $dlmalloc::dlmalloc::Chunk::set_free_with_pinuse
             return
           end
           block ;; label = @4
@@ -831,7 +831,7 @@
             br_if 0 (;@4;)
             local.get 0
             local.get 1
-            call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E
+            call $dlmalloc::dlmalloc::Dlmalloc<A>::unlink_large_chunk
             br 2 (;@2;)
           end
           block ;; label = @4
@@ -873,7 +873,7 @@
         i32.const 16
         i32.add
         local.tee 1
-        call $_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$4free17h993c5f05ba1214bcE
+        call $<dlmalloc::sys::System as dlmalloc::Allocator>::free
         i32.eqz
         br_if 1 (;@1;)
         local.get 0
@@ -887,13 +887,13 @@
       block ;; label = @2
         block ;; label = @3
           local.get 3
-          call $_ZN8dlmalloc8dlmalloc5Chunk6cinuse17h58499de57c2d37e2E
+          call $dlmalloc::dlmalloc::Chunk::cinuse
           i32.eqz
           br_if 0 (;@3;)
           local.get 1
           local.get 2
           local.get 3
-          call $_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E
+          call $dlmalloc::dlmalloc::Chunk::set_free_with_pinuse
           br 1 (;@2;)
         end
         block ;; label = @3
@@ -911,7 +911,7 @@
                 i32.eq
                 br_if 1 (;@5;)
                 local.get 3
-                call $_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E
+                call $dlmalloc::dlmalloc::Chunk::size
                 local.tee 4
                 local.get 2
                 i32.add
@@ -924,7 +924,7 @@
                     br_if 0 (;@8;)
                     local.get 0
                     local.get 3
-                    call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E
+                    call $dlmalloc::dlmalloc::Dlmalloc<A>::unlink_large_chunk
                     br 1 (;@7;)
                   end
                   block ;; label = @8
@@ -957,7 +957,7 @@
                 end
                 local.get 1
                 local.get 2
-                call $_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E
+                call $dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_free_chunk
                 local.get 1
                 local.get 0
                 i32.load offset=424
@@ -1002,7 +1002,7 @@
             i32.store offset=416
             local.get 1
             local.get 2
-            call $_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E
+            call $dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_free_chunk
             return
           end
           local.get 0
@@ -1017,23 +1017,23 @@
         i32.load offset=440
         i32.le_u
         br_if 1 (;@1;)
-        call $_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E
+        call $dlmalloc::dlmalloc::Chunk::mem_offset
         local.tee 1
         i32.const 8
-        call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+        call $dlmalloc::dlmalloc::align_up
         local.set 2
         i32.const 20
         i32.const 8
-        call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+        call $dlmalloc::dlmalloc::align_up
         local.set 3
         i32.const 16
         i32.const 8
-        call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+        call $dlmalloc::dlmalloc::align_up
         local.set 4
         i32.const 0
         i32.const 16
         i32.const 8
-        call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+        call $dlmalloc::dlmalloc::align_up
         i32.const 2
         i32.shl
         i32.sub
@@ -1063,18 +1063,18 @@
         local.tee 2
         i32.eqz
         br_if 1 (;@1;)
-        call $_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E
+        call $dlmalloc::dlmalloc::Chunk::mem_offset
         local.tee 1
         i32.const 8
-        call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+        call $dlmalloc::dlmalloc::align_up
         local.set 3
         i32.const 20
         i32.const 8
-        call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+        call $dlmalloc::dlmalloc::align_up
         local.set 5
         i32.const 16
         i32.const 8
-        call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+        call $dlmalloc::dlmalloc::align_up
         local.set 6
         i32.const 0
         local.set 4
@@ -1117,7 +1117,7 @@
                 i32.gt_u
                 br_if 0 (;@6;)
                 local.get 1
-                call $_ZN8dlmalloc8dlmalloc7Segment3top17he7e9e2493151d036E
+                call $dlmalloc::dlmalloc::Segment::top
                 local.get 2
                 i32.gt_u
                 br_if 2 (;@4;)
@@ -1133,7 +1133,7 @@
           i32.const 0
           local.set 4
           local.get 1
-          call $_ZN8dlmalloc8dlmalloc7Segment9is_extern17h6f6db2c70b891fd9E
+          call $dlmalloc::dlmalloc::Segment::is_extern
           br_if 0 (;@3;)
           i32.const 0
           local.set 4
@@ -1142,7 +1142,7 @@
           i32.load offset=12
           i32.const 1
           i32.shr_u
-          call $_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$16can_release_part17h43bfb7d8666fcc31E
+          call $<dlmalloc::sys::System as dlmalloc::Allocator>::can_release_part
           i32.eqz
           br_if 0 (;@3;)
           i32.const 0
@@ -1156,7 +1156,7 @@
             block ;; label = @5
               local.get 1
               local.get 3
-              call $_ZN8dlmalloc8dlmalloc7Segment5holds17h8f6de4ee6718009bE
+              call $dlmalloc::dlmalloc::Segment::holds
               i32.eqz
               br_if 0 (;@5;)
               i32.const 0
@@ -1177,7 +1177,7 @@
           local.get 2
           local.get 5
           i32.sub
-          call $_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$9free_part17h74489c9e7a3aa967E
+          call $<dlmalloc::sys::System as dlmalloc::Allocator>::free_part
           local.set 2
           i32.const 0
           local.set 4
@@ -1210,14 +1210,14 @@
           local.get 0
           local.get 1
           local.get 1
-          call $_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE
+          call $dlmalloc::dlmalloc::Chunk::to_mem
           local.tee 3
           i32.const 8
-          call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+          call $dlmalloc::dlmalloc::align_up
           local.get 3
           i32.sub
           local.tee 3
-          call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+          call $dlmalloc::dlmalloc::Chunk::plus_offset
           local.tee 1
           i32.store offset=428
           local.get 0
@@ -1235,22 +1235,22 @@
           i32.const 1
           i32.or
           i32.store offset=4
-          call $_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E
+          call $dlmalloc::dlmalloc::Chunk::mem_offset
           local.tee 3
           i32.const 8
-          call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+          call $dlmalloc::dlmalloc::align_up
           local.set 4
           i32.const 20
           i32.const 8
-          call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+          call $dlmalloc::dlmalloc::align_up
           local.set 6
           i32.const 16
           i32.const 8
-          call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+          call $dlmalloc::dlmalloc::align_up
           local.set 7
           local.get 1
           local.get 2
-          call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+          call $dlmalloc::dlmalloc::Chunk::plus_offset
           local.set 1
           local.get 0
           i32.const 2097152
@@ -1268,7 +1268,7 @@
           local.set 4
         end
         local.get 0
-        call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$23release_unused_segments17h25622465f0742468E
+        call $dlmalloc::dlmalloc::Dlmalloc<A>::release_unused_segments
         i32.const 0
         local.get 4
         i32.sub
@@ -1293,7 +1293,7 @@
         local.get 0
         local.get 1
         local.get 2
-        call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E
+        call $dlmalloc::dlmalloc::Dlmalloc<A>::insert_large_chunk
         local.get 0
         local.get 0
         i32.load offset=448
@@ -1304,7 +1304,7 @@
         local.get 1
         br_if 1 (;@1;)
         local.get 0
-        call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$23release_unused_segments17h25622465f0742468E
+        call $dlmalloc::dlmalloc::Dlmalloc<A>::release_unused_segments
         drop
         return
       end
@@ -1357,7 +1357,7 @@
       i32.store offset=8
     end
   )
-  (func $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$6malloc17h1ae2390053e3628cE (;5;) (type 3) (param i32 i32) (result i32)
+  (func $dlmalloc::dlmalloc::Dlmalloc<A>::malloc (;5;) (type 3) (param i32 i32) (result i32)
     (local i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i64)
     global.get $__stack_pointer
     i32.const 16
@@ -1374,25 +1374,25 @@
                 i32.const 245
                 i32.lt_u
                 br_if 0 (;@6;)
-                call $_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E
+                call $dlmalloc::dlmalloc::Chunk::mem_offset
                 local.tee 3
                 i32.const 8
-                call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                call $dlmalloc::dlmalloc::align_up
                 local.set 4
                 i32.const 20
                 i32.const 8
-                call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                call $dlmalloc::dlmalloc::align_up
                 local.set 5
                 i32.const 16
                 i32.const 8
-                call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                call $dlmalloc::dlmalloc::align_up
                 local.set 6
                 i32.const 0
                 local.set 7
                 i32.const 0
                 i32.const 16
                 i32.const 8
-                call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                call $dlmalloc::dlmalloc::align_up
                 i32.const 2
                 i32.shl
                 i32.sub
@@ -1422,7 +1422,7 @@
                 i32.const 4
                 i32.add
                 i32.const 8
-                call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                call $dlmalloc::dlmalloc::align_up
                 local.set 3
                 local.get 0
                 i32.load offset=412
@@ -1482,7 +1482,7 @@
                 end
                 local.get 3
                 local.get 10
-                call $_ZN8dlmalloc8dlmalloc24leftshift_for_tree_index17h31d064fdd867f502E
+                call $dlmalloc::dlmalloc::leftshift_for_tree_index
                 i32.shl
                 local.set 6
                 i32.const 0
@@ -1492,8 +1492,8 @@
                 loop ;; label = @7
                   block ;; label = @8
                     local.get 7
-                    call $_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E
-                    call $_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E
+                    call $dlmalloc::dlmalloc::TreeChunk::chunk
+                    call $dlmalloc::dlmalloc::Chunk::size
                     local.tee 8
                     local.get 3
                     i32.lt_u
@@ -1559,14 +1559,14 @@
               i32.add
               i32.const 16
               i32.const 8
-              call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+              call $dlmalloc::dlmalloc::align_up
               i32.const -5
               i32.add
               local.get 1
               i32.gt_u
               select
               i32.const 8
-              call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+              call $dlmalloc::dlmalloc::align_up
               local.set 3
               block ;; label = @6
                 local.get 0
@@ -1629,9 +1629,9 @@
                 local.get 3
                 i32.const 3
                 i32.shl
-                call $_ZN8dlmalloc8dlmalloc5Chunk20set_inuse_and_pinuse17h515e5a69a6d1edc6E
+                call $dlmalloc::dlmalloc::Chunk::set_inuse_and_pinuse
                 local.get 1
-                call $_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE
+                call $dlmalloc::dlmalloc::Chunk::to_mem
                 local.set 7
                 br 5 (;@1;)
               end
@@ -1656,28 +1656,28 @@
                             br_if 10 (;@2;)
                             local.get 0
                             local.get 1
-                            call $_ZN8dlmalloc8dlmalloc9least_bit17h4bca52ead665dc5aE
+                            call $dlmalloc::dlmalloc::least_bit
                             i32.ctz
                             i32.const 2
                             i32.shl
                             i32.add
                             i32.load
                             local.tee 7
-                            call $_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E
-                            call $_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E
+                            call $dlmalloc::dlmalloc::TreeChunk::chunk
+                            call $dlmalloc::dlmalloc::Chunk::size
                             local.get 3
                             i32.sub
                             local.set 4
                             block ;; label = @13
                               local.get 7
-                              call $_ZN8dlmalloc8dlmalloc9TreeChunk14leftmost_child17h20605933c801b44bE
+                              call $dlmalloc::dlmalloc::TreeChunk::leftmost_child
                               local.tee 1
                               i32.eqz
                               br_if 0 (;@13;)
                               loop ;; label = @14
                                 local.get 1
-                                call $_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E
-                                call $_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E
+                                call $dlmalloc::dlmalloc::TreeChunk::chunk
+                                call $dlmalloc::dlmalloc::Chunk::size
                                 local.get 3
                                 i32.sub
                                 local.tee 5
@@ -1694,35 +1694,35 @@
                                 select
                                 local.set 7
                                 local.get 1
-                                call $_ZN8dlmalloc8dlmalloc9TreeChunk14leftmost_child17h20605933c801b44bE
+                                call $dlmalloc::dlmalloc::TreeChunk::leftmost_child
                                 local.tee 1
                                 br_if 0 (;@14;)
                               end
                             end
                             local.get 7
-                            call $_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E
+                            call $dlmalloc::dlmalloc::TreeChunk::chunk
                             local.tee 1
                             local.get 3
-                            call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+                            call $dlmalloc::dlmalloc::Chunk::plus_offset
                             local.set 5
                             local.get 0
                             local.get 7
-                            call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E
+                            call $dlmalloc::dlmalloc::Dlmalloc<A>::unlink_large_chunk
                             local.get 4
                             i32.const 16
                             i32.const 8
-                            call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                            call $dlmalloc::dlmalloc::align_up
                             i32.lt_u
                             br_if 2 (;@10;)
                             local.get 5
-                            call $_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E
+                            call $dlmalloc::dlmalloc::TreeChunk::chunk
                             local.set 5
                             local.get 1
                             local.get 3
-                            call $_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E
+                            call $dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_inuse_chunk
                             local.get 5
                             local.get 4
-                            call $_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E
+                            call $dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_free_chunk
                             local.get 0
                             i32.load offset=416
                             local.tee 8
@@ -1741,12 +1741,12 @@
                               i32.and
                               local.tee 4
                               i32.shl
-                              call $_ZN8dlmalloc8dlmalloc9left_bits17hb6cbe146b8019d98E
+                              call $dlmalloc::dlmalloc::left_bits
                               local.get 1
                               local.get 4
                               i32.shl
                               i32.and
-                              call $_ZN8dlmalloc8dlmalloc9least_bit17h4bca52ead665dc5aE
+                              call $dlmalloc::dlmalloc::least_bit
                               i32.ctz
                               local.tee 7
                               i32.const 3
@@ -1779,10 +1779,10 @@
                           end
                           local.get 1
                           local.get 3
-                          call $_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E
+                          call $dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_inuse_chunk
                           local.get 1
                           local.get 3
-                          call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+                          call $dlmalloc::dlmalloc::Chunk::plus_offset
                           local.tee 5
                           local.get 7
                           i32.const 3
@@ -1790,7 +1790,7 @@
                           local.get 3
                           i32.sub
                           local.tee 6
-                          call $_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E
+                          call $dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_free_chunk
                           local.get 0
                           i32.load offset=416
                           local.tee 7
@@ -1853,7 +1853,7 @@
                       local.get 4
                       local.get 3
                       i32.add
-                      call $_ZN8dlmalloc8dlmalloc5Chunk20set_inuse_and_pinuse17h515e5a69a6d1edc6E
+                      call $dlmalloc::dlmalloc::Chunk::set_inuse_and_pinuse
                       br 3 (;@6;)
                     end
                     local.get 8
@@ -1912,7 +1912,7 @@
                   local.get 6
                   i32.store offset=416
                   local.get 1
-                  call $_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE
+                  call $dlmalloc::dlmalloc::Chunk::to_mem
                   local.set 7
                   br 6 (;@1;)
                 end
@@ -1924,7 +1924,7 @@
                 i32.store offset=416
               end
               local.get 1
-              call $_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE
+              call $dlmalloc::dlmalloc::Chunk::to_mem
               local.tee 7
               i32.eqz
               br_if 3 (;@2;)
@@ -1938,7 +1938,7 @@
               i32.const 1
               local.get 10
               i32.shl
-              call $_ZN8dlmalloc8dlmalloc9left_bits17hb6cbe146b8019d98E
+              call $dlmalloc::dlmalloc::left_bits
               local.get 9
               i32.and
               local.tee 1
@@ -1946,7 +1946,7 @@
               br_if 3 (;@2;)
               local.get 0
               local.get 1
-              call $_ZN8dlmalloc8dlmalloc9least_bit17h4bca52ead665dc5aE
+              call $dlmalloc::dlmalloc::least_bit
               i32.ctz
               i32.const 2
               i32.shl
@@ -1964,8 +1964,8 @@
             local.get 1
             local.get 5
             local.get 1
-            call $_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E
-            call $_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E
+            call $dlmalloc::dlmalloc::TreeChunk::chunk
+            call $dlmalloc::dlmalloc::Chunk::size
             local.tee 7
             local.get 3
             i32.ge_u
@@ -1985,7 +1985,7 @@
             select
             local.set 4
             local.get 1
-            call $_ZN8dlmalloc8dlmalloc9TreeChunk14leftmost_child17h20605933c801b44bE
+            call $dlmalloc::dlmalloc::TreeChunk::leftmost_child
             local.tee 1
             br_if 0 (;@4;)
           end
@@ -2008,28 +2008,28 @@
           br_if 1 (;@2;)
         end
         local.get 5
-        call $_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E
+        call $dlmalloc::dlmalloc::TreeChunk::chunk
         local.tee 1
         local.get 3
-        call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+        call $dlmalloc::dlmalloc::Chunk::plus_offset
         local.set 7
         local.get 0
         local.get 5
-        call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E
+        call $dlmalloc::dlmalloc::Dlmalloc<A>::unlink_large_chunk
         block ;; label = @3
           block ;; label = @4
             local.get 4
             i32.const 16
             i32.const 8
-            call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+            call $dlmalloc::dlmalloc::align_up
             i32.lt_u
             br_if 0 (;@4;)
             local.get 1
             local.get 3
-            call $_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E
+            call $dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_inuse_chunk
             local.get 7
             local.get 4
-            call $_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E
+            call $dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_free_chunk
             block ;; label = @5
               local.get 4
               i32.const 256
@@ -2038,7 +2038,7 @@
               local.get 0
               local.get 7
               local.get 4
-              call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E
+              call $dlmalloc::dlmalloc::Dlmalloc<A>::insert_large_chunk
               br 2 (;@3;)
             end
             local.get 0
@@ -2094,10 +2094,10 @@
           local.get 4
           local.get 3
           i32.add
-          call $_ZN8dlmalloc8dlmalloc5Chunk20set_inuse_and_pinuse17h515e5a69a6d1edc6E
+          call $dlmalloc::dlmalloc::Chunk::set_inuse_and_pinuse
         end
         local.get 1
-        call $_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE
+        call $dlmalloc::dlmalloc::Chunk::to_mem
         local.tee 7
         br_if 1 (;@1;)
       end
@@ -2127,26 +2127,26 @@
                         i32.add
                         local.get 0
                         local.get 3
-                        call $_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E
+                        call $dlmalloc::dlmalloc::Chunk::mem_offset
                         local.tee 1
                         i32.sub
                         local.get 1
                         i32.const 8
-                        call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                        call $dlmalloc::dlmalloc::align_up
                         i32.add
                         i32.const 20
                         i32.const 8
-                        call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                        call $dlmalloc::dlmalloc::align_up
                         i32.add
                         i32.const 16
                         i32.const 8
-                        call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                        call $dlmalloc::dlmalloc::align_up
                         i32.add
                         i32.const 8
                         i32.add
                         i32.const 65536
-                        call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
-                        call $_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$5alloc17hdbf1e2bcc01bc909E
+                        call $dlmalloc::dlmalloc::align_up
+                        call $<dlmalloc::sys::System as dlmalloc::Allocator>::alloc
                         i32.const 0
                         local.set 7
                         local.get 2
@@ -2201,7 +2201,7 @@
                             loop ;; label = @13
                               local.get 8
                               local.get 1
-                              call $_ZN8dlmalloc8dlmalloc7Segment3top17he7e9e2493151d036E
+                              call $dlmalloc::dlmalloc::Segment::top
                               i32.eq
                               br_if 1 (;@12;)
                               local.get 1
@@ -2212,17 +2212,17 @@
                             end
                           end
                           local.get 1
-                          call $_ZN8dlmalloc8dlmalloc7Segment9is_extern17h6f6db2c70b891fd9E
+                          call $dlmalloc::dlmalloc::Segment::is_extern
                           br_if 0 (;@11;)
                           local.get 1
-                          call $_ZN8dlmalloc8dlmalloc7Segment9sys_flags17h224550055bf7775bE
+                          call $dlmalloc::dlmalloc::Segment::sys_flags
                           local.get 11
                           i32.ne
                           br_if 0 (;@11;)
                           local.get 1
                           local.get 0
                           i32.load offset=428
-                          call $_ZN8dlmalloc8dlmalloc7Segment5holds17h8f6de4ee6718009bE
+                          call $dlmalloc::dlmalloc::Segment::holds
                           br_if 4 (;@7;)
                         end
                         local.get 0
@@ -2258,10 +2258,10 @@
                               end
                             end
                             local.get 1
-                            call $_ZN8dlmalloc8dlmalloc7Segment9is_extern17h6f6db2c70b891fd9E
+                            call $dlmalloc::dlmalloc::Segment::is_extern
                             br_if 0 (;@12;)
                             local.get 1
-                            call $_ZN8dlmalloc8dlmalloc7Segment9sys_flags17h224550055bf7775bE
+                            call $dlmalloc::dlmalloc::Segment::sys_flags
                             local.get 11
                             i32.eq
                             br_if 1 (;@11;)
@@ -2280,7 +2280,7 @@
                                 i32.gt_u
                                 br_if 0 (;@14;)
                                 local.get 1
-                                call $_ZN8dlmalloc8dlmalloc7Segment3top17he7e9e2493151d036E
+                                call $dlmalloc::dlmalloc::Segment::top
                                 local.get 5
                                 i32.gt_u
                                 br_if 2 (;@12;)
@@ -2294,11 +2294,11 @@
                             local.set 1
                           end
                           local.get 1
-                          call $_ZN8dlmalloc8dlmalloc7Segment3top17he7e9e2493151d036E
+                          call $dlmalloc::dlmalloc::Segment::top
                           local.tee 6
                           i32.const 20
                           i32.const 8
-                          call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                          call $dlmalloc::dlmalloc::align_up
                           local.tee 12
                           i32.sub
                           i32.const -23
@@ -2307,10 +2307,10 @@
                           local.get 5
                           local.get 1
                           local.get 1
-                          call $_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE
+                          call $dlmalloc::dlmalloc::Chunk::to_mem
                           local.tee 4
                           i32.const 8
-                          call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                          call $dlmalloc::dlmalloc::align_up
                           local.get 4
                           i32.sub
                           i32.add
@@ -2319,41 +2319,41 @@
                           local.get 5
                           i32.const 16
                           i32.const 8
-                          call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                          call $dlmalloc::dlmalloc::align_up
                           i32.add
                           i32.lt_u
                           select
                           local.tee 13
-                          call $_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE
+                          call $dlmalloc::dlmalloc::Chunk::to_mem
                           local.set 4
                           local.get 13
                           local.get 12
-                          call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+                          call $dlmalloc::dlmalloc::Chunk::plus_offset
                           local.set 1
-                          call $_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E
+                          call $dlmalloc::dlmalloc::Chunk::mem_offset
                           local.tee 14
                           i32.const 8
-                          call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                          call $dlmalloc::dlmalloc::align_up
                           local.set 15
                           i32.const 20
                           i32.const 8
-                          call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                          call $dlmalloc::dlmalloc::align_up
                           local.set 16
                           i32.const 16
                           i32.const 8
-                          call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                          call $dlmalloc::dlmalloc::align_up
                           local.set 17
                           local.get 0
                           local.get 8
                           local.get 8
-                          call $_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE
+                          call $dlmalloc::dlmalloc::Chunk::to_mem
                           local.tee 18
                           i32.const 8
-                          call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                          call $dlmalloc::dlmalloc::align_up
                           local.get 18
                           i32.sub
                           local.tee 19
-                          call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+                          call $dlmalloc::dlmalloc::Chunk::plus_offset
                           local.tee 18
                           i32.store offset=428
                           local.get 0
@@ -2375,22 +2375,22 @@
                           i32.const 1
                           i32.or
                           i32.store offset=4
-                          call $_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E
+                          call $dlmalloc::dlmalloc::Chunk::mem_offset
                           local.tee 15
                           i32.const 8
-                          call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                          call $dlmalloc::dlmalloc::align_up
                           local.set 16
                           i32.const 20
                           i32.const 8
-                          call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                          call $dlmalloc::dlmalloc::align_up
                           local.set 17
                           i32.const 16
                           i32.const 8
-                          call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                          call $dlmalloc::dlmalloc::align_up
                           local.set 19
                           local.get 18
                           local.get 14
-                          call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+                          call $dlmalloc::dlmalloc::Chunk::plus_offset
                           local.set 18
                           local.get 0
                           i32.const 2097152
@@ -2406,7 +2406,7 @@
                           i32.store offset=4
                           local.get 13
                           local.get 12
-                          call $_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E
+                          call $dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_inuse_chunk
                           local.get 9
                           i64.load align=4
                           local.set 20
@@ -2442,10 +2442,10 @@
                           loop ;; label = @12
                             local.get 1
                             i32.const 4
-                            call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+                            call $dlmalloc::dlmalloc::Chunk::plus_offset
                             local.set 4
                             local.get 1
-                            call $_ZN8dlmalloc8dlmalloc5Chunk14fencepost_head17he07aaa52f3b50dfdE
+                            call $dlmalloc::dlmalloc::Chunk::fencepost_head
                             i32.store offset=4
                             local.get 4
                             local.set 1
@@ -2468,8 +2468,8 @@
                           local.get 1
                           local.get 5
                           local.get 1
-                          call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
-                          call $_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E
+                          call $dlmalloc::dlmalloc::Chunk::plus_offset
+                          call $dlmalloc::dlmalloc::Chunk::set_free_with_pinuse
                           block ;; label = @12
                             local.get 1
                             i32.const 256
@@ -2478,7 +2478,7 @@
                             local.get 0
                             local.get 5
                             local.get 1
-                            call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E
+                            call $dlmalloc::dlmalloc::Dlmalloc<A>::insert_large_chunk
                             br 10 (;@2;)
                           end
                           local.get 0
@@ -2543,16 +2543,16 @@
                         i32.add
                         i32.store offset=4
                         local.get 8
-                        call $_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE
+                        call $dlmalloc::dlmalloc::Chunk::to_mem
                         local.tee 1
                         i32.const 8
-                        call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                        call $dlmalloc::dlmalloc::align_up
                         local.set 4
                         local.get 5
-                        call $_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE
+                        call $dlmalloc::dlmalloc::Chunk::to_mem
                         local.tee 6
                         i32.const 8
-                        call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                        call $dlmalloc::dlmalloc::align_up
                         local.set 10
                         local.get 8
                         local.get 4
@@ -2561,11 +2561,11 @@
                         i32.add
                         local.tee 4
                         local.get 3
-                        call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+                        call $dlmalloc::dlmalloc::Chunk::plus_offset
                         local.set 7
                         local.get 4
                         local.get 3
-                        call $_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E
+                        call $dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_inuse_chunk
                         local.get 5
                         local.get 10
                         local.get 6
@@ -2589,19 +2589,19 @@
                           i32.eq
                           br_if 5 (;@6;)
                           local.get 1
-                          call $_ZN8dlmalloc8dlmalloc5Chunk5inuse17h2d327e4c36b84dfeE
+                          call $dlmalloc::dlmalloc::Chunk::inuse
                           br_if 7 (;@4;)
                           block ;; label = @12
                             block ;; label = @13
                               local.get 1
-                              call $_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E
+                              call $dlmalloc::dlmalloc::Chunk::size
                               local.tee 5
                               i32.const 256
                               i32.lt_u
                               br_if 0 (;@13;)
                               local.get 0
                               local.get 1
-                              call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E
+                              call $dlmalloc::dlmalloc::Dlmalloc<A>::unlink_large_chunk
                               br 1 (;@12;)
                             end
                             block ;; label = @13
@@ -2638,7 +2638,7 @@
                           local.set 3
                           local.get 1
                           local.get 5
-                          call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+                          call $dlmalloc::dlmalloc::Chunk::plus_offset
                           local.set 1
                           br 7 (;@4;)
                         end
@@ -2658,7 +2658,7 @@
                         i32.or
                         i32.store offset=4
                         local.get 4
-                        call $_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE
+                        call $dlmalloc::dlmalloc::Chunk::to_mem
                         local.set 7
                         br 9 (;@1;)
                       end
@@ -2673,7 +2673,7 @@
                       i32.load offset=428
                       local.tee 1
                       local.get 3
-                      call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+                      call $dlmalloc::dlmalloc::Chunk::plus_offset
                       local.tee 7
                       i32.store offset=428
                       local.get 7
@@ -2683,9 +2683,9 @@
                       i32.store offset=4
                       local.get 1
                       local.get 3
-                      call $_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E
+                      call $dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_inuse_chunk
                       local.get 1
-                      call $_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE
+                      call $dlmalloc::dlmalloc::Chunk::to_mem
                       local.set 7
                       br 8 (;@1;)
                     end
@@ -2698,12 +2698,12 @@
                     local.tee 4
                     i32.const 16
                     i32.const 8
-                    call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                    call $dlmalloc::dlmalloc::align_up
                     i32.lt_u
                     br_if 3 (;@5;)
                     local.get 1
                     local.get 3
-                    call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+                    call $dlmalloc::dlmalloc::Chunk::plus_offset
                     local.set 7
                     local.get 0
                     local.get 4
@@ -2713,12 +2713,12 @@
                     i32.store offset=424
                     local.get 7
                     local.get 4
-                    call $_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E
+                    call $dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_free_chunk
                     local.get 1
                     local.get 3
-                    call $_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E
+                    call $dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_inuse_chunk
                     local.get 1
-                    call $_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE
+                    call $dlmalloc::dlmalloc::Chunk::to_mem
                     local.set 7
                     br 7 (;@1;)
                   end
@@ -2740,7 +2740,7 @@
                 i32.load offset=420
                 local.get 10
                 i32.add
-                call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$8init_top17he4cefe3b36a3bd87E
+                call $dlmalloc::dlmalloc::Dlmalloc<A>::init_top
                 br 4 (;@2;)
               end
               local.get 0
@@ -2755,9 +2755,9 @@
               i32.store offset=416
               local.get 7
               local.get 1
-              call $_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E
+              call $dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_free_chunk
               local.get 4
-              call $_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE
+              call $dlmalloc::dlmalloc::Chunk::to_mem
               local.set 7
               br 4 (;@1;)
             end
@@ -2772,16 +2772,16 @@
             i32.store offset=416
             local.get 1
             local.get 3
-            call $_ZN8dlmalloc8dlmalloc5Chunk20set_inuse_and_pinuse17h515e5a69a6d1edc6E
+            call $dlmalloc::dlmalloc::Chunk::set_inuse_and_pinuse
             local.get 1
-            call $_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE
+            call $dlmalloc::dlmalloc::Chunk::to_mem
             local.set 7
             br 3 (;@1;)
           end
           local.get 7
           local.get 3
           local.get 1
-          call $_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E
+          call $dlmalloc::dlmalloc::Chunk::set_free_with_pinuse
           block ;; label = @4
             local.get 3
             i32.const 256
@@ -2790,9 +2790,9 @@
             local.get 0
             local.get 7
             local.get 3
-            call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18insert_large_chunk17h8e77460818b80af0E
+            call $dlmalloc::dlmalloc::Dlmalloc<A>::insert_large_chunk
             local.get 4
-            call $_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE
+            call $dlmalloc::dlmalloc::Chunk::to_mem
             local.set 7
             br 3 (;@1;)
           end
@@ -2844,7 +2844,7 @@
           local.get 3
           i32.store offset=8
           local.get 4
-          call $_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE
+          call $dlmalloc::dlmalloc::Chunk::to_mem
           local.set 7
           br 2 (;@1;)
         end
@@ -2924,30 +2924,30 @@
           i32.ne
           br_if 0 (;@3;)
         end
-        call $_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E
+        call $dlmalloc::dlmalloc::Chunk::mem_offset
         local.tee 4
         i32.const 8
-        call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+        call $dlmalloc::dlmalloc::align_up
         local.set 5
         i32.const 20
         i32.const 8
-        call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+        call $dlmalloc::dlmalloc::align_up
         local.set 6
         i32.const 16
         i32.const 8
-        call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+        call $dlmalloc::dlmalloc::align_up
         local.set 9
         local.get 0
         local.get 8
         local.get 8
-        call $_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE
+        call $dlmalloc::dlmalloc::Chunk::to_mem
         local.tee 1
         i32.const 8
-        call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+        call $dlmalloc::dlmalloc::align_up
         local.get 1
         i32.sub
         local.tee 13
-        call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+        call $dlmalloc::dlmalloc::Chunk::plus_offset
         local.tee 1
         i32.store offset=428
         local.get 0
@@ -2969,22 +2969,22 @@
         i32.const 1
         i32.or
         i32.store offset=4
-        call $_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E
+        call $dlmalloc::dlmalloc::Chunk::mem_offset
         local.tee 5
         i32.const 8
-        call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+        call $dlmalloc::dlmalloc::align_up
         local.set 6
         i32.const 20
         i32.const 8
-        call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+        call $dlmalloc::dlmalloc::align_up
         local.set 8
         i32.const 16
         i32.const 8
-        call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+        call $dlmalloc::dlmalloc::align_up
         local.set 10
         local.get 1
         local.get 4
-        call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+        call $dlmalloc::dlmalloc::Chunk::plus_offset
         local.set 1
         local.get 0
         i32.const 2097152
@@ -3016,7 +3016,7 @@
       i32.load offset=428
       local.tee 1
       local.get 3
-      call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+      call $dlmalloc::dlmalloc::Chunk::plus_offset
       local.tee 7
       i32.store offset=428
       local.get 7
@@ -3026,9 +3026,9 @@
       i32.store offset=4
       local.get 1
       local.get 3
-      call $_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E
+      call $dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_inuse_chunk
       local.get 1
-      call $_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE
+      call $dlmalloc::dlmalloc::Chunk::to_mem
       local.set 7
     end
     local.get 2
@@ -3037,18 +3037,18 @@
     global.set $__stack_pointer
     local.get 7
   )
-  (func $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$8init_top17he4cefe3b36a3bd87E (;6;) (type 0) (param i32 i32 i32)
+  (func $dlmalloc::dlmalloc::Dlmalloc<A>::init_top (;6;) (type 0) (param i32 i32 i32)
     (local i32 i32 i32 i32)
     local.get 1
     local.get 1
-    call $_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE
+    call $dlmalloc::dlmalloc::Chunk::to_mem
     local.tee 3
     i32.const 8
-    call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+    call $dlmalloc::dlmalloc::align_up
     local.get 3
     i32.sub
     local.tee 3
-    call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+    call $dlmalloc::dlmalloc::Chunk::plus_offset
     local.set 1
     local.get 0
     local.get 2
@@ -3064,22 +3064,22 @@
     i32.const 1
     i32.or
     i32.store offset=4
-    call $_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E
+    call $dlmalloc::dlmalloc::Chunk::mem_offset
     local.tee 3
     i32.const 8
-    call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+    call $dlmalloc::dlmalloc::align_up
     local.set 4
     i32.const 20
     i32.const 8
-    call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+    call $dlmalloc::dlmalloc::align_up
     local.set 5
     i32.const 16
     i32.const 8
-    call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+    call $dlmalloc::dlmalloc::align_up
     local.set 6
     local.get 1
     local.get 2
-    call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+    call $dlmalloc::dlmalloc::Chunk::plus_offset
     local.set 1
     local.get 0
     i32.const 2097152
@@ -3094,32 +3094,32 @@
     i32.add
     i32.store offset=4
   )
-  (func $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$8memalign17he8794c5d1cb954f9E (;7;) (type 4) (param i32 i32 i32) (result i32)
+  (func $dlmalloc::dlmalloc::Dlmalloc<A>::memalign (;7;) (type 4) (param i32 i32 i32) (result i32)
     (local i32 i32 i32 i32 i32 i32)
     block ;; label = @1
       i32.const 16
       i32.const 8
-      call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+      call $dlmalloc::dlmalloc::align_up
       local.get 1
       i32.le_u
       br_if 0 (;@1;)
       i32.const 16
       i32.const 8
-      call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+      call $dlmalloc::dlmalloc::align_up
       local.set 1
     end
-    call $_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E
+    call $dlmalloc::dlmalloc::Chunk::mem_offset
     local.tee 3
     i32.const 8
-    call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+    call $dlmalloc::dlmalloc::align_up
     local.set 4
     i32.const 20
     i32.const 8
-    call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+    call $dlmalloc::dlmalloc::align_up
     local.set 5
     i32.const 16
     i32.const 8
-    call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+    call $dlmalloc::dlmalloc::align_up
     local.set 6
     i32.const 0
     local.set 7
@@ -3127,7 +3127,7 @@
       i32.const 0
       i32.const 16
       i32.const 8
-      call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+      call $dlmalloc::dlmalloc::align_up
       i32.const 2
       i32.shl
       i32.sub
@@ -3163,28 +3163,28 @@
       i32.add
       i32.const 16
       i32.const 8
-      call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+      call $dlmalloc::dlmalloc::align_up
       i32.const -5
       i32.add
       local.get 2
       i32.gt_u
       select
       i32.const 8
-      call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+      call $dlmalloc::dlmalloc::align_up
       local.tee 4
       i32.add
       i32.const 16
       i32.const 8
-      call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+      call $dlmalloc::dlmalloc::align_up
       i32.add
       i32.const -4
       i32.add
-      call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$6malloc17h1ae2390053e3628cE
+      call $dlmalloc::dlmalloc::Dlmalloc<A>::malloc
       local.tee 3
       i32.eqz
       br_if 0 (;@1;)
       local.get 3
-      call $_ZN8dlmalloc8dlmalloc5Chunk8from_mem17h11dd30c74f483706E
+      call $dlmalloc::dlmalloc::Chunk::from_mem
       local.set 2
       block ;; label = @2
         block ;; label = @3
@@ -3206,14 +3206,14 @@
         local.get 1
         i32.sub
         i32.and
-        call $_ZN8dlmalloc8dlmalloc5Chunk8from_mem17h11dd30c74f483706E
+        call $dlmalloc::dlmalloc::Chunk::from_mem
         local.set 7
         i32.const 16
         i32.const 8
-        call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+        call $dlmalloc::dlmalloc::align_up
         local.set 3
         local.get 2
-        call $_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E
+        call $dlmalloc::dlmalloc::Chunk::size
         local.get 7
         i32.const 0
         local.get 1
@@ -3232,18 +3232,18 @@
         local.set 3
         block ;; label = @3
           local.get 2
-          call $_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E
+          call $dlmalloc::dlmalloc::Chunk::mmapped
           br_if 0 (;@3;)
           local.get 1
           local.get 3
-          call $_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E
+          call $dlmalloc::dlmalloc::Chunk::set_inuse
           local.get 2
           local.get 7
-          call $_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E
+          call $dlmalloc::dlmalloc::Chunk::set_inuse
           local.get 0
           local.get 2
           local.get 7
-          call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$13dispose_chunk17h577eb103dc04307bE
+          call $dlmalloc::dlmalloc::Dlmalloc<A>::dispose_chunk
           br 1 (;@2;)
         end
         local.get 2
@@ -3260,41 +3260,41 @@
       end
       block ;; label = @2
         local.get 1
-        call $_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E
+        call $dlmalloc::dlmalloc::Chunk::mmapped
         br_if 0 (;@2;)
         local.get 1
-        call $_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E
+        call $dlmalloc::dlmalloc::Chunk::size
         local.tee 2
         i32.const 16
         i32.const 8
-        call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+        call $dlmalloc::dlmalloc::align_up
         local.get 4
         i32.add
         i32.le_u
         br_if 0 (;@2;)
         local.get 1
         local.get 4
-        call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+        call $dlmalloc::dlmalloc::Chunk::plus_offset
         local.set 7
         local.get 1
         local.get 4
-        call $_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E
+        call $dlmalloc::dlmalloc::Chunk::set_inuse
         local.get 7
         local.get 2
         local.get 4
         i32.sub
         local.tee 2
-        call $_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E
+        call $dlmalloc::dlmalloc::Chunk::set_inuse
         local.get 0
         local.get 7
         local.get 2
-        call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$13dispose_chunk17h577eb103dc04307bE
+        call $dlmalloc::dlmalloc::Dlmalloc<A>::dispose_chunk
       end
       local.get 1
-      call $_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE
+      call $dlmalloc::dlmalloc::Chunk::to_mem
       local.set 7
       local.get 1
-      call $_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E
+      call $dlmalloc::dlmalloc::Chunk::mmapped
       drop
     end
     local.get 7
@@ -3309,11 +3309,11 @@
     i32.sub
     local.tee 2
     global.set $__stack_pointer
-    call $_ZN8dlmalloc3sys23enable_alloc_after_fork17h64eb1fc0ff7b2689E
+    call $dlmalloc::sys::enable_alloc_after_fork
     local.get 2
     i32.const 15
     i32.add
-    call $_ZN73_$LT$dlmalloc..global..Instance$u20$as$u20$core..ops..deref..DerefMut$GT$9deref_mut17h16955ef502c5c4e5E
+    call $<dlmalloc::global::Instance as core::ops::deref::DerefMut>::deref_mut
     local.set 3
     block ;; label = @1
       block ;; label = @2
@@ -3324,19 +3324,19 @@
         local.get 3
         local.get 1
         local.get 0
-        call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$8memalign17he8794c5d1cb954f9E
+        call $dlmalloc::dlmalloc::Dlmalloc<A>::memalign
         local.set 1
         br 1 (;@1;)
       end
       local.get 3
       local.get 0
-      call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$6malloc17h1ae2390053e3628cE
+      call $dlmalloc::dlmalloc::Dlmalloc<A>::malloc
       local.set 1
     end
     local.get 2
     i32.const 15
     i32.add
-    call $_ZN68_$LT$dlmalloc..global..Instance$u20$as$u20$core..ops..drop..Drop$GT$4drop17he19d8d9c8ea92454E
+    call $<dlmalloc::global::Instance as core::ops::drop::Drop>::drop
     local.get 2
     i32.const 16
     i32.add
@@ -3350,17 +3350,17 @@
     i32.sub
     local.tee 3
     global.set $__stack_pointer
-    call $_ZN8dlmalloc3sys23enable_alloc_after_fork17h64eb1fc0ff7b2689E
+    call $dlmalloc::sys::enable_alloc_after_fork
     local.get 3
     i32.const 15
     i32.add
-    call $_ZN73_$LT$dlmalloc..global..Instance$u20$as$u20$core..ops..deref..DerefMut$GT$9deref_mut17h16955ef502c5c4e5E
+    call $<dlmalloc::global::Instance as core::ops::deref::DerefMut>::deref_mut
     local.get 0
-    call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$4free17h501de2a6604ba1ffE
+    call $dlmalloc::dlmalloc::Dlmalloc<A>::free
     local.get 3
     i32.const 15
     i32.add
-    call $_ZN68_$LT$dlmalloc..global..Instance$u20$as$u20$core..ops..drop..Drop$GT$4drop17he19d8d9c8ea92454E
+    call $<dlmalloc::global::Instance as core::ops::drop::Drop>::drop
     local.get 3
     i32.const 16
     i32.add
@@ -3373,11 +3373,11 @@
     i32.sub
     local.tee 4
     global.set $__stack_pointer
-    call $_ZN8dlmalloc3sys23enable_alloc_after_fork17h64eb1fc0ff7b2689E
+    call $dlmalloc::sys::enable_alloc_after_fork
     local.get 4
     i32.const 15
     i32.add
-    call $_ZN73_$LT$dlmalloc..global..Instance$u20$as$u20$core..ops..deref..DerefMut$GT$9deref_mut17h16955ef502c5c4e5E
+    call $<dlmalloc::global::Instance as core::ops::deref::DerefMut>::deref_mut
     local.set 5
     block ;; label = @1
       block ;; label = @2
@@ -3392,32 +3392,32 @@
                 local.get 5
                 local.get 2
                 local.get 3
-                call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$8memalign17he8794c5d1cb954f9E
+                call $dlmalloc::dlmalloc::Dlmalloc<A>::memalign
                 local.tee 2
                 br_if 1 (;@5;)
                 i32.const 0
                 local.set 2
                 br 5 (;@1;)
               end
-              call $_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E
+              call $dlmalloc::dlmalloc::Chunk::mem_offset
               local.tee 1
               i32.const 8
-              call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+              call $dlmalloc::dlmalloc::align_up
               local.set 6
               i32.const 20
               i32.const 8
-              call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+              call $dlmalloc::dlmalloc::align_up
               local.set 7
               i32.const 16
               i32.const 8
-              call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+              call $dlmalloc::dlmalloc::align_up
               local.set 8
               i32.const 0
               local.set 2
               i32.const 0
               i32.const 16
               i32.const 8
-              call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+              call $dlmalloc::dlmalloc::align_up
               i32.const 2
               i32.shl
               i32.sub
@@ -3449,23 +3449,23 @@
               i32.add
               i32.const 16
               i32.const 8
-              call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+              call $dlmalloc::dlmalloc::align_up
               i32.const -5
               i32.add
               local.get 3
               i32.gt_u
               select
               i32.const 8
-              call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+              call $dlmalloc::dlmalloc::align_up
               local.set 6
               local.get 0
-              call $_ZN8dlmalloc8dlmalloc5Chunk8from_mem17h11dd30c74f483706E
+              call $dlmalloc::dlmalloc::Chunk::from_mem
               local.set 1
               local.get 1
               local.get 1
-              call $_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E
+              call $dlmalloc::dlmalloc::Chunk::size
               local.tee 7
-              call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+              call $dlmalloc::dlmalloc::Chunk::plus_offset
               local.set 8
               block ;; label = @6
                 block ;; label = @7
@@ -3475,7 +3475,7 @@
                         block ;; label = @11
                           block ;; label = @12
                             local.get 1
-                            call $_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E
+                            call $dlmalloc::dlmalloc::Chunk::mmapped
                             br_if 0 (;@12;)
                             local.get 7
                             local.get 6
@@ -3492,10 +3492,10 @@
                             i32.eq
                             br_if 3 (;@9;)
                             local.get 8
-                            call $_ZN8dlmalloc8dlmalloc5Chunk6cinuse17h58499de57c2d37e2E
+                            call $dlmalloc::dlmalloc::Chunk::cinuse
                             br_if 9 (;@3;)
                             local.get 8
-                            call $_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E
+                            call $dlmalloc::dlmalloc::Chunk::size
                             local.tee 9
                             local.get 7
                             i32.add
@@ -3513,11 +3513,11 @@
                             br_if 1 (;@11;)
                             local.get 5
                             local.get 8
-                            call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$18unlink_large_chunk17h2e279402ce6356d4E
+                            call $dlmalloc::dlmalloc::Dlmalloc<A>::unlink_large_chunk
                             br 2 (;@10;)
                           end
                           local.get 1
-                          call $_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E
+                          call $dlmalloc::dlmalloc::Chunk::size
                           local.set 7
                           local.get 6
                           i32.const 256
@@ -3553,11 +3553,11 @@
                           i32.const 31
                           i32.add
                           local.get 5
-                          call $_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$9page_size17h0fdd55b2693d440cE
-                          call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                          call $<dlmalloc::sys::System as dlmalloc::Allocator>::page_size
+                          call $dlmalloc::dlmalloc::align_up
                           local.tee 7
                           i32.const 1
-                          call $_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$5remap17hf5ff3c6a92680f40E
+                          call $<dlmalloc::sys::System as dlmalloc::Allocator>::remap
                           local.tee 6
                           i32.eqz
                           br_if 8 (;@3;)
@@ -3573,18 +3573,18 @@
                           i32.add
                           local.tee 2
                           i32.store offset=4
-                          call $_ZN8dlmalloc8dlmalloc5Chunk14fencepost_head17he07aaa52f3b50dfdE
+                          call $dlmalloc::dlmalloc::Chunk::fencepost_head
                           local.set 0
                           local.get 1
                           local.get 2
-                          call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+                          call $dlmalloc::dlmalloc::Chunk::plus_offset
                           local.get 0
                           i32.store offset=4
                           local.get 1
                           local.get 3
                           i32.const -12
                           i32.add
-                          call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+                          call $dlmalloc::dlmalloc::Chunk::plus_offset
                           i32.const 0
                           i32.store offset=4
                           local.get 5
@@ -3650,30 +3650,30 @@
                         local.get 10
                         i32.const 16
                         i32.const 8
-                        call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                        call $dlmalloc::dlmalloc::align_up
                         i32.lt_u
                         br_if 0 (;@10;)
                         local.get 1
                         local.get 6
-                        call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+                        call $dlmalloc::dlmalloc::Chunk::plus_offset
                         local.set 7
                         local.get 1
                         local.get 6
-                        call $_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E
+                        call $dlmalloc::dlmalloc::Chunk::set_inuse
                         local.get 7
                         local.get 10
-                        call $_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E
+                        call $dlmalloc::dlmalloc::Chunk::set_inuse
                         local.get 5
                         local.get 7
                         local.get 10
-                        call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$13dispose_chunk17h577eb103dc04307bE
+                        call $dlmalloc::dlmalloc::Dlmalloc<A>::dispose_chunk
                         local.get 1
                         br_if 8 (;@2;)
                         br 7 (;@3;)
                       end
                       local.get 1
                       local.get 7
-                      call $_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E
+                      call $dlmalloc::dlmalloc::Chunk::set_inuse
                       local.get 1
                       br_if 7 (;@2;)
                       br 6 (;@3;)
@@ -3694,12 +3694,12 @@
                         local.tee 8
                         i32.const 16
                         i32.const 8
-                        call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                        call $dlmalloc::dlmalloc::align_up
                         i32.ge_u
                         br_if 0 (;@10;)
                         local.get 1
                         local.get 7
-                        call $_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E
+                        call $dlmalloc::dlmalloc::Chunk::set_inuse
                         i32.const 0
                         local.set 8
                         i32.const 0
@@ -3708,19 +3708,19 @@
                       end
                       local.get 1
                       local.get 6
-                      call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+                      call $dlmalloc::dlmalloc::Chunk::plus_offset
                       local.tee 7
                       local.get 8
-                      call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+                      call $dlmalloc::dlmalloc::Chunk::plus_offset
                       local.set 9
                       local.get 1
                       local.get 6
-                      call $_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E
+                      call $dlmalloc::dlmalloc::Chunk::set_inuse
                       local.get 7
                       local.get 8
-                      call $_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E
+                      call $dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_free_chunk
                       local.get 9
-                      call $_ZN8dlmalloc8dlmalloc5Chunk12clear_pinuse17h3c1a99d0f5bddc22E
+                      call $dlmalloc::dlmalloc::Chunk::clear_pinuse
                     end
                     local.get 5
                     local.get 7
@@ -3738,23 +3738,23 @@
                   local.tee 7
                   i32.const 16
                   i32.const 8
-                  call $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E
+                  call $dlmalloc::dlmalloc::align_up
                   i32.lt_u
                   br_if 0 (;@7;)
                   local.get 1
                   local.get 6
-                  call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+                  call $dlmalloc::dlmalloc::Chunk::plus_offset
                   local.set 8
                   local.get 1
                   local.get 6
-                  call $_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E
+                  call $dlmalloc::dlmalloc::Chunk::set_inuse
                   local.get 8
                   local.get 7
-                  call $_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E
+                  call $dlmalloc::dlmalloc::Chunk::set_inuse
                   local.get 5
                   local.get 8
                   local.get 7
-                  call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$13dispose_chunk17h577eb103dc04307bE
+                  call $dlmalloc::dlmalloc::Dlmalloc<A>::dispose_chunk
                 end
                 local.get 1
                 br_if 4 (;@2;)
@@ -3782,16 +3782,16 @@
             drop
             local.get 5
             local.get 0
-            call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$4free17h501de2a6604ba1ffE
+            call $dlmalloc::dlmalloc::Dlmalloc<A>::free
             br 3 (;@1;)
           end
           local.get 1
           local.get 6
-          call $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E
+          call $dlmalloc::dlmalloc::Chunk::plus_offset
           local.set 8
           local.get 1
           local.get 6
-          call $_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E
+          call $dlmalloc::dlmalloc::Chunk::set_inuse
           local.get 5
           local.get 8
           i32.store offset=428
@@ -3811,18 +3811,18 @@
         end
         local.get 5
         local.get 3
-        call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$6malloc17h1ae2390053e3628cE
+        call $dlmalloc::dlmalloc::Dlmalloc<A>::malloc
         local.tee 6
         i32.eqz
         br_if 1 (;@1;)
         local.get 6
         local.get 0
         local.get 1
-        call $_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E
+        call $dlmalloc::dlmalloc::Chunk::size
         i32.const -8
         i32.const -4
         local.get 1
-        call $_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E
+        call $dlmalloc::dlmalloc::Chunk::mmapped
         select
         i32.add
         local.tee 2
@@ -3835,22 +3835,22 @@
         local.set 3
         local.get 5
         local.get 0
-        call $_ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$4free17h501de2a6604ba1ffE
+        call $dlmalloc::dlmalloc::Dlmalloc<A>::free
         local.get 3
         local.set 2
         br 1 (;@1;)
       end
       local.get 1
-      call $_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E
+      call $dlmalloc::dlmalloc::Chunk::mmapped
       drop
       local.get 1
-      call $_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE
+      call $dlmalloc::dlmalloc::Chunk::to_mem
       local.set 2
     end
     local.get 4
     i32.const 15
     i32.add
-    call $_ZN68_$LT$dlmalloc..global..Instance$u20$as$u20$core..ops..drop..Drop$GT$4drop17he19d8d9c8ea92454E
+    call $<dlmalloc::global::Instance as core::ops::drop::Drop>::drop
     local.get 4
     i32.const 16
     i32.add
@@ -3863,7 +3863,7 @@
     call $__rdl_oom
     return
   )
-  (func $_ZN5alloc7raw_vec11finish_grow17hcefa6a06206fd52bE (;13;) (type 7) (param i32 i32 i32 i32)
+  (func $alloc::raw_vec::finish_grow (;13;) (type 7) (param i32 i32 i32 i32)
     (local i32)
     block ;; label = @1
       block ;; label = @2
@@ -3971,7 +3971,7 @@
     i32.const 1
     i32.store
   )
-  (func $_ZN5alloc7raw_vec19RawVec$LT$T$C$A$GT$16reserve_for_push17h2205b68aee7ddaceE (;14;) (type 8) (param i32)
+  (func $alloc::raw_vec::RawVec<T,A>::reserve_for_push (;14;) (type 8) (param i32)
     (local i32 i32 i32 i32 i32)
     global.get $__stack_pointer
     i32.const 32
@@ -4030,7 +4030,7 @@
     local.get 1
     i32.const 20
     i32.add
-    call $_ZN5alloc7raw_vec11finish_grow17hcefa6a06206fd52bE
+    call $alloc::raw_vec::finish_grow
     local.get 1
     i32.load offset=12
     local.set 2
@@ -4060,10 +4060,10 @@
         i32.const 16
         i32.add
         i32.load
-        call $_ZN5alloc5alloc18handle_alloc_error17h4f3cb0c5afb21c76E
+        call $alloc::alloc::handle_alloc_error
         unreachable
       end
-      call $_ZN5alloc7raw_vec17capacity_overflow17h6c250c8ca346b5adE
+      call $alloc::raw_vec::capacity_overflow
       unreachable
     end
     local.get 1
@@ -4087,7 +4087,7 @@
     local.get 0
     i32.const 4
     i32.add
-    call $_ZN5alloc7raw_vec19RawVec$LT$T$C$A$GT$16reserve_for_push17h2205b68aee7ddaceE
+    call $alloc::raw_vec::RawVec<T,A>::reserve_for_push
     local.get 0
     i32.load offset=4
     local.tee 1
@@ -4127,17 +4127,17 @@
     unreachable
     unreachable
   )
-  (func $_ZN5alloc7raw_vec17capacity_overflow17h6c250c8ca346b5adE (;16;) (type 9)
+  (func $alloc::raw_vec::capacity_overflow (;16;) (type 9)
     unreachable
     unreachable
   )
-  (func $_ZN5alloc5alloc18handle_alloc_error17h4f3cb0c5afb21c76E (;17;) (type 1) (param i32 i32)
+  (func $alloc::alloc::handle_alloc_error (;17;) (type 1) (param i32 i32)
     local.get 0
     local.get 1
-    call $_ZN5alloc5alloc18handle_alloc_error8rt_error17h63de615f6e977af2E
+    call $alloc::alloc::handle_alloc_error::rt_error
     unreachable
   )
-  (func $_ZN5alloc5alloc18handle_alloc_error8rt_error17h63de615f6e977af2E (;18;) (type 1) (param i32 i32)
+  (func $alloc::alloc::handle_alloc_error::rt_error (;18;) (type 1) (param i32 i32)
     local.get 1
     local.get 0
     call $__rust_alloc_error_handler
@@ -4147,7 +4147,7 @@
     unreachable
     unreachable
   )
-  (func $_ZN8dlmalloc8dlmalloc8align_up17hacb462cafc347c13E (;20;) (type 3) (param i32 i32) (result i32)
+  (func $dlmalloc::dlmalloc::align_up (;20;) (type 3) (param i32 i32) (result i32)
     local.get 0
     local.get 1
     i32.add
@@ -4158,7 +4158,7 @@
     i32.sub
     i32.and
   )
-  (func $_ZN8dlmalloc8dlmalloc9left_bits17hb6cbe146b8019d98E (;21;) (type 2) (param i32) (result i32)
+  (func $dlmalloc::dlmalloc::left_bits (;21;) (type 2) (param i32) (result i32)
     local.get 0
     i32.const 1
     i32.shl
@@ -4168,14 +4168,14 @@
     i32.sub
     i32.or
   )
-  (func $_ZN8dlmalloc8dlmalloc9least_bit17h4bca52ead665dc5aE (;22;) (type 2) (param i32) (result i32)
+  (func $dlmalloc::dlmalloc::least_bit (;22;) (type 2) (param i32) (result i32)
     i32.const 0
     local.get 0
     i32.sub
     local.get 0
     i32.and
   )
-  (func $_ZN8dlmalloc8dlmalloc24leftshift_for_tree_index17h31d064fdd867f502E (;23;) (type 2) (param i32) (result i32)
+  (func $dlmalloc::dlmalloc::leftshift_for_tree_index (;23;) (type 2) (param i32) (result i32)
     i32.const 0
     i32.const 25
     local.get 0
@@ -4187,16 +4187,16 @@
     i32.eq
     select
   )
-  (func $_ZN8dlmalloc8dlmalloc5Chunk14fencepost_head17he07aaa52f3b50dfdE (;24;) (type 5) (result i32)
+  (func $dlmalloc::dlmalloc::Chunk::fencepost_head (;24;) (type 5) (result i32)
     i32.const 7
   )
-  (func $_ZN8dlmalloc8dlmalloc5Chunk4size17h77d1c406ab42db33E (;25;) (type 2) (param i32) (result i32)
+  (func $dlmalloc::dlmalloc::Chunk::size (;25;) (type 2) (param i32) (result i32)
     local.get 0
     i32.load offset=4
     i32.const -8
     i32.and
   )
-  (func $_ZN8dlmalloc8dlmalloc5Chunk6cinuse17h58499de57c2d37e2E (;26;) (type 2) (param i32) (result i32)
+  (func $dlmalloc::dlmalloc::Chunk::cinuse (;26;) (type 2) (param i32) (result i32)
     local.get 0
     i32.load8_u offset=4
     i32.const 2
@@ -4204,13 +4204,13 @@
     i32.const 1
     i32.shr_u
   )
-  (func $_ZN8dlmalloc8dlmalloc5Chunk6pinuse17h92d5107047b03ba7E (;27;) (type 2) (param i32) (result i32)
+  (func $dlmalloc::dlmalloc::Chunk::pinuse (;27;) (type 2) (param i32) (result i32)
     local.get 0
     i32.load offset=4
     i32.const 1
     i32.and
   )
-  (func $_ZN8dlmalloc8dlmalloc5Chunk12clear_pinuse17h3c1a99d0f5bddc22E (;28;) (type 8) (param i32)
+  (func $dlmalloc::dlmalloc::Chunk::clear_pinuse (;28;) (type 8) (param i32)
     local.get 0
     local.get 0
     i32.load offset=4
@@ -4218,7 +4218,7 @@
     i32.and
     i32.store offset=4
   )
-  (func $_ZN8dlmalloc8dlmalloc5Chunk5inuse17h2d327e4c36b84dfeE (;29;) (type 2) (param i32) (result i32)
+  (func $dlmalloc::dlmalloc::Chunk::inuse (;29;) (type 2) (param i32) (result i32)
     local.get 0
     i32.load offset=4
     i32.const 3
@@ -4226,14 +4226,14 @@
     i32.const 1
     i32.ne
   )
-  (func $_ZN8dlmalloc8dlmalloc5Chunk7mmapped17h1a9959fbf47496c3E (;30;) (type 2) (param i32) (result i32)
+  (func $dlmalloc::dlmalloc::Chunk::mmapped (;30;) (type 2) (param i32) (result i32)
     local.get 0
     i32.load8_u offset=4
     i32.const 3
     i32.and
     i32.eqz
   )
-  (func $_ZN8dlmalloc8dlmalloc5Chunk9set_inuse17h4282057414c4e601E (;31;) (type 1) (param i32 i32)
+  (func $dlmalloc::dlmalloc::Chunk::set_inuse (;31;) (type 1) (param i32 i32)
     local.get 0
     local.get 0
     i32.load offset=4
@@ -4254,7 +4254,7 @@
     i32.or
     i32.store offset=4
   )
-  (func $_ZN8dlmalloc8dlmalloc5Chunk20set_inuse_and_pinuse17h515e5a69a6d1edc6E (;32;) (type 1) (param i32 i32)
+  (func $dlmalloc::dlmalloc::Chunk::set_inuse_and_pinuse (;32;) (type 1) (param i32 i32)
     local.get 0
     local.get 1
     i32.const 3
@@ -4270,14 +4270,14 @@
     i32.or
     i32.store offset=4
   )
-  (func $_ZN8dlmalloc8dlmalloc5Chunk34set_size_and_pinuse_of_inuse_chunk17h4acf6d59020bd397E (;33;) (type 1) (param i32 i32)
+  (func $dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_inuse_chunk (;33;) (type 1) (param i32 i32)
     local.get 0
     local.get 1
     i32.const 3
     i32.or
     i32.store offset=4
   )
-  (func $_ZN8dlmalloc8dlmalloc5Chunk33set_size_and_pinuse_of_free_chunk17ha971516d0be71949E (;34;) (type 1) (param i32 i32)
+  (func $dlmalloc::dlmalloc::Chunk::set_size_and_pinuse_of_free_chunk (;34;) (type 1) (param i32 i32)
     local.get 0
     local.get 1
     i32.const 1
@@ -4289,7 +4289,7 @@
     local.get 1
     i32.store
   )
-  (func $_ZN8dlmalloc8dlmalloc5Chunk20set_free_with_pinuse17h5d876ea751634e99E (;35;) (type 0) (param i32 i32 i32)
+  (func $dlmalloc::dlmalloc::Chunk::set_free_with_pinuse (;35;) (type 0) (param i32 i32 i32)
     local.get 2
     local.get 2
     i32.load offset=4
@@ -4307,30 +4307,30 @@
     local.get 1
     i32.store
   )
-  (func $_ZN8dlmalloc8dlmalloc5Chunk11plus_offset17h6e6d06559ad34b15E (;36;) (type 3) (param i32 i32) (result i32)
+  (func $dlmalloc::dlmalloc::Chunk::plus_offset (;36;) (type 3) (param i32 i32) (result i32)
     local.get 0
     local.get 1
     i32.add
   )
-  (func $_ZN8dlmalloc8dlmalloc5Chunk12minus_offset17h7c3eec81761249d9E (;37;) (type 3) (param i32 i32) (result i32)
+  (func $dlmalloc::dlmalloc::Chunk::minus_offset (;37;) (type 3) (param i32 i32) (result i32)
     local.get 0
     local.get 1
     i32.sub
   )
-  (func $_ZN8dlmalloc8dlmalloc5Chunk6to_mem17h75497733644e1d6cE (;38;) (type 2) (param i32) (result i32)
+  (func $dlmalloc::dlmalloc::Chunk::to_mem (;38;) (type 2) (param i32) (result i32)
     local.get 0
     i32.const 8
     i32.add
   )
-  (func $_ZN8dlmalloc8dlmalloc5Chunk10mem_offset17h86551c33e07de253E (;39;) (type 5) (result i32)
+  (func $dlmalloc::dlmalloc::Chunk::mem_offset (;39;) (type 5) (result i32)
     i32.const 8
   )
-  (func $_ZN8dlmalloc8dlmalloc5Chunk8from_mem17h11dd30c74f483706E (;40;) (type 2) (param i32) (result i32)
+  (func $dlmalloc::dlmalloc::Chunk::from_mem (;40;) (type 2) (param i32) (result i32)
     local.get 0
     i32.const -8
     i32.add
   )
-  (func $_ZN8dlmalloc8dlmalloc9TreeChunk14leftmost_child17h20605933c801b44bE (;41;) (type 2) (param i32) (result i32)
+  (func $dlmalloc::dlmalloc::TreeChunk::leftmost_child (;41;) (type 2) (param i32) (result i32)
     (local i32)
     block ;; label = @1
       local.get 0
@@ -4345,30 +4345,30 @@
     end
     local.get 1
   )
-  (func $_ZN8dlmalloc8dlmalloc9TreeChunk5chunk17h4efd58110bb4b6e5E (;42;) (type 2) (param i32) (result i32)
+  (func $dlmalloc::dlmalloc::TreeChunk::chunk (;42;) (type 2) (param i32) (result i32)
     local.get 0
   )
-  (func $_ZN8dlmalloc8dlmalloc9TreeChunk4next17he250edbec5d87123E (;43;) (type 2) (param i32) (result i32)
+  (func $dlmalloc::dlmalloc::TreeChunk::next (;43;) (type 2) (param i32) (result i32)
     local.get 0
     i32.load offset=12
   )
-  (func $_ZN8dlmalloc8dlmalloc9TreeChunk4prev17h7a0f1d46544cc14aE (;44;) (type 2) (param i32) (result i32)
+  (func $dlmalloc::dlmalloc::TreeChunk::prev (;44;) (type 2) (param i32) (result i32)
     local.get 0
     i32.load offset=8
   )
-  (func $_ZN8dlmalloc8dlmalloc7Segment9is_extern17h6f6db2c70b891fd9E (;45;) (type 2) (param i32) (result i32)
+  (func $dlmalloc::dlmalloc::Segment::is_extern (;45;) (type 2) (param i32) (result i32)
     local.get 0
     i32.load offset=12
     i32.const 1
     i32.and
   )
-  (func $_ZN8dlmalloc8dlmalloc7Segment9sys_flags17h224550055bf7775bE (;46;) (type 2) (param i32) (result i32)
+  (func $dlmalloc::dlmalloc::Segment::sys_flags (;46;) (type 2) (param i32) (result i32)
     local.get 0
     i32.load offset=12
     i32.const 1
     i32.shr_u
   )
-  (func $_ZN8dlmalloc8dlmalloc7Segment5holds17h8f6de4ee6718009bE (;47;) (type 3) (param i32 i32) (result i32)
+  (func $dlmalloc::dlmalloc::Segment::holds (;47;) (type 3) (param i32 i32) (result i32)
     (local i32 i32)
     i32.const 0
     local.set 2
@@ -4389,18 +4389,18 @@
     end
     local.get 2
   )
-  (func $_ZN8dlmalloc8dlmalloc7Segment3top17he7e9e2493151d036E (;48;) (type 2) (param i32) (result i32)
+  (func $dlmalloc::dlmalloc::Segment::top (;48;) (type 2) (param i32) (result i32)
     local.get 0
     i32.load
     local.get 0
     i32.load offset=4
     i32.add
   )
-  (func $_ZN73_$LT$dlmalloc..global..Instance$u20$as$u20$core..ops..deref..DerefMut$GT$9deref_mut17h16955ef502c5c4e5E (;49;) (type 2) (param i32) (result i32)
+  (func $<dlmalloc::global::Instance as core::ops::deref::DerefMut>::deref_mut (;49;) (type 2) (param i32) (result i32)
     i32.const 1048580
   )
-  (func $_ZN68_$LT$dlmalloc..global..Instance$u20$as$u20$core..ops..drop..Drop$GT$4drop17he19d8d9c8ea92454E (;50;) (type 8) (param i32))
-  (func $_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$5alloc17hdbf1e2bcc01bc909E (;51;) (type 0) (param i32 i32 i32)
+  (func $<dlmalloc::global::Instance as core::ops::drop::Drop>::drop (;50;) (type 8) (param i32))
+  (func $<dlmalloc::sys::System as dlmalloc::Allocator>::alloc (;51;) (type 0) (param i32 i32 i32)
     (local i32)
     local.get 2
     i32.const 16
@@ -4430,29 +4430,29 @@
     select
     i32.store
   )
-  (func $_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$5remap17hf5ff3c6a92680f40E (;52;) (type 10) (param i32 i32 i32 i32 i32) (result i32)
+  (func $<dlmalloc::sys::System as dlmalloc::Allocator>::remap (;52;) (type 10) (param i32 i32 i32 i32 i32) (result i32)
     i32.const 0
   )
-  (func $_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$9free_part17h74489c9e7a3aa967E (;53;) (type 6) (param i32 i32 i32 i32) (result i32)
+  (func $<dlmalloc::sys::System as dlmalloc::Allocator>::free_part (;53;) (type 6) (param i32 i32 i32 i32) (result i32)
     i32.const 0
   )
-  (func $_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$4free17h993c5f05ba1214bcE (;54;) (type 4) (param i32 i32 i32) (result i32)
+  (func $<dlmalloc::sys::System as dlmalloc::Allocator>::free (;54;) (type 4) (param i32 i32 i32) (result i32)
     i32.const 0
   )
-  (func $_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$16can_release_part17h43bfb7d8666fcc31E (;55;) (type 3) (param i32 i32) (result i32)
+  (func $<dlmalloc::sys::System as dlmalloc::Allocator>::can_release_part (;55;) (type 3) (param i32 i32) (result i32)
     i32.const 0
   )
-  (func $_ZN61_$LT$dlmalloc..sys..System$u20$as$u20$dlmalloc..Allocator$GT$9page_size17h0fdd55b2693d440cE (;56;) (type 2) (param i32) (result i32)
+  (func $<dlmalloc::sys::System as dlmalloc::Allocator>::page_size (;56;) (type 2) (param i32) (result i32)
     i32.const 65536
   )
-  (func $_ZN8dlmalloc3sys23enable_alloc_after_fork17h64eb1fc0ff7b2689E (;57;) (type 9))
+  (func $dlmalloc::sys::enable_alloc_after_fork (;57;) (type 9))
   (func $memcpy (;58;) (type 4) (param i32 i32 i32) (result i32)
     local.get 0
     local.get 1
     local.get 2
-    call $_ZN17compiler_builtins3mem6memcpy17h7b83c85e899060b3E
+    call $compiler_builtins::mem::memcpy
   )
-  (func $_ZN17compiler_builtins3mem6memcpy17h7b83c85e899060b3E (;59;) (type 4) (param i32 i32 i32) (result i32)
+  (func $compiler_builtins::mem::memcpy (;59;) (type 4) (param i32 i32 i32) (result i32)
     (local i32 i32 i32 i32 i32 i32 i32 i32)
     block ;; label = @1
       block ;; label = @2

--- a/frontend-wasm/tests/expected/signed_arith.mir
+++ b/frontend-wasm/tests/expected/signed_arith.mir
@@ -39,7 +39,7 @@ block3:
     v17 = const.i32 1048672  : i32
     v18 = const.i32 25  : i32
     v19 = const.i32 1048648  : i32
-    call noname::_ZN4core9panicking5panic17h62f53cc4db8dd7b3E(v17, v18, v19)
+    call noname::core::panicking::panic(v17, v18, v19)
     unreachable 
 
 block4:
@@ -60,7 +60,7 @@ block6:
     v14 = const.i32 1048704  : i32
     v15 = const.i32 31  : i32
     v16 = const.i32 1048648  : i32
-    call noname::_ZN4core9panicking5panic17h62f53cc4db8dd7b3E(v14, v15, v16)
+    call noname::core::panicking::panic(v14, v15, v16)
     unreachable 
 }
 
@@ -77,7 +77,7 @@ block2:
     v10 = const.i32 1048672  : i32
     v11 = const.i32 25  : i32
     v12 = const.i32 1048736  : i32
-    call noname::_ZN4core9panicking5panic17h62f53cc4db8dd7b3E(v10, v11, v12)
+    call noname::core::panicking::panic(v10, v11, v12)
     unreachable 
 
 block3:
@@ -106,7 +106,7 @@ block3:
     v17 = const.i32 1048768  : i32
     v18 = const.i32 57  : i32
     v19 = const.i32 1048752  : i32
-    call noname::_ZN4core9panicking5panic17h62f53cc4db8dd7b3E(v17, v18, v19)
+    call noname::core::panicking::panic(v17, v18, v19)
     unreachable 
 
 block4:
@@ -127,7 +127,7 @@ block6:
     v14 = const.i32 1048832  : i32
     v15 = const.i32 48  : i32
     v16 = const.i32 1048752  : i32
-    call noname::_ZN4core9panicking5panic17h62f53cc4db8dd7b3E(v14, v15, v16)
+    call noname::core::panicking::panic(v14, v15, v16)
     unreachable 
 }
 
@@ -144,7 +144,7 @@ block2:
     v10 = const.i32 1048768  : i32
     v11 = const.i32 57  : i32
     v12 = const.i32 1048880  : i32
-    call noname::_ZN4core9panicking5panic17h62f53cc4db8dd7b3E(v10, v11, v12)
+    call noname::core::panicking::panic(v10, v11, v12)
     unreachable 
 
 block3:
@@ -207,7 +207,7 @@ block1(v0: i32):
     ret v0
 }
 
-pub fn _ZN4core3ptr37drop_in_place$LT$core..fmt..Error$GT$17h282a1f10dc7e004dE(i32) {
+pub fn core::ptr::drop_in_place<core::fmt::Error>(i32) {
 block0(v0: i32):
     br block1
 
@@ -215,7 +215,7 @@ block1:
     ret 
 }
 
-pub fn _ZN4core9panicking9panic_fmt17h9f61a1f2faa523f9E(i32, i32) {
+pub fn core::panicking::panic_fmt(i32, i32) {
 block0(v0: i32, v1: i32):
     v2 = const.i32 0  : i32
     v3 = global.load (@__stack_pointer) as *mut i8  : i32
@@ -255,7 +255,7 @@ block0(v0: i32, v1: i32):
 block1:
 }
 
-pub fn _ZN4core9panicking5panic17h62f53cc4db8dd7b3E(i32, i32, i32) {
+pub fn core::panicking::panic(i32, i32, i32) {
 block0(v0: i32, v1: i32, v2: i32):
     v3 = const.i32 0  : i32
     v4 = global.load (@__stack_pointer) as *mut i8  : i32
@@ -292,13 +292,13 @@ block0(v0: i32, v1: i32, v2: i32):
     v29 = cast v6  : u32
     v30 = inttoptr v29  : *mut i32
     store v30, v28
-    call noname::_ZN4core9panicking9panic_fmt17h9f61a1f2faa523f9E(v6, v2)
+    call noname::core::panicking::panic_fmt(v6, v2)
     unreachable 
 
 block1:
 }
 
-pub fn _ZN36_$LT$T$u20$as$u20$core..any..Any$GT$7type_id17h29327df37c6e3023E(i32, i32) {
+pub fn <T as core::any::Any>::type_id(i32, i32) {
 block0(v0: i32, v1: i32):
     v2 = const.i64 -1688046730280208939  : i64
     v3 = cast v0  : u32

--- a/frontend-wasm/tests/expected/signed_arith.wat
+++ b/frontend-wasm/tests/expected/signed_arith.wat
@@ -26,13 +26,13 @@
         i32.const 1048704
         i32.const 31
         i32.const 1048648
-        call $_ZN4core9panicking5panic17h62f53cc4db8dd7b3E
+        call $core::panicking::panic
         unreachable
       end
       i32.const 1048672
       i32.const 25
       i32.const 1048648
-      call $_ZN4core9panicking5panic17h62f53cc4db8dd7b3E
+      call $core::panicking::panic
       unreachable
     end
     local.get 0
@@ -52,7 +52,7 @@
     i32.const 1048672
     i32.const 25
     i32.const 1048736
-    call $_ZN4core9panicking5panic17h62f53cc4db8dd7b3E
+    call $core::panicking::panic
     unreachable
   )
   (func $rem_s (;3;) (type 1) (param i32 i32) (result i32)
@@ -72,13 +72,13 @@
         i32.const 1048832
         i32.const 48
         i32.const 1048752
-        call $_ZN4core9panicking5panic17h62f53cc4db8dd7b3E
+        call $core::panicking::panic
         unreachable
       end
       i32.const 1048768
       i32.const 57
       i32.const 1048752
-      call $_ZN4core9panicking5panic17h62f53cc4db8dd7b3E
+      call $core::panicking::panic
       unreachable
     end
     local.get 0
@@ -98,7 +98,7 @@
     i32.const 1048768
     i32.const 57
     i32.const 1048880
-    call $_ZN4core9panicking5panic17h62f53cc4db8dd7b3E
+    call $core::panicking::panic
     unreachable
   )
   (func $shr_s (;5;) (type 1) (param i32 i32) (result i32)
@@ -136,8 +136,8 @@
     call $shr_u
     i32.add
   )
-  (func $_ZN4core3ptr37drop_in_place$LT$core..fmt..Error$GT$17h282a1f10dc7e004dE (;8;) (type 0) (param i32))
-  (func $_ZN4core9panicking9panic_fmt17h9f61a1f2faa523f9E (;9;) (type 3) (param i32 i32)
+  (func $core::ptr::drop_in_place<core::fmt::Error> (;8;) (type 0) (param i32))
+  (func $core::panicking::panic_fmt (;9;) (type 3) (param i32 i32)
     (local i32)
     global.get $__stack_pointer
     i32.const 32
@@ -165,7 +165,7 @@
     call $rust_begin_unwind
     unreachable
   )
-  (func $_ZN4core9panicking5panic17h62f53cc4db8dd7b3E (;10;) (type 4) (param i32 i32 i32)
+  (func $core::panicking::panic (;10;) (type 4) (param i32 i32 i32)
     (local i32)
     global.get $__stack_pointer
     i32.const 32
@@ -196,10 +196,10 @@
     i32.store
     local.get 3
     local.get 2
-    call $_ZN4core9panicking9panic_fmt17h9f61a1f2faa523f9E
+    call $core::panicking::panic_fmt
     unreachable
   )
-  (func $_ZN36_$LT$T$u20$as$u20$core..any..Any$GT$7type_id17h29327df37c6e3023E (;11;) (type 3) (param i32 i32)
+  (func $<T as core::any::Any>::type_id (;11;) (type 3) (param i32 i32)
     local.get 0
     i64.const -1688046730280208939
     i64.store offset=8
@@ -222,6 +222,6 @@
   (export "__main" (func $__main))
   (export "__data_end" (global 1))
   (export "__heap_base" (global 2))
-  (elem (;0;) (i32.const 1) func $_ZN4core3ptr37drop_in_place$LT$core..fmt..Error$GT$17h282a1f10dc7e004dE $_ZN36_$LT$T$u20$as$u20$core..any..Any$GT$7type_id17h29327df37c6e3023E)
+  (elem (;0;) (i32.const 1) func $core::ptr::drop_in_place<core::fmt::Error> $<T as core::any::Any>::type_id)
   (data $.rodata (;0;) (i32.const 1048576) "/tmp/6c3d0db843d22d28fff49dffc552879651b21c3f44039227473ff2d47441c4f3.rs\00\00\10\00H\00\00\00\0c\00\00\00\05\00\00\00\00\00\00\00\00\00\00\00attempt to divide by zero\00\00\00\00\00\00\00attempt to divide with overflow\00\00\00\10\00H\00\00\00\12\00\00\00\05\00\00\00\00\00\10\00H\00\00\00\18\00\00\00\05\00\00\00attempt to calculate the remainder with a divisor of zero\00\00\00\00\00\00\00attempt to calculate the remainder with overflow\00\00\10\00H\00\00\00\1e\00\00\00\05\00\00\00\01\00\00\00\00\00\00\00\01\00\00\00\02\00\00\00")
 )

--- a/frontend-wasm/tests/test_rust_comp.rs
+++ b/frontend-wasm/tests/test_rust_comp.rs
@@ -673,7 +673,6 @@ fn rust_static_mut() {
     );
 }
 
-#[ignore = "hash part in mangled function names is not stable enough"]
 #[test]
 fn dlmalloc() {
     check_ir_files_cargo(


### PR DESCRIPTION
Close #41    
    
The function names in both the .mir and .wat files are demangled in tests before `expect!` comparison. This makes tests stable when the Rust toolchain version changes and more readable.